### PR TITLE
ci: Update build number on dev builds with Discord notification

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -230,6 +230,9 @@ notify new dev build:
   needs: ["publish to public github prebuilt"] # This notify shall only happen after a publish to github public
   variables:
     TEMPLATE: "discord_template_notify_dev_public.json"
+  before_script:
+    - !reference [".notify_discord", "before_script"]
+    - export EXTRA_VERSION_IDENTIFIER=$((CI_PIPELINE_IID + BASE_BUILD_NUMER))
   rules:
     - if: $NEW_BRANCH == "dev-c3"
       variables:

--- a/release/ci/discord_template_notify_dev_public.json
+++ b/release/ci/discord_template_notify_dev_public.json
@@ -2,7 +2,7 @@
   "embeds": [
     {
       "title": "🎉 sunnypilot `${NEW_BRANCH}` New Update 🎉",
-      "description": "[sunnypilot](${PUBLIC_REPO_URL}): Build #${CI_PIPELINE_IID} of branch [${NEW_BRANCH}](${PUBLIC_REPO_URL}/tree/${NEW_BRANCH}) has been published.\n\nDrive safe! 🚗💨",
+      "description": "[sunnypilot](${PUBLIC_REPO_URL}): Build #${EXTRA_VERSION_IDENTIFIER} of branch [${NEW_BRANCH}](${PUBLIC_REPO_URL}/tree/${NEW_BRANCH}) has been published.\n\nDrive safe! 🚗💨",
       "color": 4321431
     }
   ]


### PR DESCRIPTION
Fixes the bug from https://github.com/sunnypilot/sunnypilot/pull/380 where the build numbers on `dev-c3` are not displaying with the new build numbers on Discord.