### PR TITLE
Fixed honda accord stop and go resume too slow issue.

### DIFF
--- a/selfdrive/car/honda/interface.py
+++ b/selfdrive/car/honda/interface.py
@@ -124,6 +124,9 @@ class CarInterface(CarInterfaceBase):
       ret.lateralParams.torqueBP, ret.lateralParams.torqueV = [[0, 4096], [0, 4096]]  # TODO: determine if there is a dead zone at the top end
       tire_stiffness_factor = 0.8467
 
+      ret.vEgoStarting = 0.2
+      ret.startAccel = 1.0
+
       if eps_modified:
         ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.3], [0.09]]
       else:


### PR DESCRIPTION
When the lead car is stopped and gone, it will take a long time to start to go.

vEgoStarting and startAccel will let the car resume quickly.