### PR TITLE
ci: Update version identifier in workflow for staging and release

### DIFF
--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -72,14 +72,14 @@ jobs:
             echo "BRANCH_TYPE=master" >> $GITHUB_ENV
             echo "NEW_BRANCH=${{ env.STAGING_TARGET_BRANCH }}" >> $GITHUB_ENV
             echo "EXTRA_VERSION_IDENTIFIER=staging" >> $GITHUB_ENV
-            echo "VERSION=$(cat common/version.h | grep COMMA_VERSION | sed -e 's/[^0-9|.]//g')" >> $GITHUB_ENV
+            echo "VERSION=$(cat common/version.h | grep COMMA_VERSION | sed -e 's/[^0-9|.]//g')-staging" >> $GITHUB_ENV
           
           elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
             # Tag configuration
             echo "BRANCH_TYPE=tag" >> $GITHUB_ENV
             echo "NEW_BRANCH=${{ env.RELEASE_TARGET_BRANCH }}" >> $GITHUB_ENV
             echo "EXTRA_VERSION_IDENTIFIER=release" >> $GITHUB_ENV
-            echo "VERSION=$(cat common/version.h | grep COMMA_VERSION | sed -e 's/[^0-9|.]//g')" >> $GITHUB_ENV
+            echo "VERSION=$(cat common/version.h | grep COMMA_VERSION | sed -e 's/[^0-9|.]//g')-release" >> $GITHUB_ENV
           
           else
             # Feature branch configuration


### PR DESCRIPTION
Appended "-staging" and "-release" to the VERSION variable in the GitHub Actions workflow to clearly distinguish build types. This ensures clarity in versioning for staging and release environments.


