### PR TITLE
CI: Add GitHub Action to build models from upstream

### DIFF
--- a/.github/workflows/sunnypilot-build-model.yaml
+++ b/.github/workflows/sunnypilot-build-model.yaml
@@ -80,8 +80,16 @@ jobs:
             --chown=comma:comma \
             ./selfdrive/modeld/models/ ${OUTPUT_DIR}/
 
-      - name: Upload Build Artifacts
+      - name: Upload Build Artifacts (Custom Name)
+        if: github.event.inputs.custom_name != ''
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.event.inputs.custom_name != '' && format('model-{}-{}', github.event.inputs.custom_name, github.run_number) || format('model-{}-{}', github.event.inputs.upstream_branch, github.run_number) }}
+          name: model-${{ github.event.inputs.custom_name }}-${{ github.run_number }}
+          path: ${{ env.OUTPUT_DIR }}
+
+      - name: Upload Build Artifacts (Default Name)
+        if: github.event.inputs.custom_name == ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: model-${{ github.event.inputs.upstream_branch }}-${{ github.run_number }}
           path: ${{ env.OUTPUT_DIR }}

--- a/.github/workflows/sunnypilot-build-model.yaml
+++ b/.github/workflows/sunnypilot-build-model.yaml
@@ -17,7 +17,6 @@ on:
       custom_name:
         description: 'Custom name for the model'
         required: false
-        default: ''
         type: string
 
 jobs:
@@ -80,16 +79,8 @@ jobs:
             --chown=comma:comma \
             ./selfdrive/modeld/models/ ${OUTPUT_DIR}/
 
-      - name: Upload Build Artifacts (Custom Name)
-        if: github.event.inputs.custom_name != ''
+      - name: Upload Build Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: model-${{ github.event.inputs.custom_name }}-${{ github.run_number }}
-          path: ${{ env.OUTPUT_DIR }}
-
-      - name: Upload Build Artifacts (Default Name)
-        if: github.event.inputs.custom_name == ''
-        uses: actions/upload-artifact@v4
-        with:
-          name: model-${{ github.event.inputs.upstream_branch }}-${{ github.run_number }}
+          name: model-${{ github.event.inputs.custom_name || github.event.inputs.upstream_branch }}-${{ github.run_number }}
           path: ${{ env.OUTPUT_DIR }}

--- a/.github/workflows/sunnypilot-build-model.yaml
+++ b/.github/workflows/sunnypilot-build-model.yaml
@@ -37,11 +37,11 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{env.SCONS_CACHE_DIR}}
-          key: scons-${{ runner.os }}-${{ runner.arch }}-${{ github.ref_name }}-model-${{ github.head_ref }}-${{ github.sha }}
+          key: scons-${{ runner.os }}-${{ runner.arch }}-${{ github.head_ref || github.ref_name }}-model-${{ github.sha }}
           restore-keys: |
-            scons-${{ runner.os }}-${{ runner.arch }}-${{ github.ref_name }}-model-${{ github.head_ref }}
-            scons-${{ runner.os }}-${{ runner.arch }}-${{ github.ref_name }}-model
-            scons-${{ runner.os }}-${{ runner.arch }}-${{ github.ref_name }}
+            scons-${{ runner.os }}-${{ runner.arch }}-${{ github.head_ref || github.ref_name }}-model-${{ github.sha }}
+            scons-${{ runner.os }}-${{ runner.arch }}-${{ github.head_ref || github.ref_name }}-model
+            scons-${{ runner.os }}-${{ runner.arch }}-${{ github.head_ref || github.ref_name }}
             scons-${{ runner.os }}-${{ runner.arch }}-master-new
             scons-${{ runner.os }}-${{ runner.arch }}-master
             scons-${{ runner.os }}-${{ runner.arch }}

--- a/.github/workflows/sunnypilot-build-model.yaml
+++ b/.github/workflows/sunnypilot-build-model.yaml
@@ -14,6 +14,11 @@ on:
         required: true
         default: 'master'
         type: string
+      custom_name:
+        description: 'Custom name for the model'
+        required: false
+        default: ''
+        type: string
 
 jobs:
   build_model:
@@ -78,5 +83,5 @@ jobs:
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: model-${{ github.event.inputs.upstream_branch }}-${{ github.run_number }}
+          name: ${{ github.event.inputs.custom_name != '' && format('model-{}-{}', github.event.inputs.custom_name, github.run_number) || format('model-{}-{}', github.event.inputs.upstream_branch, github.run_number) }}
           path: ${{ env.OUTPUT_DIR }}

--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -238,7 +238,7 @@ jobs:
   notify:
     needs: [ build, publish ]
     runs-on: ubuntu-24.04
-    if: ${{ steps.publish.outcome == 'success' }}
+    if: success()
     steps:
       - uses: actions/checkout@v4
       - name: Setup Alpine Linux environment

--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -23,6 +23,8 @@ on:
     tags: [ '*' ]
   pull_request:
     branches: [ master, master-new ]
+    types: [ opened, synchronize, reopened ]
+    drafts: true
   workflow_dispatch:
     inputs:
       extra_version:
@@ -188,7 +190,6 @@ jobs:
           path: prebuilt.tar.gz
 
   publish:
-    continue-on-error: true
     concurrency:
       group: publish-${{ github.head_ref || github.ref_name }}
       cancel-in-progress: true

--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -23,8 +23,6 @@ on:
     tags: [ '*' ]
   pull_request:
     branches: [ master, master-new ]
-    types: [ opened, synchronize, reopened ]
-    drafts: true
   workflow_dispatch:
     inputs:
       extra_version:
@@ -193,6 +191,7 @@ jobs:
     concurrency:
       group: publish-${{ github.head_ref || github.ref_name }}
       cancel-in-progress: true
+    if: ${{ github.event_name != 'pull_request' || github.event_name == 'pull_request' && github.event.pull_request.draft }} 
     needs: build
     runs-on: ubuntu-24.04
     environment: ${{ contains(fromJSON(vars.AUTO_DEPLOY_PREBUILT_BRANCHES), github.head_ref || github.ref_name) && 'auto-deploy' || 'feature-branch' }}

--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -188,6 +188,7 @@ jobs:
           path: prebuilt.tar.gz
 
   publish:
+    continue-on-error: true
     concurrency:
       group: publish-${{ github.head_ref || github.ref_name }}
       cancel-in-progress: true
@@ -237,6 +238,7 @@ jobs:
   notify:
     needs: [ build, publish ]
     runs-on: ubuntu-24.04
+    if: steps.publish.outcome == 'success'
     steps:
       - uses: actions/checkout@v4
       - name: Setup Alpine Linux environment

--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -238,7 +238,7 @@ jobs:
   notify:
     needs: [ build, publish ]
     runs-on: ubuntu-24.04
-    if: steps.publish.outcome == 'success'
+    if: ${{ steps.publish.outcome == 'success' }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup Alpine Linux environment


### PR DESCRIPTION
This workflow automates building models from a specified upstream branch of the openpilot repository. It caches dependencies, applies necessary patches, builds the model artifacts, and uploads them for use. This setup facilitates smoother integration and testing processes.
