### PR TITLE
System: fix dynamic pathing for crash logs

### DIFF
--- a/sunnypilot/sunnylink/api.py
+++ b/sunnypilot/sunnylink/api.py
@@ -14,7 +14,7 @@ from openpilot.system.hardware.hw import Paths
 API_HOST = os.getenv('SUNNYLINK_API_HOST', 'https://stg.api.sunnypilot.ai')
 UNREGISTERED_SUNNYLINK_DONGLE_ID = "UnregisteredDevice"
 MAX_RETRIES = 6
-CRASH_LOG_DIR = '/data/community/crashes'
+CRASH_LOG_DIR = Paths.crash_log_root()
 
 
 class SunnylinkApi(BaseApi):

--- a/system/hardware/hw.py
+++ b/system/hardware/hw.py
@@ -70,3 +70,10 @@ class Paths:
       return str(Path(Paths.comma_home()) / "media" / "0" / "models")
     else:
       return "/data/media/0/models"
+
+  @staticmethod
+  def crash_log_root() -> str:
+    if PC:
+      return str(Path(Paths.comma_home()) / "community" / "crashes")
+    else:
+      return "/data/community/crashes"


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix the crash log directory path to be consistent across different platforms.