### PR TITLE
Tesla: Add toggle for Tesla stock longitudinal (TACC)

### DIFF
--- a/common/params.cc
+++ b/common/params.cc
@@ -308,6 +308,7 @@ std::unordered_map<std::string, uint32_t> keys = {
     {"SpeedLimitWarningValueOffset", PERSISTENT | BACKUP},
     {"SpeedLimitWarningOffsetType", PERSISTENT | BACKUP},
     {"StandStillTimer", PERSISTENT | BACKUP},
+    {"StockLongTesla", PERSISTENT | BACKUP},
     {"StockLongToyota", PERSISTENT | BACKUP},
     {"SubaruManualParkingBrakeSng", PERSISTENT | BACKUP},
     {"SunnylinkDongleId", PERSISTENT},

--- a/selfdrive/car/tesla/interface.py
+++ b/selfdrive/car/tesla/interface.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from cereal import car
 from panda import Panda
+from openpilot.common.params import Params
 from openpilot.selfdrive.car.tesla.values import CAR
 from openpilot.selfdrive.car import get_safety_config
 from openpilot.selfdrive.car.interfaces import CarInterfaceBase
@@ -26,10 +27,14 @@ class CarInterface(CarInterfaceBase):
     ret.longitudinalActuatorDelay = 0.5 # s
     ret.radarUnavailable = True
 
+    params = Params()
+    stock_acc = params.get_bool("StockLongTesla")
+
     if candidate in [CAR.TESLA_AP3_MODEL3, CAR.TESLA_AP3_MODELY]:
       flags = Panda.FLAG_TESLA_MODEL3_Y
-      flags |= Panda.FLAG_TESLA_LONG_CONTROL
-      ret.openpilotLongitudinalControl = True
+      if not stock_acc:
+        flags |= Panda.FLAG_TESLA_LONG_CONTROL
+      ret.openpilotLongitudinalControl = not stock_acc
       ret.safetyConfigs = [get_safety_config(car.CarParams.SafetyModel.tesla, flags)]
 
     ret.steerLimitTimer = 1.0

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle_settings.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle_settings.cc
@@ -121,7 +121,7 @@ SPVehiclesTogglesPanel::SPVehiclesTogglesPanel(VehiclePanel *parent) : ListWidge
 
   // Tesla
   addItem(new LabelControlSP(tr("Tesla")));
-  stockLongTesla = new ParamControlSP(
+  auto stockLongTesla = new ParamControlSP(
     "StockLongTesla",
     tr("Enable Stock Longitudinal Control (TACC)"),
     tr("sunnypilot will <b>not</b> take over control of gas and brakes. Stock Tesla longitudinal control (TACC) will be used."),

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle_settings.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle_settings.cc
@@ -119,6 +119,16 @@ SPVehiclesTogglesPanel::SPVehiclesTogglesPanel(VehiclePanel *parent) : ListWidge
   subaruManualParkingBrakeSng->setConfirmation(true, false);
   addItem(subaruManualParkingBrakeSng);
 
+  // Tesla
+  addItem(new LabelControlSP(tr("Tesla")));
+  stockLongTesla = new ParamControlSP(
+    "StockLongTesla",
+    tr("Enable Stock Longitudinal Control (TACC)"),
+    tr("sunnypilot will <b>not</b> take over control of gas and brakes. Stock Tesla longitudinal control (TACC) will be used."),
+    "../assets/offroad/icon_blank.png");
+  stockLongTesla->setConfirmation(true, false);
+  addItem(stockLongTesla);
+
   // Toyota/Lexus
   addItem(new LabelControlSP(tr("Toyota/Lexus")));
   stockLongToyota = new ParamControlSP(

--- a/system/manager/manager.py
+++ b/system/manager/manager.py
@@ -95,6 +95,7 @@ def manager_init() -> None:
     ("SpeedLimitWarningValueOffset", "0"),
     ("SpeedLimitWarningOffsetType", "0"),
     ("StandStillTimer", "0"),
+    ("StockLongTesla", "0"),
     ("StockLongToyota", "0"),
     ("TorqueDeadzoneDeg", "0"),
     ("TorqueFriction", "1"),


### PR DESCRIPTION
This adds a toggle to enable stock Tesla long control (TACC) for those of us who prefer its smoothness.

**Routes:**

with stock tacc: `bbbf82d987d681bc/00000235--c0f726a812/0`

with op long: `bbbf82d987d681bc/00000236--52348b0db4/0`