### PR TITLE
ci: Skip simulator failures

### DIFF
--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -355,6 +355,7 @@ jobs:
         ${{ env.RUN }} "source selfdrive/test/setup_xvfb.sh && \
                         source selfdrive/test/setup_vsound.sh && \
                         CI=1 pytest tools/sim/tests/test_metadrive_bridge.py"
+      continue-on-error: true
 
   create_ui_report:
     # This job name needs to be the same as UI_JOB_NAME in ui_preview.yaml


### PR DESCRIPTION
Allows fails for the simulator test because we don't trust it, it fails even without changes