### PR TITLE
Nnlc adjustable lat jerk

### DIFF
--- a/selfdrive/controls/lib/latcontrol_torque.py
+++ b/selfdrive/controls/lib/latcontrol_torque.py
@@ -83,8 +83,7 @@ class LatControlTorque(LatControl):
     self.torqued_override = self.param_s.get_bool("TorquedOverride")
     self._frame = 0
 
-    self.use_lateral_jerk = self.param_s.get_bool("TorqueLateralJerk")  # TODO: make this a parameter in the UI
-    self.nnff_no_lateral_jerk = self.param_s.get_bool("NNFFNoLateralJerk")  # TODO: make this a parameter in the UI
+    self.use_lateral_jerk = self.param_s.get_bool("TorqueLateralJerk")
 
     # Twilsonco's Lateral Neural Network Feedforward
     self.use_nn = CI.has_lateral_torque_nn
@@ -102,8 +101,12 @@ class LatControlTorque(LatControl):
 
       # Scaling the lateral acceleration "friction response" could be helpful for some.
       # Increase for a stronger response, decrease for a weaker response.
-      self.lat_jerk_friction_factor = 0.4
-      self.lat_accel_friction_factor = 0.7 # in [0, 3], in 0.05 increments. 3 is arbitrary safety limit
+      nnff_lateral_jerk_factor = 1.0 # replace with ---> float(self.param_s.get("NNFFLateralJerkFactor", encoding="utf8"))
+      nnff_lateral_jerk_factor = max(0.0, min(1.0, nnff_lateral_jerk_factor))
+      
+      self.lat_jerk_friction_factor = 0.4 * nnff_lateral_jerk_factor
+      # Increasing lat accel friction factor to account for any decrease of the lat jerk friction factor from default
+      self.lat_accel_friction_factor = 0.7 + (0.3 * (1.0 - nnff_lateral_jerk_factor)) # in [0, 3], in 0.05 increments. 3 is arbitrary safety limit
 
       # precompute time differences between ModelConstants.T_IDXS
       self.t_diffs = np.diff(ModelConstants.T_IDXS)

--- a/selfdrive/controls/lib/latcontrol_torque.py
+++ b/selfdrive/controls/lib/latcontrol_torque.py
@@ -213,11 +213,11 @@ class LatControlTorque(LatControl):
         if self.use_steering_angle or lookahead_lateral_jerk == 0.0:
           lookahead_lateral_jerk = 0.0
           actual_lateral_jerk = 0.0
-          lat_accel_friction_factor = 1.0
-        else:
-          lat_accel_friction_factor = self.lat_accel_friction_factor
         lateral_jerk_setpoint = self.lat_jerk_friction_factor * lookahead_lateral_jerk
         lateral_jerk_measurement = self.lat_jerk_friction_factor * actual_lateral_jerk
+
+      lat_accel_friction_factor = 1.0 if self.use_steering_angle or lookahead_lateral_jerk == 0.0 else \
+                                  self.lat_accel_friction_factor
 
       if self.use_nn and model_good:
         # update past data


### PR DESCRIPTION
Simple change to NNLC and `TorqueLateralJerk`, replacing `NNFFNoLateralJerk` with `NNFFLateralJerkFactor`, i.e. making it an adjustable float rather than a bool. This will allow for better fine-tuning of lateral jerk NNLC and "TorqueLateralJerk" input.

Also includes two bugfixes, 

1. the `lat_accel_friction_factor` would be increased when there's no desired lateral jerk, but it wasn't being lowered again in case there was non-zero desired lateral jerk. This would have resulted in too-high "friction compensation" after the bug was tripped. 
2. Because `self.use_lateral_jerk` can be changed onroad, it was possible to trigger a crash due to some of the lateral jerk instance variables having not been defined inside `init()`. The fix is to define all potentially necessary instance variables in `init()` regardless of NNLC and TorqueLateralJerk settings.

Both of these changes (first bugfix and adjustable lateral jerk) should help folks experiencing overactive NNLC and "TorqueLateralJerk" steering.