### PR TITLE
KIA EV9 (HDA2) data added

### DIFF
--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -206,6 +206,10 @@ class CarInterface(CarInterfaceBase):
       ret.wheelbase = 2.9
       ret.steerRatio = 16.
       ret.tireStiffnessFactor = 0.65
+    elif candidate == CAR.KIA_EV9:
+      ref.mass = 2615
+      ref.wheelbase = 3.1
+      ret.steerRatio = 16.02
     elif candidate == CAR.KIA_SPORTAGE_HYBRID_5TH_GEN:
       ret.mass = 1767.  # SX Prestige trim support only
       ret.wheelbase = 2.756

--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -289,7 +289,7 @@ CAR_INFO: Dict[str, Optional[Union[HyundaiCarInfo, List[HyundaiCarInfo]]]] = {
   ],
   CAR.KIA_EV9: [
     HyundaiCarInfo("Kia EV9 (with HDA II) 2023", "Highway Driving Assist II", car_parts=CarParts.common([CarHarness.hyundai_r]))
-  ]
+  ],
   CAR.KIA_CARNIVAL_4TH_GEN: [
     HyundaiCarInfo("Kia Carnival 2023-24", car_parts=CarParts.common([CarHarness.hyundai_a])),
     HyundaiCarInfo("Kia Carnival (China only) 2023", car_parts=CarParts.common([CarHarness.hyundai_k]))
@@ -2052,10 +2052,10 @@ FW_VERSIONS = {
   CAR.KIA_EV9: {
     (Ecu.fwdRadar, 0x7d0, None): [
       b'\xf1\x00MV__ RDR -----      1.00 1.02 99110-DO700         ',
-    ]
-    (Ecu.adas, 0x730 None): [
+    ],
+    (Ecu.adas, 0x730, None): [
       b'\xf1\x00MV  FBL5 1.00 1.02 230602',
-    ]
+    ],
     (Ecu.fwdCamera, 0x7c4, None): [
       b'\xf1\x00MV  MFC  AT KOR LHD 1.00 1.01 99211-DO000 230419',
     ],

--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -39,7 +39,7 @@ class CarControllerParams:
     # If the max stock LKAS request is <384, add your car to this list.
     elif CP.carFingerprint in (CAR.GENESIS_G80, CAR.GENESIS_G90, CAR.ELANTRA, CAR.ELANTRA_GT_I30, CAR.IONIQ,
                                CAR.IONIQ_EV_LTD, CAR.SANTA_FE_PHEV_2022, CAR.SONATA_LF, CAR.KIA_FORTE, CAR.KIA_NIRO_PHEV,
-                               CAR.KIA_OPTIMA_H, CAR.KIA_OPTIMA_H_G4_FL, CAR.KIA_SORENTO):
+                               CAR.KIA_OPTIMA_H, CAR.KIA_OPTIMA_H_G4_FL, CAR.KIA_SORENTO, CAR.KIA_EV9):
       self.STEER_MAX = 255
 
     # these cars have significantly more torque than most HKG; limit to 70% of max
@@ -140,6 +140,7 @@ class CAR(StrEnum):
   KIA_STINGER_2022 = "KIA STINGER 2022"
   KIA_CEED = "KIA CEED INTRO ED 2019"
   KIA_EV6 = "KIA EV6 2022"
+  KIA_EV9 = "KIA EV9 2023"
   KIA_CARNIVAL_4TH_GEN = "KIA CARNIVAL 4TH GEN"
 
   # Genesis
@@ -286,6 +287,9 @@ CAR_INFO: Dict[str, Optional[Union[HyundaiCarInfo, List[HyundaiCarInfo]]]] = {
     HyundaiCarInfo("Kia EV6 (without HDA II) 2022-23", "Highway Driving Assist", car_parts=CarParts.common([CarHarness.hyundai_l])),
     HyundaiCarInfo("Kia EV6 (with HDA II) 2022-23", "Highway Driving Assist II", car_parts=CarParts.common([CarHarness.hyundai_p]))
   ],
+  CAR.KIA_EV9: [
+    HyundaiCarInfo("Kia EV9 (with HDA II) 2023", "Highway Driving Assist II", car_parts=CarParts.common([CarHarness.hyundai_r]))
+  ]
   CAR.KIA_CARNIVAL_4TH_GEN: [
     HyundaiCarInfo("Kia Carnival 2023-24", car_parts=CarParts.common([CarHarness.hyundai_a])),
     HyundaiCarInfo("Kia Carnival (China only) 2023", car_parts=CarParts.common([CarHarness.hyundai_k]))
@@ -2045,6 +2049,17 @@ FW_VERSIONS = {
       b'\xf1\x00CV1 MFC  AT KOR LHD 1.00 1.06 99210-CV000 220328',
     ],
   },
+  CAR.KIA_EV9: {
+    (Ecu.fwdRadar, 0x7d0, None): [
+      b'\xf1\x00MV__ RDR -----      1.00 1.02 99110-DO700         ',
+    ]
+    (Ecu.adas, 0x730 None): [
+      b'\xf1\x00MV  FBL5 1.00 1.02 230602',
+    ]
+    (Ecu.fwdCamera, 0x7c4, None): [
+      b'\xf1\x00MV  MFC  AT KOR LHD 1.00 1.01 99211-DO000 230419',
+    ],
+  },    
   CAR.IONIQ_5: {
     (Ecu.fwdRadar, 0x7d0, None): [
       b'\xf1\x00NE1_ RDR -----      1.00 1.00 99110-GI000         ',
@@ -2226,7 +2241,7 @@ CAN_GEARS = {
 CANFD_CAR = {CAR.KIA_EV6, CAR.IONIQ_5, CAR.IONIQ_6, CAR.TUCSON_4TH_GEN, CAR.TUCSON_HYBRID_4TH_GEN, CAR.KIA_SPORTAGE_HYBRID_5TH_GEN,
              CAR.SANTA_CRUZ_1ST_GEN, CAR.KIA_SPORTAGE_5TH_GEN, CAR.GENESIS_GV70_1ST_GEN, CAR.KIA_SORENTO_PHEV_4TH_GEN,
              CAR.GENESIS_GV60_EV_1ST_GEN, CAR.KIA_SORENTO_4TH_GEN, CAR.KIA_NIRO_HEV_2ND_GEN, CAR.KIA_NIRO_EV_2ND_GEN,
-             CAR.GENESIS_GV80, CAR.KIA_CARNIVAL_4TH_GEN, CAR.KIA_SORENTO_HEV_4TH_GEN, CAR.KONA_EV_2ND_GEN, CAR.KIA_K8_HEV_1ST_GEN}
+             CAR.GENESIS_GV80, CAR.KIA_CARNIVAL_4TH_GEN, CAR.KIA_SORENTO_HEV_4TH_GEN, CAR.KONA_EV_2ND_GEN, CAR.KIA_K8_HEV_1ST_GEN, CAR.KIA_EV9}
 
 # The radar does SCC on these cars when HDA I, rather than the camera
 CANFD_RADAR_SCC_CAR = {CAR.GENESIS_GV70_1ST_GEN, CAR.KIA_SORENTO_PHEV_4TH_GEN, CAR.KIA_SORENTO_4TH_GEN, CAR.GENESIS_GV80,
@@ -2247,7 +2262,7 @@ HYBRID_CAR = {CAR.IONIQ_PHEV, CAR.ELANTRA_HEV_2021, CAR.KIA_NIRO_PHEV, CAR.KIA_N
               CAR.AZERA_HEV_6TH_GEN}
 
 EV_CAR = {CAR.IONIQ_EV_2020, CAR.IONIQ_EV_LTD, CAR.KONA_EV, CAR.KIA_NIRO_EV, CAR.KIA_NIRO_EV_2ND_GEN, CAR.KONA_EV_2022,
-          CAR.KIA_EV6, CAR.IONIQ_5, CAR.IONIQ_6, CAR.GENESIS_GV60_EV_1ST_GEN, CAR.KONA_EV_2ND_GEN}
+          CAR.KIA_EV6, CAR.IONIQ_5, CAR.IONIQ_6, CAR.GENESIS_GV60_EV_1ST_GEN, CAR.KONA_EV_2ND_GEN, CAR.KIA_EV9}
 
 # these cars require a special panda safety mode due to missing counters and checksums in the messages
 LEGACY_SAFETY_MODE_CAR = {CAR.HYUNDAI_GENESIS, CAR.IONIQ_EV_LTD, CAR.KIA_OPTIMA_G4,
@@ -2318,6 +2333,7 @@ DBC = {
   CAR.VELOSTER: dbc_dict('hyundai_kia_generic', None),
   CAR.KIA_CEED: dbc_dict('hyundai_kia_generic', None),
   CAR.KIA_EV6: dbc_dict('hyundai_canfd', None),
+  CAR.KIA_EV9: dbc_dict('hyundai_canfd', None),
   CAR.SONATA_HYBRID: dbc_dict('hyundai_kia_generic', 'hyundai_kia_mando_front_radar_generated'),
   CAR.TUCSON_4TH_GEN: dbc_dict('hyundai_canfd', None),
   CAR.TUCSON_HYBRID_4TH_GEN: dbc_dict('hyundai_canfd', None),


### PR DESCRIPTION
log: 
carParams
{'carParams': {'alternativeExperience': 1,
               'autoResumeSng': True,
               'carFingerprint': 'mock',
               'carFw': [{'address': 2000,
                          'brand': 'hyundai',
                          'bus': 0,
                          'ecu': 'fwdRadar',
                          'fwVersion': b'\xf1\x00MV__ RDR -----      1.00 1.02 99110-DO700         ',
                          'logging': False,
                          'obdMultiplexing': True,
                          'request': [b'"\xf1\x00'],
                          'responseAddress': 2008,
                          'subAddress': 0},
                         {'address': 1840,
                          'brand': 'hyundai',
                          'bus': 1,
                          'ecu': 'adas',
                          'fwVersion': b'\xf1\x00MV  FBL5 1.00 1.02 230602',
                          'logging': True,
                          'obdMultiplexing': False,
                          'request': [b'"\xf1\x00'],
                          'responseAddress': 1848,
                          'subAddress': 0},
                         {'address': 1988,
                          'brand': 'hyundai',
                          'bus': 1,
                          'ecu': 'fwdCamera',
                          'fwVersion': b'\xf1\x00MV  MFC  AT KOR LHD 1.00 1.01 99211-DO000 230419',
                          'logging': False,
                          'obdMultiplexing': False,
                          'request': [b'"\xf1\x00'],
                          'responseAddress': 1996,
                          'subAddress': 0}],
               'carName': 'mock',
               'carVin': '00000000000000000',
               'centerToFront': 1.350000023841858,
               'communityFeatureDEPRECATED': False,
               'dashcamOnly': False,
               'directAccelControlDEPRECATED': False,
               'enableApgsDEPRECATED': False,
               'enableBsm': False,
               'enableCameraDEPRECATED': False,
               'enableDsu': False,
               'enableGasInterceptor': False,
               'experimentalLongitudinalAvailable': False,
               'fingerprintSource': 'can',
               'flags': 0,
               'fuzzyFingerprint': False,
               'hasStockCameraDEPRECATED': False,
               'isPandaBlackDEPRECATED': False,
               'lateralTuning': {'pid': {'kf': 0.0}},
               'longitudinalActuatorDelayLowerBound': 0.15000000596046448,
               'longitudinalActuatorDelayUpperBound': 0.15000000596046448,
               'longitudinalTuning': {'deadzoneBP': [0.0], 'deadzoneV': [0.0], 'kf': 1.0, 'kiBP': [0.0], 'kiV': [1.0], 'kpBP': [0.0], 'kpV': [1.0]},
               'mass': 1836.0,
               'maxLateralAccel': 10.0,
               'maxSteeringAngleDegDEPRECATED': 0.0,
               'minEnableSpeed': -1.0,
               'minSpeedCanDEPRECATED': 0.0,
               'minSteerSpeed': 0.0,
               'networkLocation': 'fwdCamera',
               'notCar': False,
               'openpilotLongitudinalControl': False,
               'passive': True,
               'pcmCruise': True,
               'radarTimeStep': 0.05000000074505806,
               'radarUnavailable': False,
               'rotationalInertia': 3139.534912109375,
               'safetyConfigs': [{'safetyModel': 'noOutput', 'safetyParam': 0, 'safetyParam2DEPRECATED': 0, 'safetyParamDEPRECATED': 0}],
               'safetyModelDEPRECATED': 'silent',
               'safetyModelPassiveDEPRECATED': 'silent',
               'safetyParamDEPRECATED': 0,
               'startAccel': 0.0,
               'startingAccelRateDEPRECATED': 0.0,
               'startingState': False,
               'steerActuatorDelay': 0.0,
               'steerControlType': 'torque',
               'steerLimitAlert': False,
               'steerLimitTimer': 1.0,
               'steerRateCostDEPRECATED': 0.0,
               'steerRatio': 13.0,
               'steerRatioRear': 0.0,
               'stopAccel': -2.0,
               'stoppingControl': True,
               'stoppingDecelRate': 0.800000011920929,
               'tireStiffnessFactor': 1.0,
               'tireStiffnessFront': 201087.203125,
               'tireStiffnessRear': 317877.90625,
               'transmissionType': 'unknown',
               'vEgoStarting': 0.5,
               'vEgoStopping': 0.5,
               'wheelSpeedFactor': 1.0,
               'wheelbase': 2.700000047683716},
 'logMonoTime': 47460581229,
 'valid': True}
{'carParams': {'alternativeExperience': 1,
               'autoResumeSng': True,
               'carFingerprint': 'mock',
               'carFw': [{'address': 2000,
                          'brand': 'hyundai',
                          'bus': 0,
                          'ecu': 'fwdRadar',
                          'fwVersion': b'\xf1\x00MV__ RDR -----      1.00 1.02 99110-DO700         ',
                          'logging': False,
                          'obdMultiplexing': True,
                          'request': [b'"\xf1\x00'],
                          'responseAddress': 2008,
                          'subAddress': 0},
                         {'address': 1840,
                          'brand': 'hyundai',
                          'bus': 1,
                          'ecu': 'adas',
                          'fwVersion': b'\xf1\x00MV  FBL5 1.00 1.02 230602',
                          'logging': True,
                          'obdMultiplexing': False,
                          'request': [b'"\xf1\x00'],
                          'responseAddress': 1848,
                          'subAddress': 0},
                         {'address': 1988,
                          'brand': 'hyundai',
                          'bus': 1,
                          'ecu': 'fwdCamera',
                          'fwVersion': b'\xf1\x00MV  MFC  AT KOR LHD 1.00 1.01 99211-DO000 230419',
                          'logging': False,
                          'obdMultiplexing': False,
                          'request': [b'"\xf1\x00'],
                          'responseAddress': 1996,
                          'subAddress': 0}],
               'carName': 'mock',
               'carVin': '00000000000000000',
               'centerToFront': 1.350000023841858,
               'communityFeatureDEPRECATED': False,
               'dashcamOnly': False,
               'directAccelControlDEPRECATED': False,
               'enableApgsDEPRECATED': False,
               'enableBsm': False,
               'enableCameraDEPRECATED': False,
               'enableDsu': False,
               'enableGasInterceptor': False,
               'experimentalLongitudinalAvailable': False,
               'fingerprintSource': 'can',
               'flags': 0,
               'fuzzyFingerprint': False,
               'hasStockCameraDEPRECATED': False,
               'isPandaBlackDEPRECATED': False,
               'lateralTuning': {'pid': {'kf': 0.0}},
               'longitudinalActuatorDelayLowerBound': 0.15000000596046448,
               'longitudinalActuatorDelayUpperBound': 0.15000000596046448,
               'longitudinalTuning': {'deadzoneBP': [0.0], 'deadzoneV': [0.0], 'kf': 1.0, 'kiBP': [0.0], 'kiV': [1.0], 'kpBP': [0.0], 'kpV': [1.0]},
               'mass': 1836.0,
               'maxLateralAccel': 10.0,
               'maxSteeringAngleDegDEPRECATED': 0.0,
               'minEnableSpeed': -1.0,
               'minSpeedCanDEPRECATED': 0.0,
               'minSteerSpeed': 0.0,
               'networkLocation': 'fwdCamera',
               'notCar': False,
               'openpilotLongitudinalControl': False,
               'passive': True,
               'pcmCruise': True,
               'radarTimeStep': 0.05000000074505806,
               'radarUnavailable': False,
               'rotationalInertia': 3139.534912109375,
               'safetyConfigs': [{'safetyModel': 'noOutput', 'safetyParam': 0, 'safetyParam2DEPRECATED': 0, 'safetyParamDEPRECATED': 0}],
               'safetyModelDEPRECATED': 'silent',
               'safetyModelPassiveDEPRECATED': 'silent',
               'safetyParamDEPRECATED': 0,
               'startAccel': 0.0,
               'startingAccelRateDEPRECATED': 0.0,
               'startingState': False,
               'steerActuatorDelay': 0.0,
               'steerControlType': 'torque',
               'steerLimitAlert': False,
               'steerLimitTimer': 1.0,
               'steerRateCostDEPRECATED': 0.0,
               'steerRatio': 13.0,
               'steerRatioRear': 0.0,
               'stopAccel': -2.0,
               'stoppingControl': True,
               'stoppingDecelRate': 0.800000011920929,
               'tireStiffnessFactor': 1.0,
               'tireStiffnessFront': 201087.203125,
               'tireStiffnessRear': 317877.90625,
               'transmissionType': 'unknown',
               'vEgoStarting': 0.5,
               'vEgoStopping': 0.5,
               'wheelSpeedFactor': 1.0,
               'wheelbase': 2.700000047683716},
 'logMonoTime': 97455653867,
 'valid': True}


...
[Sign out](https://useradmin.comma.ai/auth/logout)