### PR TITLE
Revert "ci: Skip simulator failures"

### DIFF
--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -331,7 +331,6 @@ jobs:
         ${{ env.RUN }} "source selfdrive/test/setup_xvfb.sh && \
                         source selfdrive/test/setup_vsound.sh && \
                         CI=1 pytest tools/sim/tests/test_metadrive_bridge.py"
-      continue-on-error: true
 
   create_ui_report:
     # This job name needs to be the same as UI_JOB_NAME in ui_preview.yaml


### PR DESCRIPTION
Reverts sunnypilot/sunnypilot#470

This is fixed in upstream:
- https://github.com/commaai/openpilot/pull/34160