### PR TITLE
Docs: Move HOW-TOS to `master`

### DIFF
--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -45,9 +45,9 @@ to go back to the default values.
     1. `pkill -f openpilot`
     2. `python /data/openpilot/selfdrive/debug/hyundai_enable_radar_points.py`
     3. Follow the instructions in the script:
-       * `Power on the vehicle keeping the engine off (press start button twice) then type OK to continue`.
-           * If successful, the following message should appear: `[DONE]. Restart your vehicle and ensure there are no faults`.
-           * If the script did not run successfully, reach out to the community in [Sunnyhaibin's Openpilot Discord Server](https://discord.gg/wRW3meAgtx) or `#hyundai-kia-genesis channel` on [commaai community Discord Server](https://discord.comma.ai) for assistance.
+        * `Power on the vehicle keeping the engine off (press start button twice) then type OK to continue`.
+            * If successful, the following message should appear: `[DONE]. Restart your vehicle and ensure there are no faults`.
+            * If the script did not run successfully, reach out to the community in [Sunnyhaibin's Openpilot Discord Server](https://discord.gg/wRW3meAgtx) or `#hyundai-kia-genesis channel` on [commaai community Discord Server](https://discord.comma.ai) for assistance.
     4. Reboot your comma device:
         1. C3: `sudo reboot`
         2. C2 or EON: `reboot`
@@ -56,16 +56,15 @@ to go back to the default values.
 7. With all `rlogs` uploaded, open the drive in Cabana from [comma Connect](https://connect.comma.ai). Load DBC -> `hyundai_kia_mando_front_radar.dbc`, then search `RADAR_TRACK_50x` (`x` could be anything), open any of them, and look at `LONG_DIST`.
 8. If the radar tracks data is relevant with the lead car you drove behind, you are done! Your car now have radar tracks enabled.
 </details>
-   
+
 <details><summary><h3>🗺 Enable Mapbox Navigation</h3></summary>
-   
+
 1) Create a free mapbox account. Account will ask for a credit card for verification. You will not be charged for the free tier.
-2) On the Dashboard, you will see a section called Access Tokens. Click `Create a Token`. Name it whatever you like. Set the scopes to allow everything for both Public and Secret. Copy both of these keys. **YOU WON'T BE ABLE TO ACCESS THE SECRET KEY AFTER THIS WINDOW.** 
-3) On your C3, go to `SP - Visuals` and toggle `Enable Mapbox Navigation*`. Accept the reboot.
-4) Once rebooted, connect your C3 to a network with internet access and find the C3’s IP address.
-5) In a browser, navigate to that IP with **port 8082** (i.e 192.168.1.69:8082). You should be greeted with the Comma logo and a public key input field.
-6) Paste your Public token (pk.xx), click enter, paste your Secret key (sk.xx), click enter. You can now search for places. This page will be available at your devices’s IP address/port 8082 to search for destinations.
-7) To set Home and Work addresses, search for a place, select Home/Work from the dropdown and click Navigate. For non-Home/Work destinations, select Recent Places.<br>*At this time, it is not possible to search directly on the C3.*
+2) On the Dashboard, you will see a section called Access Tokens. Click `Create a Token`. Name it whatever you like. Set the scopes to allow everything for both Public and Secret. Copy both of these keys. **YOU WON'T BE ABLE TO ACCESS THE SECRET KEY AFTER THIS WINDOW.**
+3) Once rebooted, connect your C3 to a network with internet access and find the C3’s IP address.
+4) In a browser, navigate to that IP with **port 8082** (i.e 192.168.1.69:8082). You should be greeted with the Comma logo and a public key input field.
+5) Paste your Public token (pk.xx), click enter, paste your Secret key (sk.xx), click enter. You can now search for places. This page will be available at your devices’s IP address/port 8082 to search for destinations.
+6) To set Home and Work addresses, search for a place, select Home/Work from the dropdown and click Navigate. For non-Home/Work destinations, select Recent Places.<br>*At this time, it is not possible to search directly on the C3.*
 
 **TIPS:**
 - If your C3 is showing a black screen that says “Map Loading”, performing a reboot via the UI should fix it.

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -10,9 +10,9 @@ Table of Contents
 
 ## Enable Radar Tracks and openpilot Longitudinal Control
 
-(Last updated date: October 3rd, 2021)
+*(Last updated date: October 3rd, 2021)*
 
-(Base on `master` on version 0.8.10 `d546c109ef4854322bfaea12954ad854d593554c`)
+*(Base on `master` on version 0.8.10 `d546c109ef4854322bfaea12954ad854d593554c`)*
 
 * [Enable Radar Tracks](#-Enable-Radar_Tracks-)
 * [Enable openpilot Longitudinal Control](#-Enable-openpilot-Longitudinal-Control-)
@@ -32,7 +32,7 @@ USE AT YOUR OWN RISK! Stock system safety features, like AEB and FCW, might be a
 
 ### 🚨 Enable Radar Tracks 🚨
 
-**(EXPERIMENTAL, as of October 3rd, 2021)**
+***(EXPERIMENTAL, as of October 3rd, 2021)***
 
 1. Ensure the car is at the `OFF` ignition position.
 2. Connect your compatible comma device (EON, C2, C3) to the car. comma device power should be ON.
@@ -53,7 +53,7 @@ USE AT YOUR OWN RISK! Stock system safety features, like AEB and FCW, might be a
 
 ### 🚨 Enable openpilot Longitudinal Control 🚨
 
-**(EXPERIMENTAL, as of October 3rd, 2021)**
+***(EXPERIMENTAL, as of October 3rd, 2021)***
 
 1. Connect your compatible comma device (EON, C2, C3) to the car. comma device power should be ON.
     * (Note: If doing this in the car, ensure the car is at the `OFF` ignition position.)

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -70,8 +70,5 @@ Directory Structure
         └── Toggles
             └── openpilot Longitudinal Control
 
-Licensing
-------
-
 5. Set the toggle `openpilot Longitudinal Control` to `ON`. Reboot the comma device to ensure the take the change in effect.
 6. Start the car and drive. If a chevron (triangle) appears behind a lead car, openpilot Longitudinal Control has been successfully enabled.

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -63,10 +63,10 @@ USE AT YOUR OWN RISK! Stock system safety features, like AEB and FCW, might be a
         2. C2 or EON: `reboot`
 4. Once your comma device has been rebooted, a new toggle should appear:
 ---
-        .
-        └── Settings
-            └── Toggles
-                └── openpilot Longitudinal Control
+            .
+            └── Settings
+                └── Toggles
+                    └── openpilot Longitudinal Control
    
 5. Set the toggle `openpilot Longitudinal Control` to `ON`. Reboot the comma device to ensure the take the change in effect.
 6. Start the car and drive. If a chevron (triangle) appears behind a lead car, openpilot Longitudinal Control has been successfully enabled.

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -89,8 +89,7 @@ to go back to the default values.
 
 ❗Note❗: Some Hyundai/Kia/Genesis car models may not see the chevron behind a lead car after enabling `openpilot Longitudinal Control`. This could cause by the affected car models being listed in the `LEGACY_SAFETY_MODE_CAR` blacklist in `selfdrive/car/hyundai/values.py` and openpilot Longitudinal Control may not have been tested/confirmed by comma or the community.
 * If you would like to test whether openpilot Longitudinal Control would work for your car model, ensure that your car model is removed from the blacklist in the following statement in `selfdrive/car/hyundai/values.py`:
-
-
-
+```
     ## As of January 9th, 2022 ##
     LEGACY_SAFETY_MODE_CAR = set([CAR.HYUNDAI_GENESIS, CAR.IONIQ_EV_2020, CAR.IONIQ_EV_LTD, CAR.IONIQ_PHEV, CAR.IONIQ, CAR.KONA_EV, CAR.KIA_SORENTO, CAR.SONATA_LF, CAR.KIA_NIRO_EV, CAR.KIA_OPTIMA, CAR.VELOSTER, CAR.KIA_STINGER, CAR.GENESIS_G70, CAR.GENESIS_G80, CAR.KIA_CEED, CAR.ELANTRA, CAR.IONIQ_HEV_2022])
+```

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -5,13 +5,12 @@ Table of Contents
 =======================
 
 * [Radar Tracks](#Radar-Tracks)
-    * [Enable Radar Tracks](#-Enable-Radar-Tracks-)
-* [Enable openpilot Longitudinal Control](#-Enable-openpilot-Longitudinal-Control-)
-* [Enable Mapbox Navigation](#-Enable-Mapbox-Navigation-)
+    * [Enable Radar Tracks](#-Enable-Radar-Tracks)
+* [Enable Mapbox Navigation](#-Enable-Mapbox-Navigation)
 
 ---
 
-## Radar Tracks
+<details><summary><h3>📡 Radar Tracks</h3></summary>
 
 Radar tracks can now be enabled manually on applicable cars through SSH thanks to [@greghogan](https://github.com/greghogan) and [@pd0wm](https://github.com/pd0wm).
 
@@ -29,7 +28,7 @@ to go back to the default values.
 **How radar points can be used along with vision:**
 * Current OP long policy is identify with vision first, if vision sees a vehicle match it to a radar point. If vision sees nothing you get a false negative and no lead car detection. (Source: [Hubblesphere#7894 from comma.ai community Discord](https://discord.com/channels/469524606043160576/872899198738104330/872913890793635872))
 
-### 🚨 Enable Radar Tracks 🚨
+### 🚨 Enable Radar Tracks
 
 ***(EXPERIMENTAL, as of January 1st, 2022)***
 
@@ -56,46 +55,10 @@ to go back to the default values.
 6. Go for a quick drive and drive behind a lead car with varied follow distance. Then, come back and allow the drive to upload its `rlogs` in [comma Connect](https://connect.comma.ai).
 7. With all `rlogs` uploaded, open the drive in Cabana from [comma Connect](https://connect.comma.ai). Load DBC -> `hyundai_kia_mando_front_radar.dbc`, then search `RADAR_TRACK_50x` (`x` could be anything), open any of them, and look at `LONG_DIST`.
 8. If the radar tracks data is relevant with the lead car you drove behind, you are done! Your car now have radar tracks enabled.
-
-### 🚨 Enable openpilot Longitudinal Control 🚨
-
-***(EXPERIMENTAL, as of January 9th, 2022)***
-
-*(Base on version 0.8.12 [`devel`](https://github.com/commaai/openpilot/tree/devel))*
-
-**USE AT YOUR OWN RISK!** Stock system safety features, like AEB and FCW, might be affected by these changes.
-
-1. Connect your compatible comma device (EON, C2, C3) to the car. comma device power should be ON.
-    * (Note: If doing this in the car, ensure the car is at the `OFF` ignition position.)
-2. Use a laptop or applicable device to connect to your comma device via SSH. (Tips: Instructions to SSH in [HERE](https://github.com/commaai/openpilot/wiki/SSH))
-3. In the SSH terminal after successfully connected to your comma device, execute the following commands:
-    1. ```echo -n "1" > /data/params/d/DisableRadar_Allow```
-        * Note: It will automatically create the file `DisableRadar_Allow` under `/data/params/d` after executing the command.
-    2. Reboot your comma device:
-        1. C3: `sudo reboot`
-        2. C2 or EON: `reboot`
-4. Once your comma device is rebooted, a new toggle should appear:
----
-            .
-            └── Settings
-                └── Toggles
-                    └── ***openpilot Longitudinal Control***
+</details>
    
-5. Set the toggle `openpilot Longitudinal Control` to `ON`. (Note: If this step is done while the car is at the `ON` ignition position, turn off the car to take the change in effect.)
-6. Start the car. Drive and check for the following:
-   1. Is there a chevron (triangle) appear behind a lead car?
-   2. Are you able to engage openpilot with no fault?
-   3. (Optional, PROCEED WITH EXTREME CAUTION AND BE READY TO MANUALLY TAKE OVER AT ALL TIMES) With the car engaged with openpilot and cruising at or below `35 MPH` or `56 KM/H` in good road conditions, is your car able to detect and slow down / stop behind a stopped car?
-7. If you answered `YES` to all the above questions in Step 6, you have successfully enabled openpilot Longitudinal Control.
-
-❗Note❗: Some Hyundai/Kia/Genesis car models may not see the chevron behind a lead car after enabling `openpilot Longitudinal Control`. This could cause by the affected car models being listed in the `LEGACY_SAFETY_MODE_CAR` blacklist in `selfdrive/car/hyundai/values.py` and openpilot Longitudinal Control may not have been tested/confirmed by comma or the community.
-* If you would like to test whether openpilot Longitudinal Control would work for your car model, ensure that your car model is removed from the blacklist in the following statement in `selfdrive/car/hyundai/values.py`:
-```
-    ## As of January 9th, 2022 ##
-    LEGACY_SAFETY_MODE_CAR = set([CAR.HYUNDAI_GENESIS, CAR.IONIQ_EV_2020, CAR.IONIQ_EV_LTD, CAR.IONIQ_PHEV, CAR.IONIQ, CAR.KONA_EV, CAR.KIA_SORENTO, CAR.SONATA_LF, CAR.KIA_NIRO_EV, CAR.KIA_OPTIMA, CAR.VELOSTER, CAR.KIA_STINGER, CAR.GENESIS_G70, CAR.GENESIS_G80, CAR.KIA_CEED, CAR.ELANTRA, CAR.IONIQ_HEV_2022])
-```
-
-### 🗺 Enable Mapbox Navigation 🗺
+<details><summary><h3>🗺 Enable Mapbox Navigation</h3></summary>
+   
 1) Create a free mapbox account. Account will ask for a credit card for verification. You will not be charged for the free tier.
 2) On the Dashboard, you will see a section called Access Tokens. Click `Create a Token`. Name it whatever you like. Set the scopes to allow everything for both Public and Secret. Copy both of these keys. **YOU WON'T BE ABLE TO ACCESS THE SECRET KEY AFTER THIS WINDOW.** 
 3) On your C3, go to `SP - Visuals` and toggle `Enable Mapbox Navigation*`. Accept the reboot.
@@ -112,3 +75,4 @@ to go back to the default values.
 **IMPORTANT NOTE:** Your C3 will require an active internet connection to download map data, generate driving directions, and ETA. Once map data and directions are downloaded, it *is* possible to use it offline, however nothing will update (such as new driving direction after a missed turn, updated ETA, map data further into your drive etc.)
 
 ***NAVIGATION NOTE:** At this time, mapbox does not support alphanumeric addresses (i.e W123N1234 Main St). There is currently no known workaround for this.*
+</details>

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -36,6 +36,8 @@ to go back to the default values.
 
 *(Base on version 0.8.10 [`master e98d1258114967999d9b3f5f1e46db98f76f78e6`](https://github.com/commaai/openpilot/tree/e98d1258114967999d9b3f5f1e46db98f76f78e6))*
 
+**USE AT YOUR OWN RISK!** Stock system safety features, like AEB and FCW, might be affected by these changes.
+
 1. Ensure the car is at the `OFF` ignition position.
 2. Connect your compatible comma device (EON, C2, C3) to the car. comma device power should be ON.
 3. Use a laptop or applicable device to connect to your comma device via SSH. (Tips: Instructions to SSH in [HERE](https://github.com/commaai/openpilot/wiki/SSH))
@@ -56,6 +58,8 @@ to go back to the default values.
 ***(EXPERIMENTAL, as of October 3rd, 2021)***
 
 *(Base on version 0.8.10 [`master e98d1258114967999d9b3f5f1e46db98f76f78e6`](https://github.com/commaai/openpilot/tree/e98d1258114967999d9b3f5f1e46db98f76f78e6))*
+
+**USE AT YOUR OWN RISK!** Stock system safety features, like AEB and FCW, might be affected by these changes.
 
 1. Connect your compatible comma device (EON, C2, C3) to the car. comma device power should be ON.
     * (Note: If doing this in the car, ensure the car is at the `OFF` ignition position.)

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -62,9 +62,7 @@ USE AT YOUR OWN RISK! Stock system safety features, like AEB and FCW, might be a
         1. C3: `sudo reboot`
         2. C2 or EON: `reboot`
 4. Once your comma device has been rebooted, a new toggle should appear:
-
-Directory Structure
-------
+---
     .
     └── Settings
         └── Toggles

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -1,4 +1,4 @@
-# Introduction
+# How Tos
 This page is a repository of useful how-tos as a supplement for additional information.
 
 Table of Contents

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -4,10 +4,13 @@ This page is a repository of useful how-tos as a supplement for additional infor
 Table of Contents
 =======================
 
-* [Enable Radar Tracks](#-Enable-Radar-Tracks-)
+* [Radar Tracks](#Radar-Tracks)
+    * [Enable Radar Tracks](#-Enable-Radar-Tracks-)
 * [Enable openpilot Longitudinal Control](#-Enable-openpilot-Longitudinal-Control-)
 
 ---
+
+## Radar Tracks
 
 Radar tracks can now be enabled manually on applicable cars through SSH thanks to [@greghogan](https://github.com/greghogan) and [@pd0wm](https://github.com/pd0wm).
 

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -34,6 +34,8 @@ USE AT YOUR OWN RISK! Stock system safety features, like AEB and FCW, might be a
 
 ***(EXPERIMENTAL, as of October 3rd, 2021)***
 
+*(Base on master on version 0.8.10 d546c109ef4854322bfaea12954ad854d593554c)*
+
 1. Ensure the car is at the `OFF` ignition position.
 2. Connect your compatible comma device (EON, C2, C3) to the car. comma device power should be ON.
 3. Use a laptop or applicable device to connect to your comma device via SSH. (Tips: Instructions to SSH in [HERE](https://github.com/commaai/openpilot/wiki/SSH))
@@ -52,6 +54,8 @@ USE AT YOUR OWN RISK! Stock system safety features, like AEB and FCW, might be a
 ### 🚨 Enable openpilot Longitudinal Control 🚨
 
 ***(EXPERIMENTAL, as of October 3rd, 2021)***
+
+*(Base on master on version 0.8.10 d546c109ef4854322bfaea12954ad854d593554c)*
 
 1. Connect your compatible comma device (EON, C2, C3) to the car. comma device power should be ON.
     * (Note: If doing this in the car, ensure the car is at the `OFF` ignition position.)

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -62,6 +62,7 @@ USE AT YOUR OWN RISK! Stock system safety features, like AEB and FCW, might be a
         1. C3: `sudo reboot`
         2. C2 or EON: `reboot`
 4. Once your comma device has been rebooted, a new toggle should appear:
+
     .
     └── Settings
         └── Toggles

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -6,7 +6,7 @@ Table of Contents
 
 * [Enable Radar Tracks and openpilot Longitudinal Control](#Enable-Radar-Tracks-and-openpilot-Longitudinal-Control)
 
-##Enable Radar Tracks and openpilot Longitudinal Control
+## Enable Radar Tracks and openpilot Longitudinal Control
 (Last updated date: October 3rd, 2021. Base on `master` on 0.8.10 `d546c109ef4854322bfaea12954ad854d593554c`)
 
 * [Enable Radar Tracks](#Enable-Radar_Tracks)

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -72,3 +72,8 @@ to go back to the default values.
    
 5. Set the toggle `openpilot Longitudinal Control` to `ON`. Reboot the comma device to ensure to take the change in effect.
 6. Start the car and drive. If a chevron (triangle) appears behind a lead car, you have successfully enabled openpilot Longitudinal Control.
+
+Note: Some Hyundai/Kia/Genesis cars may not see the chevron behind a lead car after enabling `openpilot Longitudinal Control`. Ensure that your car model is listed in the following statement in `selfdrive/car/hyundai/interface.py`:
+
+    ## As of October 3rd, 2021 ##
+    ret.openpilotLongitudinalControl = Params().get_bool("DisableRadar") and candidate in [CAR.SONATA, CAR.SONATA_HYBRID, CAR.PALISADE, CAR.SANTA_FE]

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -45,9 +45,9 @@ to go back to the default values.
     1. `pkill -f openpilot`
     2. `python /data/openpilot/selfdrive/debug/hyundai_enable_radar_points.py`
     3. Follow the instructions in the script:
-        1. `Power on the vehicle keeping the engine off (press start button twice) then type OK to continue`.
-        2a. If successful, the following message should appear: `[DONE]. Restart your vehicle and ensure there are no faults`.
-        2b. If the script did not run successfully, reach out to the community in [Sunnyhaibin's Openpilot Discord Server](https://discord.gg/wRW3meAgtx) or `#hyundai-kia-genesis channel` on [commaai community Discord Server](https://discord.comma.ai) for assistance.
+       * `Power on the vehicle keeping the engine off (press start button twice) then type OK to continue`.
+           * If successful, the following message should appear: `[DONE]. Restart your vehicle and ensure there are no faults`.
+           * If the script did not run successfully, reach out to the community in [Sunnyhaibin's Openpilot Discord Server](https://discord.gg/wRW3meAgtx) or `#hyundai-kia-genesis channel` on [commaai community Discord Server](https://discord.comma.ai) for assistance.
     4. Reboot your comma device:
         1. C3: `sudo reboot`
         2. C2 or EON: `reboot`

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -9,8 +9,8 @@ Table of Contents
 ## Enable Radar Tracks and openpilot Longitudinal Control
 (Last updated date: October 3rd, 2021. Base on `master` on 0.8.10 `d546c109ef4854322bfaea12954ad854d593554c`)
 
-* [Enable Radar Tracks](#Enable-Radar_Tracks)
-* [Enable openpilot Longitudinal Control](#Enable-openpilot-Longitudinal-Control)
+* [Enable Radar Tracks](#-Enable-Radar_Tracks-)
+* [Enable openpilot Longitudinal Control](#-Enable-openpilot-Longitudinal-Control-)
 
 Radar tracks can now be enabled manually on applicable cars through SSH thanks to [@greghogan](https://github.com/greghogan) and [@pd0wm](https://github.com/pd0wm).
 
@@ -25,7 +25,7 @@ to go back to the default values.
 
 USE AT YOUR OWN RISK! Stock system safety features, like AEB and FCW, might be affected by these changes.
 
-### Enable Radar Tracks
+### 🚨 Enable Radar Tracks 🚨
 
 1. Ensure the car is at the `OFF` ignition position.
 2. Connect your compatible comma device (EON, C2, C3) to the car. comma device power should be ON.
@@ -44,7 +44,7 @@ USE AT YOUR OWN RISK! Stock system safety features, like AEB and FCW, might be a
 5. Once your comma device has been rebooted, start your car with engine on (with or without comma device connected). Ensure that there are no faults from the car.
 6. If there is no fault, you are done! You have successfully enabled radar tracks on your car's radar.
 
-### Enable openpilot Longitudinal Control
+### 🚨 Enable openpilot Longitudinal Control 🚨
 
 1. Connect your compatible comma device (EON, C2, C3) to the car. comma device power should be ON.
     * (Note: If doing this in the car, ensure the car is at the `OFF` ignition position.)

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -29,6 +29,8 @@ to go back to the default values.
 
 ***(EXPERIMENTAL, as of October 3rd, 2021)***
 
+***(Only applicable to some Hyundai and Kia cars, as of October 3rd, 2021)***
+
 *(Base on version 0.8.10 [`master e98d1258114967999d9b3f5f1e46db98f76f78e6`](https://github.com/commaai/openpilot/tree/e98d1258114967999d9b3f5f1e46db98f76f78e6))*
 
 1. Ensure the car is at the `OFF` ignition position.

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -42,7 +42,7 @@ to go back to the default values.
 2. Connect your compatible comma device (EON, C2, C3) to the car. comma device power should be ON.
 3. Use a laptop or applicable device to connect to your comma device via SSH. (Tips: Instructions to SSH in [HERE](https://github.com/commaai/openpilot/wiki/SSH))
 4. In the SSH terminal after successfully connected to your comma device, execute the following commands:
-    1. ```killall boardd```
+    1. `pkill -f openpilot`
     2. `python /data/openpilot/selfdrive/debug/hyundai_enable_radar_points.py`
     3. Follow the instructions in the script:
         1. `Power on the vehicle keeping the engine off (press start button twice) then type OK to continue`.

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -6,6 +6,8 @@ Table of Contents
 
 * [Enable Radar Tracks and openpilot Longitudinal Control](#Enable-Radar-Tracks-and-openpilot-Longitudinal-Control)
 
+---
+
 ## Enable Radar Tracks and openpilot Longitudinal Control
 (Last updated date: October 3rd, 2021. Base on `master` on 0.8.10 `d546c109ef4854322bfaea12954ad854d593554c`)
 

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -4,10 +4,13 @@ This page is a repository of useful how-tos as a supplement for additional infor
 Table of Contents
 =======================
 
-* Enable Radar Tracks
+* [Enable Radar Tracks and openpilot Longitudinal Control](#Enable-Radar-Tracks-and-openpilot-Longitudinal-Control)
 
-##Enable Radar Tracks
-(Last updated date: October 3rd, 2021)
+##Enable Radar Tracks and openpilot Longitudinal Control
+(Last updated date: October 3rd, 2021. Base on `master` on 0.8.10 `d546c109ef4854322bfaea12954ad854d593554c`)
+
+* [Enable Radar Tracks](#Enable-Radar_Tracks)
+* [Enable openpilot Longitudinal Control](#Enable-openpilot-Longitudinal-Control)
 
 Radar tracks can now be enabled manually on applicable cars through SSH thanks to [@greghogan](https://github.com/greghogan) and [@pd0wm](https://github.com/pd0wm).
 
@@ -22,10 +25,41 @@ to go back to the default values.
 
 USE AT YOUR OWN RISK! Stock system safety features, like AEB and FCW, might be affected by these changes.
 
-To enable radar tracks:
-(Instructions are base on `master` on 0.8.10 `d546c109ef4854322bfaea12954ad854d593554c`)
+###Enable Radar Tracks
+
 1. Ensure the car is at the `OFF` ignition position.
-2. Connect your compatible comma device (EON, C2, C3) to the car. Power should be on.
+2. Connect your compatible comma device (EON, C2, C3) to the car. comma device power should be ON.
 3. Use a laptop or applicable device to connect to your comma device via SSH. (Tips: Instructions to SSH in [HERE](https://github.com/commaai/openpilot/wiki/SSH))
 4. In the SSH terminal after successfully connected to your comma device, execute the following commands:
-    i. ```killall boardd```
+    1. ```killall boardd```
+    2. `python /data/openpilot/selfdrive/debug/hyundai_enable_radar_points.py`
+    3. Follow the instructions in the script:
+       ```
+        1. `Power on the vehicle keeping the engine off (press start button twice) then type OK to continue`.
+        2. If successful, the following message should appear: `[DONE]. Restart your vehicle and ensure there are no faults.
+       ```
+    4. Reboot your comma device:
+        1. C3: `sudo reboot`
+        2. C2 or EON: `reboot`
+5. Once your comma device has been rebooted, start your car with engine on (with or without comma device connected). Ensure that there are no faults from the car.
+6. If there is no fault, you are done! You have successfully enabled radar tracks on your car's radar.
+
+###Enable openpilot Longitudinal Control
+
+1. Connect your compatible comma device (EON, C2, C3) to the car. comma device power should be ON.
+    * (Note: If doing this in the car, ensure the car is at the `OFF` ignition position.)
+2. Use a laptop or applicable device to connect to your comma device via SSH. (Tips: Instructions to SSH in [HERE](https://github.com/commaai/openpilot/wiki/SSH))
+3. In the SSH terminal after successfully connected to your comma device, execute the following commands:
+    1. ```echo -n "1" > /data/params/d/DisableRadar_Allow```
+    2. Reboot your comma device:
+        1. C3: `sudo reboot`
+        2. C2 or EON: `reboot`
+4. Once your comma device has been rebooted, a new toggle should appear:
+
+
+    .
+    └── Settings
+        └── Toggles
+            └── ***openpilot Longitudinal Control***
+5. Set the toggle `openpilot Longitudinal Control` to `ON`. Reboot the comma device to ensure the take the change in effect.
+6. Start the car and drive. If a chevron (triangle) appears behind a lead car, openpilot Longitudinal Control has been successfully enabled.

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -54,7 +54,7 @@ to go back to the default values.
 5. Once your comma device has been rebooted, start your car with engine on (with or without comma device connected). Ensure that there are no faults from the car. If there are faults, reach out to the community in [Sunnyhaibin's Openpilot Discord Server](https://discord.gg/wRW3meAgtx) or `#hyundai-kia-genesis channel` on [commaai community Discord Server](https://discord.comma.ai) for assistance.
 6. Go for a quick drive and drive behind a lead car with varied follow distance. Then, come back and allow the drive to upload its `rlogs` in [comma Connect](https://connect.comma.ai).
 7. With all `rlogs` uploaded, open the drive in Cabana from [comma Connect](https://connect.comma.ai). Load DBC -> `hyundai_kia_mando_front_radar.dbc`, then search `RADAR_TRACK_50x` (`x` could be anything), open any of them, and look at `LONG_DIST`.
-8. If the radar tracks data is relevant with the lead car you drove behind, you are done! Your car now had radar tracks enabled.
+8. If the radar tracks data is relevant with the lead car you drove behind, you are done! Your car now have radar tracks enabled.
 
 ### 🚨 Enable openpilot Longitudinal Control 🚨
 

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -9,7 +9,9 @@ Table of Contents
 ---
 
 ## Enable Radar Tracks and openpilot Longitudinal Control
-(Last updated date: October 3rd, 2021. Base on `master` on version 0.8.10 `d546c109ef4854322bfaea12954ad854d593554c`)
+
+(Last updated date: October 3rd, 2021.)
+(Base on `master` on version 0.8.10 `d546c109ef4854322bfaea12954ad854d593554c`)
 
 * [Enable Radar Tracks](#-Enable-Radar_Tracks-)
 * [Enable openpilot Longitudinal Control](#-Enable-openpilot-Longitudinal-Control-)
@@ -29,6 +31,8 @@ USE AT YOUR OWN RISK! Stock system safety features, like AEB and FCW, might be a
 
 ### 🚨 Enable Radar Tracks 🚨
 
+**(EXPERIMENTAL, as of October 3rd, 2021)**
+
 1. Ensure the car is at the `OFF` ignition position.
 2. Connect your compatible comma device (EON, C2, C3) to the car. comma device power should be ON.
 3. Use a laptop or applicable device to connect to your comma device via SSH. (Tips: Instructions to SSH in [HERE](https://github.com/commaai/openpilot/wiki/SSH))
@@ -47,6 +51,8 @@ USE AT YOUR OWN RISK! Stock system safety features, like AEB and FCW, might be a
 6. If there is no fault, you are done! You have successfully enabled radar tracks on your car's radar.
 
 ### 🚨 Enable openpilot Longitudinal Control 🚨
+
+**(EXPERIMENTAL, as of October 3rd, 2021)**
 
 1. Connect your compatible comma device (EON, C2, C3) to the car. comma device power should be ON.
     * (Note: If doing this in the car, ensure the car is at the `OFF` ignition position.)

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -12,7 +12,7 @@ Table of Contents
 
 *(Last updated date: October 3rd, 2021)*
 
-*(Base on `master` on version 0.8.10 `d546c109ef4854322bfaea12954ad854d593554c`)*
+*(Base on version 0.8.10 [`master e98d1258114967999d9b3f5f1e46db98f76f78e6`](https://github.com/commaai/openpilot/tree/e98d1258114967999d9b3f5f1e46db98f76f78e6))*
 
 * [Enable Radar Tracks](#-Enable-Radar-Tracks-)
 * [Enable openpilot Longitudinal Control](#-Enable-openpilot-Longitudinal-Control-)
@@ -34,7 +34,7 @@ USE AT YOUR OWN RISK! Stock system safety features, like AEB and FCW, might be a
 
 ***(EXPERIMENTAL, as of October 3rd, 2021)***
 
-*(Base on master on version 0.8.10 d546c109ef4854322bfaea12954ad854d593554c)*
+*(Base on version 0.8.10 [`master e98d1258114967999d9b3f5f1e46db98f76f78e6`](https://github.com/commaai/openpilot/tree/e98d1258114967999d9b3f5f1e46db98f76f78e6))*
 
 1. Ensure the car is at the `OFF` ignition position.
 2. Connect your compatible comma device (EON, C2, C3) to the car. comma device power should be ON.
@@ -55,7 +55,7 @@ USE AT YOUR OWN RISK! Stock system safety features, like AEB and FCW, might be a
 
 ***(EXPERIMENTAL, as of October 3rd, 2021)***
 
-*(Base on master on version 0.8.10 d546c109ef4854322bfaea12954ad854d593554c)*
+*(Base on version 0.8.10 [`master e98d1258114967999d9b3f5f1e46db98f76f78e6`](https://github.com/commaai/openpilot/tree/e98d1258114967999d9b3f5f1e46db98f76f78e6))*
 
 1. Connect your compatible comma device (EON, C2, C3) to the car. comma device power should be ON.
     * (Note: If doing this in the car, ensure the car is at the `OFF` ignition position.)

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -47,7 +47,7 @@ USE AT YOUR OWN RISK! Stock system safety features, like AEB and FCW, might be a
         1. C3: `sudo reboot`
         2. C2 or EON: `reboot`
 5. Once your comma device has been rebooted, start your car with engine on (with or without comma device connected). Ensure that there are no faults from the car.
-6. If there is no fault, you are done! You have successfully enabled radar tracks on your car's radar.
+6. If there are no faults, you are done! You have successfully enabled radar tracks on your car's radar.
 
 ### 🚨 Enable openpilot Longitudinal Control 🚨
 

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -66,7 +66,7 @@ USE AT YOUR OWN RISK! Stock system safety features, like AEB and FCW, might be a
             .
             └── Settings
                 └── Toggles
-                    └── openpilot Longitudinal Control
+                    └── ***openpilot Longitudinal Control***
    
 5. Set the toggle `openpilot Longitudinal Control` to `ON`. Reboot the comma device to ensure the take the change in effect.
 6. Start the car and drive. If a chevron (triangle) appears behind a lead car, openpilot Longitudinal Control has been successfully enabled.

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -80,7 +80,7 @@ to go back to the default values.
                 └── Toggles
                     └── ***openpilot Longitudinal Control***
    
-5. Set the toggle `openpilot Longitudinal Control` to `ON`. (Note: If this step is done while the car is at the `ON` ignition position, turn of the car to take the change in effect.)
+5. Set the toggle `openpilot Longitudinal Control` to `ON`. (Note: If this step is done while the car is at the `ON` ignition position, turn off the car to take the change in effect.)
 6. Start the car. Drive and check for the following:
    1. Is there a chevron (triangle) appear behind a lead car?
    2. Are you able to engage openpilot with no fault?

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -88,8 +88,8 @@ to go back to the default values.
 7. If you answered `YES` to all the above questions in Step 6, you have successfully enabled openpilot Longitudinal Control.
 
 ❗Note❗: Some Hyundai/Kia/Genesis car models may not see the chevron behind a lead car after enabling `openpilot Longitudinal Control`. This could cause by the affected car models being listed in the `LEGACY_SAFETY_MODE_CAR` blacklist in `selfdrive/car/hyundai/values.py` and openpilot Longitudinal Control may not have been tested/confirmed by comma or the community.
+* If you would like to test whether openpilot Longitudinal Control would work for your car model, ensure that your car model is removed from the blacklist in the following statement in `selfdrive/car/hyundai/values.py`:
 
-If you would like to test whether openpilot Longitudinal Control would work for your car model, ensure that your car model is removed from the blacklist in the following statement in `selfdrive/car/hyundai/values.py`:
 
     ## As of January 9th, 2022 ##
     LEGACY_SAFETY_MODE_CAR = set([CAR.HYUNDAI_GENESIS, CAR.IONIQ_EV_2020, CAR.IONIQ_EV_LTD, CAR.IONIQ_PHEV, CAR.IONIQ, CAR.KONA_EV, CAR.KIA_SORENTO, CAR.SONATA_LF, CAR.KIA_NIRO_EV, CAR.KIA_OPTIMA, CAR.VELOSTER, CAR.KIA_STINGER, CAR.GENESIS_G70, CAR.GENESIS_G80, CAR.KIA_CEED, CAR.ELANTRA, CAR.IONIQ_HEV_2022])

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -63,10 +63,10 @@ USE AT YOUR OWN RISK! Stock system safety features, like AEB and FCW, might be a
         2. C2 or EON: `reboot`
 4. Once your comma device has been rebooted, a new toggle should appear:
 ---
-    .
-    └── Settings
-        └── Toggles
-            └── openpilot Longitudinal Control
-
+        .
+        └── Settings
+            └── Toggles
+                └── openpilot Longitudinal Control
+   
 5. Set the toggle `openpilot Longitudinal Control` to `ON`. Reboot the comma device to ensure the take the change in effect.
 6. Start the car and drive. If a chevron (triangle) appears behind a lead car, openpilot Longitudinal Control has been successfully enabled.

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -1,0 +1,31 @@
+#Introduction
+This page is a repository of useful how-tos as a supplement for additional information.
+
+Table of Contents
+=======================
+
+* Enable Radar Tracks
+
+##Enable Radar Tracks
+(Last updated date: October 3rd, 2021)
+
+Radar tracks can now be enabled manually on applicable cars through SSH thanks to [@greghogan](https://github.com/greghogan) and [@pd0wm](https://github.com/pd0wm).
+
+Some Hyundai radars can be reconfigured to output (debug) radar points on bus 1.
+Reconfiguration is done over UDS by reading/writing to 0x0142 using the Read/Write Data By Identifier
+endpoints (0x22 & 0x2E). This script checks your radar firmware version against a list of known
+firmware versions. If you want to try on a new radar, make sure to note the default config value
+in case it is different from the other radars and you need to revert the changes.
+After changing the config the car should not show any faults when openpilot is not running.
+These config changes are persistent across car reboots. You need to run this script again
+to go back to the default values.
+
+USE AT YOUR OWN RISK! Stock system safety features, like AEB and FCW, might be affected by these changes.
+
+To enable radar tracks:
+(Instructions are base on `master` on 0.8.10 `d546c109ef4854322bfaea12954ad854d593554c`)
+1. Ensure the car is at the `OFF` ignition position.
+2. Connect your compatible comma device (EON, C2, C3) to the car. Power should be on.
+3. Use a laptop or applicable device to connect to your comma device via SSH. (Tips: Instructions to SSH in [HERE](https://github.com/commaai/openpilot/wiki/SSH))
+4. In the SSH terminal after successfully connected to your comma device, execute the following commands:
+    i. ```killall boardd```

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -41,10 +41,8 @@ USE AT YOUR OWN RISK! Stock system safety features, like AEB and FCW, might be a
     1. ```killall boardd```
     2. `python /data/openpilot/selfdrive/debug/hyundai_enable_radar_points.py`
     3. Follow the instructions in the script:
-       ```
         1. `Power on the vehicle keeping the engine off (press start button twice) then type OK to continue`.
-        2. If successful, the following message should appear: `[DONE]. Restart your vehicle and ensure there are no faults.
-       ```
+        2. If successful, the following message should appear: `[DONE]. Restart your vehicle and ensure there are no faults`.
     4. Reboot your comma device:
         1. C3: `sudo reboot`
         2. C2 or EON: `reboot`

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -10,7 +10,8 @@ Table of Contents
 
 ## Enable Radar Tracks and openpilot Longitudinal Control
 
-(Last updated date: October 3rd, 2021.)
+(Last updated date: October 3rd, 2021)
+
 (Base on `master` on version 0.8.10 `d546c109ef4854322bfaea12954ad854d593554c`)
 
 * [Enable Radar Tracks](#-Enable-Radar_Tracks-)

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -10,12 +10,10 @@ Table of Contents
 
 ## Enable Radar Tracks and openpilot Longitudinal Control
 
-*(Last updated date: October 3rd, 2021)*
-
-*(Base on version 0.8.10 [`master e98d1258114967999d9b3f5f1e46db98f76f78e6`](https://github.com/commaai/openpilot/tree/e98d1258114967999d9b3f5f1e46db98f76f78e6))*
-
 * [Enable Radar Tracks](#-Enable-Radar-Tracks-)
 * [Enable openpilot Longitudinal Control](#-Enable-openpilot-Longitudinal-Control-)
+
+
 
 Radar tracks can now be enabled manually on applicable cars through SSH thanks to [@greghogan](https://github.com/greghogan) and [@pd0wm](https://github.com/pd0wm).
 

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -68,5 +68,5 @@ USE AT YOUR OWN RISK! Stock system safety features, like AEB and FCW, might be a
                 └── Toggles
                     └── ***openpilot Longitudinal Control***
    
-5. Set the toggle `openpilot Longitudinal Control` to `ON`. Reboot the comma device to ensure the take the change in effect.
+5. Set the toggle `openpilot Longitudinal Control` to `ON`. Reboot the comma device to ensure to take the change in effect.
 6. Start the car and drive. If a chevron (triangle) appears behind a lead car, openpilot Longitudinal Control has been successfully enabled.

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -68,4 +68,4 @@ to go back to the default values.
                     └── ***openpilot Longitudinal Control***
    
 5. Set the toggle `openpilot Longitudinal Control` to `ON`. Reboot the comma device to ensure to take the change in effect.
-6. Start the car and drive. If a chevron (triangle) appears behind a lead car, openpilot Longitudinal Control has been successfully enabled.
+6. Start the car and drive. If a chevron (triangle) appears behind a lead car, you have successfully enabled openpilot Longitudinal Control.

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -25,6 +25,9 @@ to go back to the default values.
 
 **USE AT YOUR OWN RISK!** Stock system safety features, like AEB and FCW, might be affected by these changes.
 
+**How radar points can be used along with vision:**
+* Current OP long policy is identify with vision first, if vision sees a vehicle match it to a radar point. If vision sees nothing you get a false negative and no lead car detection. It's been this way for a long time now. (Source: [Hubblesphere#7894 from comma.ai community Discord](https://discord.com/channels/469524606043160576/872899198738104330/872913890793635872))
+
 ### 🚨 Enable Radar Tracks 🚨
 
 ***(EXPERIMENTAL, as of October 3rd, 2021)***

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -68,5 +68,6 @@ USE AT YOUR OWN RISK! Stock system safety features, like AEB and FCW, might be a
     └── Settings
         └── Toggles
             └── ***openpilot Longitudinal Control***
+
 5. Set the toggle `openpilot Longitudinal Control` to `ON`. Reboot the comma device to ensure the take the change in effect.
 6. Start the car and drive. If a chevron (triangle) appears behind a lead car, openpilot Longitudinal Control has been successfully enabled.

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -1,4 +1,4 @@
-#Introduction
+# Introduction
 This page is a repository of useful how-tos as a supplement for additional information.
 
 Table of Contents
@@ -25,7 +25,7 @@ to go back to the default values.
 
 USE AT YOUR OWN RISK! Stock system safety features, like AEB and FCW, might be affected by these changes.
 
-###Enable Radar Tracks
+### Enable Radar Tracks
 
 1. Ensure the car is at the `OFF` ignition position.
 2. Connect your compatible comma device (EON, C2, C3) to the car. comma device power should be ON.
@@ -44,7 +44,7 @@ USE AT YOUR OWN RISK! Stock system safety features, like AEB and FCW, might be a
 5. Once your comma device has been rebooted, start your car with engine on (with or without comma device connected). Ensure that there are no faults from the car.
 6. If there is no fault, you are done! You have successfully enabled radar tracks on your car's radar.
 
-###Enable openpilot Longitudinal Control
+### Enable openpilot Longitudinal Control
 
 1. Connect your compatible comma device (EON, C2, C3) to the car. comma device power should be ON.
     * (Note: If doing this in the car, ensure the car is at the `OFF` ignition position.)

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -91,5 +91,6 @@ to go back to the default values.
 * If you would like to test whether openpilot Longitudinal Control would work for your car model, ensure that your car model is removed from the blacklist in the following statement in `selfdrive/car/hyundai/values.py`:
 
 
+
     ## As of January 9th, 2022 ##
     LEGACY_SAFETY_MODE_CAR = set([CAR.HYUNDAI_GENESIS, CAR.IONIQ_EV_2020, CAR.IONIQ_EV_LTD, CAR.IONIQ_PHEV, CAR.IONIQ, CAR.KONA_EV, CAR.KIA_SORENTO, CAR.SONATA_LF, CAR.KIA_NIRO_EV, CAR.KIA_OPTIMA, CAR.VELOSTER, CAR.KIA_STINGER, CAR.GENESIS_G70, CAR.GENESIS_G80, CAR.KIA_CEED, CAR.ELANTRA, CAR.IONIQ_HEV_2022])

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -9,7 +9,7 @@ Table of Contents
 ---
 
 ## Enable Radar Tracks and openpilot Longitudinal Control
-(Last updated date: October 3rd, 2021. Base on `master` on 0.8.10 `d546c109ef4854322bfaea12954ad854d593554c`)
+(Last updated date: October 3rd, 2021. Base on `master` on version 0.8.10 `d546c109ef4854322bfaea12954ad854d593554c`)
 
 * [Enable Radar Tracks](#-Enable-Radar_Tracks-)
 * [Enable openpilot Longitudinal Control](#-Enable-openpilot-Longitudinal-Control-)

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -63,10 +63,15 @@ USE AT YOUR OWN RISK! Stock system safety features, like AEB and FCW, might be a
         2. C2 or EON: `reboot`
 4. Once your comma device has been rebooted, a new toggle should appear:
 
+Directory Structure
+------
     .
     └── Settings
         └── Toggles
             └── openpilot Longitudinal Control
+
+Licensing
+------
 
 5. Set the toggle `openpilot Longitudinal Control` to `ON`. Reboot the comma device to ensure the take the change in effect.
 6. Start the car and drive. If a chevron (triangle) appears behind a lead car, openpilot Longitudinal Control has been successfully enabled.

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -57,6 +57,7 @@ to go back to the default values.
 2. Use a laptop or applicable device to connect to your comma device via SSH. (Tips: Instructions to SSH in [HERE](https://github.com/commaai/openpilot/wiki/SSH))
 3. In the SSH terminal after successfully connected to your comma device, execute the following commands:
     1. ```echo -n "1" > /data/params/d/DisableRadar_Allow```
+        * Note: It will automatically create the file `DisableRadar_Allow` under `/data/params/d` after executing the command.
     2. Reboot your comma device:
         1. C3: `sudo reboot`
         2. C2 or EON: `reboot`

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -14,7 +14,7 @@ Table of Contents
 
 *(Base on `master` on version 0.8.10 `d546c109ef4854322bfaea12954ad854d593554c`)*
 
-* [Enable Radar Tracks](#-Enable-Radar_Tracks-)
+* [Enable Radar Tracks](#-Enable-Radar-Tracks-)
 * [Enable openpilot Longitudinal Control](#-Enable-openpilot-Longitudinal-Control-)
 
 Radar tracks can now be enabled manually on applicable cars through SSH thanks to [@greghogan](https://github.com/greghogan) and [@pd0wm](https://github.com/pd0wm).

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -4,16 +4,10 @@ This page is a repository of useful how-tos as a supplement for additional infor
 Table of Contents
 =======================
 
-* [Enable Radar Tracks and openpilot Longitudinal Control](#Enable-Radar-Tracks-and-openpilot-Longitudinal-Control)
-
----
-
-## Enable Radar Tracks and openpilot Longitudinal Control
-
 * [Enable Radar Tracks](#-Enable-Radar-Tracks-)
 * [Enable openpilot Longitudinal Control](#-Enable-openpilot-Longitudinal-Control-)
 
-
+---
 
 Radar tracks can now be enabled manually on applicable cars through SSH thanks to [@greghogan](https://github.com/greghogan) and [@pd0wm](https://github.com/pd0wm).
 

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -26,7 +26,7 @@ to go back to the default values.
 **USE AT YOUR OWN RISK!** Stock system safety features, like AEB and FCW, might be affected by these changes.
 
 **How radar points can be used along with vision:**
-* Current OP long policy is identify with vision first, if vision sees a vehicle match it to a radar point. If vision sees nothing you get a false negative and no lead car detection. It's been this way for a long time now. (Source: [Hubblesphere#7894 from comma.ai community Discord](https://discord.com/channels/469524606043160576/872899198738104330/872913890793635872))
+* Current OP long policy is identify with vision first, if vision sees a vehicle match it to a radar point. If vision sees nothing you get a false negative and no lead car detection. (Source: [Hubblesphere#7894 from comma.ai community Discord](https://discord.com/channels/469524606043160576/872899198738104330/872913890793635872))
 
 ### 🚨 Enable Radar Tracks 🚨
 

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -30,11 +30,11 @@ to go back to the default values.
 
 ### 🚨 Enable Radar Tracks 🚨
 
-***(EXPERIMENTAL, as of October 3rd, 2021)***
+***(EXPERIMENTAL, as of January 1st, 2022)***
 
-***(Only applicable to some Hyundai and Kia cars, as of October 3rd, 2021)***
+***(Only applicable to some Hyundai, Kia, and Genesis cars, as of January 1st, 2022)***
 
-*(Base on version 0.8.10 [`master e98d1258114967999d9b3f5f1e46db98f76f78e6`](https://github.com/commaai/openpilot/tree/e98d1258114967999d9b3f5f1e46db98f76f78e6))*
+*(Base on version 0.8.12 [`devel`](https://github.com/commaai/openpilot/tree/devel))*
 
 **USE AT YOUR OWN RISK!** Stock system safety features, like AEB and FCW, might be affected by these changes.
 
@@ -46,12 +46,17 @@ to go back to the default values.
     2. `python /data/openpilot/selfdrive/debug/hyundai_enable_radar_points.py`
     3. Follow the instructions in the script:
         1. `Power on the vehicle keeping the engine off (press start button twice) then type OK to continue`.
-        2. If successful, the following message should appear: `[DONE]. Restart your vehicle and ensure there are no faults`.
+        2a. If successful, the following message should appear: `[DONE]. Restart your vehicle and ensure there are no faults`.
+        2b. If the script did not run successfully, reach out to the community in [Sunnyhaibin's Openpilot Discord Server](https://discord.gg/wRW3meAgtx) or `#hyundai-kia-genesis channel` on [commaai community Discord Server](https://discord.comma.ai) for assistance.
     4. Reboot your comma device:
         1. C3: `sudo reboot`
         2. C2 or EON: `reboot`
 5. Once your comma device has been rebooted, start your car with engine on (with or without comma device connected). Ensure that there are no faults from the car.
-6. If there are no faults, you are done! You have successfully enabled radar tracks on your car's radar.
+6a. If the car has no faults: Go to Step 7
+6b. If the car has faults: 
+7. Go for a quick drive and drive behind a lead car with varied follow distance. Then, come back and allow the drive to upload its `rlogs` in [comma Connect](https://connect.comma.ai).
+8. With all `rlogs` uploaded, open the drive in Cabana from [comma Connect](https://connect.comma.ai). Load DBC -> `hyundai_kia_mando_front_radar.dbc`, then search `RADAR_TRACK_50x` (`x` could be anything), open any of them, and look at `LONG_DIST`.
+9. If the radar tracks data is relevant with the lead car you drove behind, you are done! Your car now had radar tracks enabled.
 
 ### 🚨 Enable openpilot Longitudinal Control 🚨
 

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -51,16 +51,16 @@ to go back to the default values.
     4. Reboot your comma device:
         1. C3: `sudo reboot`
         2. C2 or EON: `reboot`
-5. Once your comma device has been rebooted, start your car with engine on (with or without comma device connected). Ensure that there are no faults from the car. If there are faults, reach out to the community in [Sunnyhaibin's Openpilot Discord Server](https://discord.gg/wRW3meAgtx) or `#hyundai-kia-genesis channel` on [commaai community Discord Server](https://discord.comma.ai) for assistance.
+5. Once your comma device is rebooted, start your car with engine on (with or without comma device connected). Ensure that there are no faults from the car. If there are faults, reach out to the community in [Sunnyhaibin's Openpilot Discord Server](https://discord.gg/wRW3meAgtx) or `#hyundai-kia-genesis channel` on [commaai community Discord Server](https://discord.comma.ai) for assistance.
 6. Go for a quick drive and drive behind a lead car with varied follow distance. Then, come back and allow the drive to upload its `rlogs` in [comma Connect](https://connect.comma.ai).
 7. With all `rlogs` uploaded, open the drive in Cabana from [comma Connect](https://connect.comma.ai). Load DBC -> `hyundai_kia_mando_front_radar.dbc`, then search `RADAR_TRACK_50x` (`x` could be anything), open any of them, and look at `LONG_DIST`.
 8. If the radar tracks data is relevant with the lead car you drove behind, you are done! Your car now have radar tracks enabled.
 
 ### 🚨 Enable openpilot Longitudinal Control 🚨
 
-***(EXPERIMENTAL, as of October 3rd, 2021)***
+***(EXPERIMENTAL, as of January 9th, 2022)***
 
-*(Base on version 0.8.10 [`master e98d1258114967999d9b3f5f1e46db98f76f78e6`](https://github.com/commaai/openpilot/tree/e98d1258114967999d9b3f5f1e46db98f76f78e6))*
+*(Base on version 0.8.12 [`devel`](https://github.com/commaai/openpilot/tree/devel))*
 
 **USE AT YOUR OWN RISK!** Stock system safety features, like AEB and FCW, might be affected by these changes.
 
@@ -73,17 +73,23 @@ to go back to the default values.
     2. Reboot your comma device:
         1. C3: `sudo reboot`
         2. C2 or EON: `reboot`
-4. Once your comma device has been rebooted, a new toggle should appear:
+4. Once your comma device is rebooted, a new toggle should appear:
 ---
             .
             └── Settings
                 └── Toggles
                     └── ***openpilot Longitudinal Control***
    
-5. Set the toggle `openpilot Longitudinal Control` to `ON`. Reboot the comma device to ensure to take the change in effect.
-6. Start the car and drive. If a chevron (triangle) appears behind a lead car, you have successfully enabled openpilot Longitudinal Control.
+5. Set the toggle `openpilot Longitudinal Control` to `ON`. (Note: If this step is done while the car is at the `ON` ignition position, turn of the car to take the change in effect.)
+6. Start the car. Drive and check for the following:
+   1. Is there a chevron (triangle) appear behind a lead car?
+   2. Are you able to engage openpilot with no fault?
+   3. (Optional, PROCEED WITH EXTREME CAUTION AND BE READY TO MANUALLY TAKE OVER AT ALL TIMES) With the car engaged with openpilot and cruising at or below `35 MPH` or `56 KM/H` in good road conditions, is your car able to detect and slow down / stop behind a stopped car?
+7. If you answered `YES` to all the above questions in Step 6, you have successfully enabled openpilot Longitudinal Control.
 
-Note: Some Hyundai/Kia/Genesis cars may not see the chevron behind a lead car after enabling `openpilot Longitudinal Control`. Ensure that your car model is listed in the following statement in `selfdrive/car/hyundai/interface.py`:
+❗Note❗: Some Hyundai/Kia/Genesis car models may not see the chevron behind a lead car after enabling `openpilot Longitudinal Control`. This could cause by the affected car models being listed in the `LEGACY_SAFETY_MODE_CAR` blacklist in `selfdrive/car/hyundai/values.py` and openpilot Longitudinal Control may not have been tested/confirmed by comma or the community.
 
-    ## As of October 3rd, 2021 ##
-    ret.openpilotLongitudinalControl = Params().get_bool("DisableRadar") and candidate in [CAR.SONATA, CAR.SONATA_HYBRID, CAR.PALISADE, CAR.SANTA_FE]
+If you would like to test whether openpilot Longitudinal Control would work for your car model, ensure that your car model is removed from the blacklist in the following statement in `selfdrive/car/hyundai/values.py`:
+
+    ## As of January 9th, 2022 ##
+    LEGACY_SAFETY_MODE_CAR = set([CAR.HYUNDAI_GENESIS, CAR.IONIQ_EV_2020, CAR.IONIQ_EV_LTD, CAR.IONIQ_PHEV, CAR.IONIQ, CAR.KONA_EV, CAR.KIA_SORENTO, CAR.SONATA_LF, CAR.KIA_NIRO_EV, CAR.KIA_OPTIMA, CAR.VELOSTER, CAR.KIA_STINGER, CAR.GENESIS_G70, CAR.GENESIS_G80, CAR.KIA_CEED, CAR.ELANTRA, CAR.IONIQ_HEV_2022])

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -51,12 +51,10 @@ to go back to the default values.
     4. Reboot your comma device:
         1. C3: `sudo reboot`
         2. C2 or EON: `reboot`
-5. Once your comma device has been rebooted, start your car with engine on (with or without comma device connected). Ensure that there are no faults from the car.
-6a. If the car has no faults: Go to Step 7
-6b. If the car has faults: 
-7. Go for a quick drive and drive behind a lead car with varied follow distance. Then, come back and allow the drive to upload its `rlogs` in [comma Connect](https://connect.comma.ai).
-8. With all `rlogs` uploaded, open the drive in Cabana from [comma Connect](https://connect.comma.ai). Load DBC -> `hyundai_kia_mando_front_radar.dbc`, then search `RADAR_TRACK_50x` (`x` could be anything), open any of them, and look at `LONG_DIST`.
-9. If the radar tracks data is relevant with the lead car you drove behind, you are done! Your car now had radar tracks enabled.
+5. Once your comma device has been rebooted, start your car with engine on (with or without comma device connected). Ensure that there are no faults from the car. If there are faults, reach out to the community in [Sunnyhaibin's Openpilot Discord Server](https://discord.gg/wRW3meAgtx) or `#hyundai-kia-genesis channel` on [commaai community Discord Server](https://discord.comma.ai) for assistance.
+6. Go for a quick drive and drive behind a lead car with varied follow distance. Then, come back and allow the drive to upload its `rlogs` in [comma Connect](https://connect.comma.ai).
+7. With all `rlogs` uploaded, open the drive in Cabana from [comma Connect](https://connect.comma.ai). Load DBC -> `hyundai_kia_mando_front_radar.dbc`, then search `RADAR_TRACK_50x` (`x` could be anything), open any of them, and look at `LONG_DIST`.
+8. If the radar tracks data is relevant with the lead car you drove behind, you are done! Your car now had radar tracks enabled.
 
 ### 🚨 Enable openpilot Longitudinal Control 🚨
 

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -66,7 +66,7 @@ USE AT YOUR OWN RISK! Stock system safety features, like AEB and FCW, might be a
     .
     └── Settings
         └── Toggles
-            └── ***openpilot Longitudinal Control***
+            └── openpilot Longitudinal Control
 
 5. Set the toggle `openpilot Longitudinal Control` to `ON`. Reboot the comma device to ensure the take the change in effect.
 6. Start the car and drive. If a chevron (triangle) appears behind a lead car, openpilot Longitudinal Control has been successfully enabled.

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -62,8 +62,6 @@ USE AT YOUR OWN RISK! Stock system safety features, like AEB and FCW, might be a
         1. C3: `sudo reboot`
         2. C2 or EON: `reboot`
 4. Once your comma device has been rebooted, a new toggle should appear:
-
-
     .
     └── Settings
         └── Toggles

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -7,6 +7,7 @@ Table of Contents
 * [Radar Tracks](#Radar-Tracks)
     * [Enable Radar Tracks](#-Enable-Radar-Tracks-)
 * [Enable openpilot Longitudinal Control](#-Enable-openpilot-Longitudinal-Control-)
+* [Enable Mapbox Navigation](#-Enable-Mapbox-Navigation-)
 
 ---
 
@@ -93,3 +94,21 @@ to go back to the default values.
     ## As of January 9th, 2022 ##
     LEGACY_SAFETY_MODE_CAR = set([CAR.HYUNDAI_GENESIS, CAR.IONIQ_EV_2020, CAR.IONIQ_EV_LTD, CAR.IONIQ_PHEV, CAR.IONIQ, CAR.KONA_EV, CAR.KIA_SORENTO, CAR.SONATA_LF, CAR.KIA_NIRO_EV, CAR.KIA_OPTIMA, CAR.VELOSTER, CAR.KIA_STINGER, CAR.GENESIS_G70, CAR.GENESIS_G80, CAR.KIA_CEED, CAR.ELANTRA, CAR.IONIQ_HEV_2022])
 ```
+
+### 🗺 Enable Mapbox Navigation 🗺
+1) Create a free mapbox account. Account will ask for a credit card for verification. You will not be charged for the free tier.
+2) On the Dashboard, you will see a section called Access Tokens. Click `Create a Token`. Name it whatever you like. Set the scopes to allow everything for both Public and Secret. Copy both of these keys. **YOU WON'T BE ABLE TO ACCESS THE SECRET KEY AFTER THIS WINDOW.** 
+3) On your C3, go to `SP - Visuals` and toggle `Enable Mapbox Navigation*`. Accept the reboot.
+4) Once rebooted, connect your C3 to a network with internet access and find the C3’s IP address.
+5) In a browser, navigate to that IP with **port 8082** (i.e 192.168.1.69:8082). You should be greeted with the Comma logo and a public key input field.
+6) Paste your Public token (pk.xx), click enter, paste your Secret key (sk.xx), click enter. You can now search for places. This page will be available at your devices’s IP address/port 8082 to search for destinations.
+7) To set Home and Work addresses, search for a place, select Home/Work from the dropdown and click Navigate. For non-Home/Work destinations, select Recent Places.<br>*At this time, it is not possible to search directly on the C3.*
+
+**TIPS:**
+- If your C3 is showing a black screen that says “Map Loading”, performing a reboot via the UI should fix it.
+- If your phone can create a Hotspot, you are able to connect the C3 to your phone hotspot and use your phone browser to search for places.
+- In the Navigation panel on the C3, you can select Home, Work, and from a list of Recent Places you have navigated to without needing a browser (assuming the C3 is connected to the internet.)
+
+**IMPORTANT NOTE:** Your C3 will require an active internet connection to download map data, generate driving directions, and ETA. Once map data and directions are downloaded, it *is* possible to use it offline, however nothing will update (such as new driving direction after a missed turn, updated ETA, map data further into your drive etc.)
+
+***NAVIGATION NOTE:** At this time, mapbox does not support alphanumeric addresses (i.e W123N1234 Main St). There is currently no known workaround for this.*

--- a/HOW-TOS.md
+++ b/HOW-TOS.md
@@ -26,7 +26,7 @@ After changing the config the car should not show any faults when openpilot is n
 These config changes are persistent across car reboots. You need to run this script again
 to go back to the default values.
 
-USE AT YOUR OWN RISK! Stock system safety features, like AEB and FCW, might be affected by these changes.
+**USE AT YOUR OWN RISK!** Stock system safety features, like AEB and FCW, might be affected by these changes.
 
 ### 🚨 Enable Radar Tracks 🚨
 

--- a/README.md
+++ b/README.md
@@ -140,15 +140,7 @@ comma three:
 * [`release-c3`](https://github.com/sunnyhaibin/openpilot/tree/release-c3):
 
   ```
-  cd /data; rm -rf ./openpilot; git clone -b release-c3 --recurse-submodules https://github.com/sunnyhaibin/sunnypilot.git openpilot; cd openpilot; sudo reboot
-  ```
-
-comma two:
-------
-* [`0.8.12-prod-personal-hkg`](https://github.com/sunnyhaibin/openpilot/tree/0.8.12-prod-personal-hkg):
-
-  ```
-  cd /data; rm -rf ./openpilot; git clone -b 0.8.12-prod-personal-hkg --recurse-submodules https://github.com/sunnyhaibin/sunnypilot.git openpilot; cd openpilot; sudo reboot
+  cd /data && rm -rf ./openpilot && git clone -b release-c3 --recurse-submodules https://github.com/sunnyhaibin/sunnypilot.git openpilot && cd openpilot && sudo reboot
   ```
 
 After running the command to install the desired branch, your comma device should reboot.
@@ -355,7 +347,7 @@ Example:
 
 ---
 
-How-To instructions can be found in [HOW-TOS.md](https://github.com/sunnyhaibin/openpilot/blob/(!)README/HOW-TOS.md).
+How-To instructions can be found in [HOW-TOS.md](HOW-TOS.md).
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ Join the official sunnypilot Discord server to stay up to date with all the late
 To use sunnypilot in a car, you need the following:
 * A supported device to run this software
     * a [comma three](https://comma.ai/shop/products/three), or
-    * a comma two (only with older versions below 0.8.13)
 * This software
 * One of [the 250+ supported cars](https://github.com/commaai/openpilot/blob/master/docs/CARS.md). We support Honda, Toyota, Hyundai, Nissan, Kia, Chrysler, Lexus, Acura, Audi, VW, Ford and more. If your car is not supported but has adaptive cruise control and lane-keeping assist, it's likely able to run sunnypilot.
 * A [car harness](https://comma.ai/shop/products/car-harness) to connect to your car
@@ -114,26 +113,6 @@ Please refer to [Recommended Branches](#-recommended-branches) to find your pref
 |   `dev-c3`   | https://dev-c3.sunnypilot.ai     |
 
 Requires further assistance with software installation? Join the [sunnypilot Discord server](https://discord.sunnypilot.com) and message us in the `#installation-help` channel.
-
-comma two
-------
-
-1. [Factory reset/uninstall](https://github.com/commaai/openpilot/wiki/FAQ#how-can-i-reset-the-device) the previous software if you have another software/fork installed.
-2. After factory reset/uninstall and upon reboot, select `Custom Software` when given the option.
-3. Input the installation URL per [Recommended Branches](#-recommended-branches). Example: ```https://smiskol.com/fork/sunnyhaibin/0.8.12-4-prod```
-4. Complete the rest of the installation following the onscreen instructions.
-
-Requires further assistance with software installation? Join the [sunnypilot Discord server](https://discord.sunnypilot.com) and message us in the `#installation-help` channel.
-
-  </details>
-
-  <details>
-  <summary>SSH (More Versatile)</summary>
-  <br>
-
-Prerequisites: [How to SSH](https://github.com/commaai/openpilot/wiki/SSH)
-
-If you are looking to install sunnypilot via SSH, run the following command in an SSH terminal after connecting to your device:
 
 comma three:
 ------


### PR DESCRIPTION
I found that because the branch `(!)README` is so far behind, it causes GIT to store a lot of granular commit info separated +  all the git history before the branch was cleared which causes every  `git fetch` to waste a whopping 1.08GiB! 

I've moved the only thing that was missing which is the `HOW-TOS.md` to master branch and updated the `README.md` accordingly

![image](https://github.com/user-attachments/assets/c5c8b60c-385f-4434-86e8-b77a4f9d87db)

After this is merged, we'll nuke the branch `(!)README`
