### PR TITLE
MADS: Hyundai: Skip cruise main button check with `pcmCruise`

### DIFF
--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -221,8 +221,8 @@ class CarInterface(CarInterfaceBase):
           self.CS.accEnabled = True
 
     if self.enable_mads:
-      if not self.CS.prev_mads_enabled and self.CS.mads_enabled and \
-        (any(b.type == ButtonType.altButton3 for b in self.CS.button_events) and not self.CP.pcmCruise):
+      if not self.CS.prev_mads_enabled and self.CS.mads_enabled and (self.CP.pcmCruise or
+        (any(b.type == ButtonType.altButton3 for b in self.CS.button_events) and not self.CP.pcmCruise)):
         self.CS.madsEnabled = True
       if any(b.type == ButtonType.altButton1 and b.pressed for b in self.CS.button_events):
         self.CS.madsEnabled = not self.CS.madsEnabled

--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -222,7 +222,7 @@ class CarInterface(CarInterfaceBase):
 
     if self.enable_mads:
       if not self.CS.prev_mads_enabled and self.CS.mads_enabled and \
-        any(b.type == ButtonType.altButton3 for b in self.CS.button_events):
+        (any(b.type == ButtonType.altButton3 for b in self.CS.button_events) and not self.CP.pcmCruise):
         self.CS.madsEnabled = True
       if any(b.type == ButtonType.altButton1 and b.pressed for b in self.CS.button_events):
         self.CS.madsEnabled = not self.CS.madsEnabled


### PR DESCRIPTION
This resolves a race condition between `madsEnabled` and stock `pcmCruise` for Hyundai. The addition of a check for `pcmCruise` status ensures that we only check for cruise available state without the cruise main button press check, preventing potential race conditions.