### PR TITLE
Hyundai Longitudinal: Match stock timestep for ESCC and Camera-based SCC

### DIFF
--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -109,6 +109,7 @@ class CarInterface(CarInterfaceBase):
 
     if DBC[ret.carFingerprint]["radar"] is None:
       if ret.spFlags & (HyundaiFlagsSP.SP_ENHANCED_SCC | HyundaiFlagsSP.SP_CAMERA_SCC_LEAD):
+        ret.radarTimeStep = 0.02
         ret.radarUnavailable = False
 
     # *** feature detection ***


### PR DESCRIPTION
The current radar parser updates at 20 Hz, which is not the same as the timestep for ESCC and camera-based SCC cars doing longitudinal (50 Hz). This change syncs the timestep for radar parser with ESCC and camera-based SCC cars.

Thanks to @ajouatom for bringing this to our attention!