### PR TITLE
Tesla: Add toggle for virtual torque blending

### DIFF
--- a/common/params.cc
+++ b/common/params.cc
@@ -314,6 +314,7 @@ std::unordered_map<std::string, uint32_t> keys = {
     {"SunnylinkEnabled", PERSISTENT},
     {"SunnylinkdPid", PERSISTENT},
     {"TermsVersionSunnypilot", PERSISTENT},
+    {"TeslaVirtualTorqueBlending", PERSISTENT | BACKUP},
     {"TorqueDeadzoneDeg", PERSISTENT | BACKUP},
     {"TorqueFriction", PERSISTENT | BACKUP},
     {"TorqueMaxLatAccel", PERSISTENT | BACKUP},

--- a/selfdrive/car/tesla/carcontroller.py
+++ b/selfdrive/car/tesla/carcontroller.py
@@ -1,4 +1,5 @@
 from openpilot.common.numpy_fast import clip
+from openpilot.common.params import Params
 from opendbc.can.packer import CANPacker
 from openpilot.selfdrive.car import apply_std_steer_angle_limits
 from openpilot.selfdrive.car.interfaces import CarControllerBase
@@ -31,7 +32,7 @@ class CarController(CarControllerBase):
     self.packer = CANPacker(dbc_name)
     self.pt_packer = CANPacker(DBC[CP.carFingerprint]['pt'])
     self.tesla_can = TeslaCAN(self.packer, self.pt_packer)
-    self.virtual_blending = False  # TODO: pull from toggle
+    self.virtual_blending = Params().get_bool("TeslaVirtualTorqueBlending")
 
   def update(self, CC, CS, now_nanos):
     actuators = CC.actuators

--- a/selfdrive/car/tesla/carstate.py
+++ b/selfdrive/car/tesla/carstate.py
@@ -18,6 +18,7 @@ class CarState(CarStateBase):
     self.acc_enabled = None
     self.sccm_right_stalk_counter = None
     self.das_control = None
+    self.steering_override = False  # Set in CC because actuator info is needed to determine this.
 
   def update(self, cp, cp_cam, cp_adas):
     ret = car.CarState.new_message()
@@ -46,9 +47,10 @@ class CarState(CarStateBase):
     ret.steeringRateDeg = -cp_adas.vl["SCCM_steeringAngleSensor"]["SCCM_steeringAngleSpeed"]
     ret.steeringTorque = -epas_status["EPAS3S_torsionBarTorque"]
 
-    ret.steeringPressed = (self.hands_on_level > 0)
-    ret.steerFaultPermanent = self.can_define.dv["EPAS3S_sysStatus"]["EPAS3S_eacStatus"].get(int(epas_status["EPAS3S_eacStatus"]), None) in ["EAC_FAULT"]
-    ret.steerFaultTemporary = (self.steer_warning not in ("EAC_ERROR_IDLE", "EAC_ERROR_HANDS_ON"))
+    ret.steeringPressed = (self.hands_on_level > 0 or self.steering_override or self.update_steering_pressed(abs(ret.steeringTorque) > 1.0, 5))  # hands_on_level has too much filtering
+    eac_status = self.can_define.dv["EPAS3S_sysStatus"]["EPAS3S_eacStatus"].get(int(epas_status["EPAS3S_eacStatus"]), None)
+    ret.steerFaultPermanent = eac_status in ["EAC_FAULT"]
+    ret.steerFaultTemporary = self.steer_warning not in ["EAC_ERROR_IDLE", "EAC_ERROR_HANDS_ON"] and eac_status not in ["EAC_ACTIVE", "EAC_AVAILABLE"]
 
     # Cruise state
     cruise_state = self.can_define.dv["DI_state"]["DI_cruiseState"].get(int(cp.vl["DI_state"]["DI_cruiseState"]), None)

--- a/selfdrive/car/tesla/interface.py
+++ b/selfdrive/car/tesla/interface.py
@@ -16,9 +16,9 @@ class CarInterface(CarInterfaceBase):
   def _get_params(ret, candidate, fingerprint, car_fw, experimental_long, docs):
     ret.carName = "tesla"
 
-    # There is no safe way to do steer blending with user torque,
-    # so the steering behaves like autopilot. This is not
-    # how openpilot should be, hence dashcamOnly
+    # Steer blending with user torque is done virtually, and is limited to 2Nm of torque
+    # before it temporarily disables OP Lat control for higher user torque. This is not
+    # how openpilot typically works, hence dashcamOnly
     # ret.dashcamOnly = True
 
     ret.steerControlType = car.CarParams.SteerControlType.angle

--- a/selfdrive/car/tesla/values.py
+++ b/selfdrive/car/tesla/values.py
@@ -75,6 +75,11 @@ class CarControllerParams:
   JERK_LIMIT_MAX = 8
   JERK_LIMIT_MIN = -8
   ACCEL_TO_SPEED_MULTIPLIER = 3
+  TORQUE_TO_ANGLE_MULTIPLIER_OUTER = 4  # Higher = easier to influence when manually steering more than OP
+  TORQUE_TO_ANGLE_MULTIPLIER_INNER = 8  # Higher = easier to influence when manually steering less than OP
+  TORQUE_TO_ANGLE_DEADZONE = 0.5  # This equates to hands-on level 1, so we don't allow override if not hands-on
+  TORQUE_TO_ANGLE_CLIP = 10. # Steering (usually) disengages at 2.5 Nm, this limit exists only in case the EPAS gives bad data
+  CONTINUED_OVERRIDE_ANGLE = 10.  # The angle difference between OP and user to continue overriding steering (prevents oscillation)
 
   def __init__(self, CP):
     pass

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle_settings.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle_settings.cc
@@ -124,7 +124,7 @@ SPVehiclesTogglesPanel::SPVehiclesTogglesPanel(VehiclePanel *parent) : ListWidge
   auto teslaVirtualTorqueBlending = new ParamControlSP(
     "TeslaVirtualTorqueBlending",
     tr("Virtual Torque Blending (Beta)"),
-    tr("Experimental feature to blend steering torque from user input to lat control."),
+    tr("Experimental feature to allow influencing of the steering angle while ALC is active. Note: ALC/ACC will no longer disengage by applying force to the wheel."),
     "../assets/offroad/icon_blank.png");
   teslaVirtualTorqueBlending->setConfirmation(true, false);
   addItem(teslaVirtualTorqueBlending);

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle_settings.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle_settings.cc
@@ -119,6 +119,16 @@ SPVehiclesTogglesPanel::SPVehiclesTogglesPanel(VehiclePanel *parent) : ListWidge
   subaruManualParkingBrakeSng->setConfirmation(true, false);
   addItem(subaruManualParkingBrakeSng);
 
+  // Tesla
+  addItem(new LabelControlSP(tr("Tesla")));
+  auto teslaVirtualTorqueBlending = new ParamControlSP(
+    "TeslaVirtualTorqueBlending",
+    tr("Virtual Torque Blending (Beta)"),
+    tr("Experimental feature to blend steering torque from user input to lat control."),
+    "../assets/offroad/icon_blank.png");
+  teslaVirtualTorqueBlending->setConfirmation(true, false);
+  addItem(teslaVirtualTorqueBlending);
+
   // Toyota/Lexus
   addItem(new LabelControlSP(tr("Toyota/Lexus")));
   stockLongToyota = new ParamControlSP(

--- a/system/manager/manager.py
+++ b/system/manager/manager.py
@@ -96,6 +96,7 @@ def manager_init() -> None:
     ("SpeedLimitWarningOffsetType", "0"),
     ("StandStillTimer", "0"),
     ("StockLongToyota", "0"),
+    ("TeslaVirtualTorqueBlending", "0"),
     ("TorqueDeadzoneDeg", "0"),
     ("TorqueFriction", "1"),
     ("TorqueMaxLatAccel", "250"),


### PR DESCRIPTION
(Rebase of #358)

This PR adds Virtual Torque Blending logic to Tesla AP3 model 3/Y. The feature sits behind a Tesla-specific toggle in vehicle settings.

**Routes:**

enabled: `bbbf82d987d681bc/00000230--172c8e8257`

disabled: `bbbf82d987d681bc/00000231--16650ce95c`

**TL;DR:** Enabling the Virtual Torque Blending toggle allows the user to steer while OP is engaged. It works by taking the user's steering torque and adjusts the angle output from OP before sending it to the car's EPAS, allowing the user to easily nudge the car within the lane, nudge it into exit ramps, and manually take turns, all without disengaging OP.

Torque blending strength can be tweaked by changing the multipliers in values.py, although keep in mind the latency and rate limit's effect on the strength's real-world effect, see below.

**Limitation:** The EPAS will not allow more than 2.5 Nm of torque from the user (except in very brief bursts) without faulting, in addition the control loop is a bit too slow to keep up with a fast manual steering jerk from the user. As a result, the virtual blending switches to a silent disengagement of lat control in some scenarios, automatically re-enabling lat control once the user's torque has decreased and the user's steering angle is again close to the OP commanded angle, or if more than 1 second elapses without user torque even if there is still an angular disagreement. This switchover from torque blending to full override sometimes results in feeling a bump in the steering, similar to the bump when disengaging from classic AP. Work is still being done to try to minimize the strength of this bump, it's typically felt when turning sharp corners at low speeds.

**Safety considerations:**
- Ability to always override: this is baked in to the Tesla's EPAS, it's always possible to override the steering with ~ 2.5 Nm of force no matter what OP tries to do.
- Never silently release control to the user without the user having hands on the wheel: the main criteria for silently disengaging is to reach hands-on-level 3, which is a signal from the EPAS that roughly equates to > 2.5 Nm of force (with some filtering)
- Avoid accidental torque blending: there is a 0.5 Nm deadzone where the angle is not modified, so that a misbalance of the wheel, or slight hand weight, will not cause it to veer from OP's lat control.
- Avoid high-rate steering even if data is faulty: the steering rate limiting is applied *after* the torque blending, so even if OP receives faulty torque data, the rate limits will still be respected, giving the user time to override.
- Blending is disabled by default behind a toggle to ensure the user is aware of the feature, reducing risk of accidental nudging from misunderstanding the capability.

As always, it's possible not all safety considerations were realized, or that an edge case was missed, use with caution.