### PR TITLE
car: Check params before car state is updated

### DIFF
--- a/selfdrive/car/card.py
+++ b/selfdrive/car/card.py
@@ -95,7 +95,7 @@ class Car:
 
     self.param_manager: ParamManager = ParamManager()
     self.param_manager.update(self.params)
-    self.params_list: SimpleNamespace = self.param_manager.get_params()
+    self._params_list: SimpleNamespace = self.param_manager.get_params()
 
     # card is driven by can recv, expected at 100Hz
     self.rk = Ratekeeper(100, print_delay_threshold=None)
@@ -105,7 +105,7 @@ class Car:
 
     # Update carState from CAN
     can_strs = messaging.drain_sock_raw(self.can_sock, wait_for_one=True)
-    CS = self.CI.update(self.CC_prev, can_strs, self.params_list)
+    CS = self.CI.update(self.CC_prev, can_strs, self._params_list)
 
     self.sm.update(0)
 
@@ -196,7 +196,7 @@ class Car:
   def sp_params_thread(self, event: threading.Event) -> None:
     while not event.is_set():
       self.param_manager.update(self.params)
-      self.params_list = self.param_manager.get_params()
+      self._params_list = self.param_manager.get_params()
       time.sleep(0.1)
 
   def card_thread(self):

--- a/selfdrive/car/card.py
+++ b/selfdrive/car/card.py
@@ -92,7 +92,13 @@ class Car:
 
     self.events = Events()
 
-    self.params_list: SimpleNamespace | None = None
+    self.params_list: SimpleNamespace = SimpleNamespace(
+      experimental_mode=self.params.get_bool("ExperimentalMode"),
+      is_metric=self.params.get_bool("IsMetric"),
+      below_speed_pause=self.params.get_bool("BelowSpeedPause"),
+      pause_lateral_speed=int(self.params.get("PauseLateralSpeed", encoding="utf8")),
+      reverse_dm_cam=self.params.get_bool("ReverseDmCam"),
+    )
 
     # card is driven by can recv, expected at 100Hz
     self.rk = Ratekeeper(100, print_delay_threshold=None)

--- a/selfdrive/car/card.py
+++ b/selfdrive/car/card.py
@@ -190,7 +190,7 @@ class Car:
     self.initialized_prev = initialized
     self.CS_prev = CS.as_reader()
 
-  def sp_params_thread(self, event):
+  def sp_params_thread(self, event: threading.Event) -> None:
     while not event.is_set():
       params_list = {
         "experimental_mode": self.params.get_bool("ExperimentalMode"),

--- a/selfdrive/car/card.py
+++ b/selfdrive/car/card.py
@@ -92,13 +92,7 @@ class Car:
 
     self.events = Events()
 
-    self.params_list: SimpleNamespace = SimpleNamespace(
-      experimental_mode=self.params.get_bool("ExperimentalMode"),
-      is_metric=self.params.get_bool("IsMetric"),
-      below_speed_pause=self.params.get_bool("BelowSpeedPause"),
-      pause_lateral_speed=int(self.params.get("PauseLateralSpeed", encoding="utf8")),
-      reverse_dm_cam=self.params.get_bool("ReverseDmCam"),
-    )
+    self.params_list: SimpleNamespace | None = None
 
     # card is driven by can recv, expected at 100Hz
     self.rk = Ratekeeper(100, print_delay_threshold=None)

--- a/selfdrive/car/card.py
+++ b/selfdrive/car/card.py
@@ -16,6 +16,7 @@ from openpilot.common.realtime import config_realtime_process, Priority, Ratekee
 from openpilot.selfdrive.pandad import can_list_to_can_capnp
 from openpilot.selfdrive.car.car_helpers import get_car, get_one_can
 from openpilot.selfdrive.car.interfaces import CarInterfaceBase
+from openpilot.selfdrive.car.param_manager import ParamManager
 from openpilot.selfdrive.controls.lib.events import Events
 
 REPLAY = "REPLAY" in os.environ
@@ -92,7 +93,9 @@ class Car:
 
     self.events = Events()
 
-    self.params_list: SimpleNamespace | None = None
+    self.param_manager: ParamManager = ParamManager()
+    self.param_manager.update(self.params)
+    self.params_list: SimpleNamespace = self.param_manager.get_params()
 
     # card is driven by can recv, expected at 100Hz
     self.rk = Ratekeeper(100, print_delay_threshold=None)
@@ -192,14 +195,8 @@ class Car:
 
   def sp_params_thread(self, event: threading.Event) -> None:
     while not event.is_set():
-      params_list = {
-        "experimental_mode": self.params.get_bool("ExperimentalMode"),
-        "is_metric": self.params.get_bool("IsMetric"),
-        "below_speed_pause": self.params.get_bool("BelowSpeedPause"),
-        "pause_lateral_speed": int(self.params.get("PauseLateralSpeed", encoding="utf8")),
-        "reverse_dm_cam": self.params.get_bool("ReverseDmCam"),
-      }
-      self.params_list = SimpleNamespace(**params_list)
+      self.param_manager.update(self.params)
+      self.params_list = self.param_manager.get_params()
       time.sleep(0.1)
 
   def card_thread(self):

--- a/selfdrive/car/chrysler/interface.py
+++ b/selfdrive/car/chrysler/interface.py
@@ -91,7 +91,6 @@ class CarInterface(CarInterfaceBase):
 
   def _update(self, c):
     ret = self.CS.update(self.cp, self.cp_cam)
-    self.sp_update_params()
 
     self.CS.button_events.extend(create_button_events(self.CS.distance_button, self.CS.prev_distance_button, {1: ButtonType.gapAdjustCruise}))
     self.CS.button_events.extend(create_button_events(self.CS.lkas_enabled, self.CS.prev_lkas_enabled, {1: ButtonType.altButton1}))

--- a/selfdrive/car/ford/interface.py
+++ b/selfdrive/car/ford/interface.py
@@ -72,7 +72,6 @@ class CarInterface(CarInterfaceBase):
 
   def _update(self, c):
     ret = self.CS.update(self.cp, self.cp_cam)
-    self.sp_update_params()
 
     self.CS.button_events.extend(create_button_events(self.CS.distance_button, self.CS.prev_distance_button, {1: ButtonType.gapAdjustCruise}))
     self.CS.button_events.extend(create_button_events(self.CS.lkas_enabled, self.CS.prev_lkas_enabled, {1: ButtonType.altButton1}))

--- a/selfdrive/car/gm/interface.py
+++ b/selfdrive/car/gm/interface.py
@@ -204,7 +204,6 @@ class CarInterface(CarInterfaceBase):
   # returns a car.CarState
   def _update(self, c):
     ret = self.CS.update(self.cp, self.cp_cam, self.cp_loopback)
-    self.sp_update_params()
 
     distance_button = 0
 

--- a/selfdrive/car/honda/interface.py
+++ b/selfdrive/car/honda/interface.py
@@ -266,7 +266,6 @@ class CarInterface(CarInterfaceBase):
   # returns a car.CarState
   def _update(self, c):
     ret = self.CS.update(self.cp, self.cp_cam, self.cp_body)
-    self.sp_update_params()
 
     self.CS.button_events = [
       *create_button_events(self.CS.cruise_buttons, self.CS.prev_cruise_buttons, BUTTONS_DICT),

--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -203,7 +203,6 @@ class CarInterface(CarInterfaceBase):
 
   def _update(self, c):
     ret = self.CS.update(self.cp, self.cp_cam)
-    self.sp_update_params()
 
     self.CS.button_events.extend(create_button_events(self.CS.cruise_buttons[-1], self.CS.prev_cruise_buttons, BUTTONS_DICT))
     self.CS.button_events.extend(create_button_events(self.CS.lfa_enabled, self.CS.prev_lfa_enabled, {1: ButtonType.altButton1}))

--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -770,7 +770,13 @@ class CarStateBase(ABC):
     self.control_initialized = False
 
     self.button_events: list[capnp.lib.capnp._DynamicStructBuilder] = []
-    self.params_list: SimpleNamespace | None = None
+    self.params_list: SimpleNamespace = SimpleNamespace(
+      experimental_mode=False,
+      is_metric=False,
+      below_speed_pause=False,
+      pause_lateral_speed=0,
+      reverse_dm_cam=False
+    )
 
     Q = [[0.0, 0.0], [0.0, 100.0]]
     R = 0.3

--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -20,6 +20,7 @@ from openpilot.common.numpy_fast import clip
 from openpilot.common.params import Params
 from openpilot.common.realtime import DT_CTRL
 from openpilot.selfdrive.car import apply_hysteresis, gen_empty_fingerprint, scale_rot_inertia, scale_tire_stiffness, STD_CARGO_KG, ButtonEvents
+from openpilot.selfdrive.car.param_manager import ParamManager
 from openpilot.selfdrive.car.values import PLATFORMS
 from openpilot.selfdrive.controls.lib.desire_helper import get_min_lateral_speed
 from openpilot.selfdrive.controls.lib.drive_helpers import V_CRUISE_MAX, V_CRUISE_UNSET, get_friction
@@ -770,13 +771,7 @@ class CarStateBase(ABC):
     self.control_initialized = False
 
     self.button_events: list[capnp.lib.capnp._DynamicStructBuilder] = []
-    self.params_list: SimpleNamespace = SimpleNamespace(
-      experimental_mode=False,
-      is_metric=False,
-      below_speed_pause=False,
-      pause_lateral_speed=0,
-      reverse_dm_cam=False
-    )
+    self.params_list: SimpleNamespace = ParamManager().get_params()
 
     Q = [[0.0, 0.0], [0.0, 100.0]]
     R = 0.3

--- a/selfdrive/car/mazda/interface.py
+++ b/selfdrive/car/mazda/interface.py
@@ -37,7 +37,6 @@ class CarInterface(CarInterfaceBase):
   # returns a car.CarState
   def _update(self, c):
     ret = self.CS.update(self.cp, self.cp_cam)
-    self.sp_update_params()
 
     # TODO: add button types for inc and dec
     self.CS.button_events.extend(create_button_events(self.CS.distance_button, self.CS.prev_distance_button, {1: ButtonType.gapAdjustCruise}))

--- a/selfdrive/car/nissan/interface.py
+++ b/selfdrive/car/nissan/interface.py
@@ -32,7 +32,6 @@ class CarInterface(CarInterfaceBase):
   # returns a car.CarState
   def _update(self, c):
     ret = self.CS.update(self.cp, self.cp_adas, self.cp_cam)
-    self.sp_update_params()
 
     self.CS.button_events = create_button_events(self.CS.distance_button, self.CS.prev_distance_button, {1: ButtonType.gapAdjustCruise})
 

--- a/selfdrive/car/param_manager.py
+++ b/selfdrive/car/param_manager.py
@@ -1,0 +1,30 @@
+from types import SimpleNamespace
+
+from openpilot.common.params import Params
+
+
+class ParamManager:
+  def __init__(self):
+    self.params_list: SimpleNamespace = self.convert_to_namespace({
+      "below_speed_pause": False,
+      "experimental_mode": False,
+      "is_metric": False,
+      "pause_lateral_speed": 0,
+      "reverse_dm_cam": False,
+    })
+
+  @staticmethod
+  def convert_to_namespace(data: dict) -> SimpleNamespace:
+    return SimpleNamespace(**data)
+
+  def get_params(self) -> SimpleNamespace:
+    return self.params_list
+
+  def update(self, params: Params) -> None:
+    self.params_list = self.convert_to_namespace({
+      "below_speed_pause": params.get_bool("BelowSpeedPause"),
+      "experimental_mode": params.get_bool("ExperimentalMode"),
+      "is_metric": params.get_bool("IsMetric"),
+      "pause_lateral_speed": int(params.get("PauseLateralSpeed", encoding="utf8")),
+      "reverse_dm_cam": params.get_bool("ReverseDmCam"),
+    })

--- a/selfdrive/car/param_manager.py
+++ b/selfdrive/car/param_manager.py
@@ -5,7 +5,7 @@ from openpilot.common.params import Params
 
 class ParamManager:
   def __init__(self):
-    self.params_list: SimpleNamespace = self.convert_to_namespace({
+    self._params_list: SimpleNamespace = self._create_namespace({
       "below_speed_pause": False,
       "experimental_mode": False,
       "is_metric": False,
@@ -14,14 +14,14 @@ class ParamManager:
     })
 
   @staticmethod
-  def convert_to_namespace(data: dict) -> SimpleNamespace:
+  def _create_namespace(data: dict) -> SimpleNamespace:
     return SimpleNamespace(**data)
 
   def get_params(self) -> SimpleNamespace:
-    return self.params_list
+    return self._params_list
 
   def update(self, params: Params) -> None:
-    self.params_list = self.convert_to_namespace({
+    self._params_list = self._create_namespace({
       "below_speed_pause": params.get_bool("BelowSpeedPause"),
       "experimental_mode": params.get_bool("ExperimentalMode"),
       "is_metric": params.get_bool("IsMetric"),

--- a/selfdrive/car/subaru/interface.py
+++ b/selfdrive/car/subaru/interface.py
@@ -116,7 +116,6 @@ class CarInterface(CarInterfaceBase):
   def _update(self, c):
 
     ret = self.CS.update(self.cp, self.cp_cam, self.cp_body)
-    self.sp_update_params()
 
     self.CS.mads_enabled = self.get_sp_cruise_main_state(ret, self.CS)
 

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -207,7 +207,6 @@ class CarInterface(CarInterfaceBase):
   # returns a car.CarState
   def _update(self, c):
     ret = self.CS.update(self.cp, self.cp_cam)
-    self.sp_update_params()
 
     distance_button = 0
 

--- a/selfdrive/car/volkswagen/interface.py
+++ b/selfdrive/car/volkswagen/interface.py
@@ -113,7 +113,6 @@ class CarInterface(CarInterfaceBase):
   # returns a car.CarState
   def _update(self, c):
     ret = self.CS.update(self.cp, self.cp_cam, self.cp_ext, self.CP.transmissionType)
-    self.sp_update_params()
 
     self.CS.mads_enabled = self.get_sp_cruise_main_state(ret, self.CS)
 


### PR DESCRIPTION
Unity custom param calls before `CarState` update is called.

Part of https://github.com/sunnypilot/sunnypilot/issues/377