### PR TITLE
add fw 2024 Telluride non-HDA2

### DIFF
--- a/selfdrive/car/hyundai/values.py
+++ b/selfdrive/car/hyundai/values.py
@@ -2109,6 +2109,7 @@ FW_VERSIONS = {
       b'\xf1\x00LX2 MFC  AT USA LHD 1.00 1.04 99211-S8150 220622',
       b'\xf1\x00ON  MFC  AT USA LHD 1.00 1.01 99211-S9150 220708',
       b'\xf1\x00ON  MFC  AT USA LHD 1.00 1.00 99211-S9160 230303',
+      b'\xf1\x00ON  MFC  AT USA LHD 1.00 1.01 99211-S9160 230802',
     ],
     (Ecu.fwdRadar, 0x7d0, None): [
       b'\xf1\x00LX2_ SCC -----      1.00 1.01 99110-S8150         ',


### PR DESCRIPTION
**Car**
Which car (make, model, year) this fingerprint is for:
2024 Kia Telluride non-HDA2

**Route**
A route with the fingerprint:
a865aebac3863cd4|2024-05-16--13-29-49

