### PR TITLE
Disable cruise main state detection for Tesla

### DIFF
--- a/selfdrive/car/tesla/interface.py
+++ b/selfdrive/car/tesla/interface.py
@@ -40,7 +40,9 @@ class CarInterface(CarInterfaceBase):
     ret = self.CS.update(self.cp, self.cp_cam, self.cp_adas)
     self.sp_update_params()
 
-    self.CS.mads_enabled = self.get_sp_cruise_main_state(ret, self.CS)
+    # TODO: Implement detection of half vs full press of stalk for MADS control
+    # Until then, we're disabling main state control to prevent it from trying to self-engage without user input
+    self.CS.mads_enabled = False  # Tesla has no "cruise main state", as cruise is automatically available
 
     if ret.cruiseState.available:
       if self.enable_mads:


### PR DESCRIPTION
This is an intermediate fix to allow SP to work on tesla by default (even if the user forgets to disable MADS)

Tesla has no main cruise on/off state, cruise availability is determined automatically based on vehicle speed, road detection, and brake pedal input. So this PR disables the cruise main detection for MADS to ensure it doesn't attempt to automatically engage without user input.

Without this PR, if mads is enabled, it will attempt to engage MADS as soon as the car has reached 18mph and cause a controls mismatch.

Before: bbbf82d987d681bc/00000229--3f4ce34e89/0

After: bbbf82d987d681bc/0000022c--c954640cea/0