### PR TITLE
Honda Bosch: Update tuning for modified EPS

### DIFF
--- a/selfdrive/car/honda/interface.py
+++ b/selfdrive/car/honda/interface.py
@@ -124,7 +124,7 @@ class CarInterface(CarInterfaceBase):
       ret.tireStiffnessFactor = 0.8467
 
       if eps_modified:
-        ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.3], [0.09]]
+        ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.25], [0.075]]
       else:
         ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.6], [0.18]]
 


### PR DESCRIPTION
Current tuning has a minimal amount of overshoot, this eliminates it.