### PR TITLE
Remove dangling imports

### DIFF
--- a/selfdrive/car/tesla/carstate.py
+++ b/selfdrive/car/tesla/carstate.py
@@ -1,7 +1,7 @@
 import copy
 from cereal import car
 from openpilot.common.conversions import Conversions as CV
-from openpilot.selfdrive.car.tesla.values import DBC, CANBUS, GEAR_MAP, BUTTONS, BUTTON_STATES
+from openpilot.selfdrive.car.tesla.values import DBC, CANBUS, GEAR_MAP, BUTTONS
 from openpilot.selfdrive.car.interfaces import CarStateBase
 from opendbc.can.parser import CANParser
 from opendbc.can.can_define import CANDefine

--- a/selfdrive/car/tesla/interface.py
+++ b/selfdrive/car/tesla/interface.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 from cereal import car
 from panda import Panda
-from openpilot.selfdrive.car.tesla.values import CAR, BUTTON_STATES
-from openpilot.selfdrive.car import get_safety_config, create_mads_event
+from openpilot.selfdrive.car.tesla.values import CAR
+from openpilot.selfdrive.car import get_safety_config
 from openpilot.selfdrive.car.interfaces import CarInterfaceBase
 
 ButtonType = car.CarState.ButtonEvent.Type


### PR DESCRIPTION
SP failed to start due to an import error on button states. I noticed create_mads_event was also unused.

This gets the tesla port to a working state as long as mads is disabled.