### PR TITLE
ci: enable macos runners again

### DIFF
--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -95,7 +95,6 @@ jobs:
       timeout-minutes: 30
 
   build_mac:
-    if: github.repository == 'commaai/openpilot' # Blocking macos builds as well since they have a 10x miltiplier for GH action minutes, waaaay too much!
     name: build macOS
     runs-on: ${{ ((github.repository == 'commaai/openpilot') &&
                    ((github.event_name != 'pull_request') ||


### PR DESCRIPTION
MacOS runners are also free on GH public repos lol