### PR TITLE
ui: remove stretch in sunnypilot panel

### DIFF
--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/sunnypilot_panel.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/sunnypilot_panel.cc
@@ -49,7 +49,6 @@ SunnypilotPanel::SunnypilotPanel(SettingsWindowSP *parent) : QFrame(parent) {
 
   sunnypilotScroller = new ScrollViewSP(list, this);
   vlayout->addWidget(sunnypilotScroller);
-  vlayout->addStretch(1);
 
   main_layout->addWidget(sunnypilotScreen);
   main_layout->addWidget(madsWidget);

--- a/selfdrive/ui/tests/test_ui/run.py
+++ b/selfdrive/ui/tests/test_ui/run.py
@@ -186,7 +186,7 @@ def setup_settings_sunnypilot_mads(click, pm: PubMaster):
 
   setup_settings_device(click, pm)
   click(278, 846)
-  click(970, 250)
+  click(970, 455)
   time.sleep(UI_DELAY)
 
 CASES = {


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Remove unnecessary stretch from the sunnypilot panel layout.