### PR TITLE
ui: add drive stats and move comma Prime status on offroad home

### DIFF
--- a/common/params.cc
+++ b/common/params.cc
@@ -201,6 +201,7 @@ std::unordered_map<std::string, uint32_t> keys = {
     {"Version", PERSISTENT},
 
     // --- sunnypilot params --- //
+    {"ApiCache_DriveStats", PERSISTENT},
     {"EnableGithubRunner", PERSISTENT | BACKUP},
 
     // MADS params

--- a/selfdrive/ui/qt/home.h
+++ b/selfdrive/ui/qt/home.h
@@ -19,6 +19,7 @@
 #define LayoutWidget LayoutWidgetSP
 #define Sidebar SidebarSP
 #define ElidedLabel ElidedLabelSP
+#define SetupWidget SetupWidgetSP
 #else
 #include "selfdrive/ui/qt/widgets/controls.h"
 #include "selfdrive/ui/qt/onroad/onroad_home.h"

--- a/selfdrive/ui/qt/offroad/offroad_home.cc
+++ b/selfdrive/ui/qt/offroad/offroad_home.cc
@@ -45,10 +45,11 @@ OffroadHome::OffroadHome(QWidget* parent) : QFrame(parent) {
 
   QWidget *home_widget = new QWidget(this);
   {
-    QHBoxLayout *home_layout = new QHBoxLayout(home_widget);
+    home_layout = new QHBoxLayout(home_widget);
     home_layout->setContentsMargins(0, 0, 0, 0);
     home_layout->setSpacing(30);
 
+#ifndef SUNNYPILOT
     // left: PrimeAdWidget
     QStackedWidget *left_widget = new QStackedWidget(this);
     QVBoxLayout *left_prime_layout = new QVBoxLayout();
@@ -69,6 +70,7 @@ OffroadHome::OffroadHome(QWidget* parent) : QFrame(parent) {
     });
 
     home_layout->addWidget(left_widget, 1);
+#endif
 
     // right: ExperimentalModeButton, SetupWidget
     QWidget* right_widget = new QWidget(this);

--- a/selfdrive/ui/qt/offroad/offroad_home.h
+++ b/selfdrive/ui/qt/offroad/offroad_home.h
@@ -15,14 +15,17 @@
 #include "selfdrive/ui/sunnypilot/qt/widgets/controls.h"
 #include "selfdrive/ui/sunnypilot/qt/onroad/onroad_home.h"
 #include "selfdrive/ui/sunnypilot/qt/sidebar.h"
+#include "selfdrive/ui/sunnypilot/qt/widgets/prime.h"
 #define OnroadWindow OnroadWindowSP
 #define LayoutWidget LayoutWidgetSP
 #define Sidebar SidebarSP
 #define ElidedLabel ElidedLabelSP
+#define SetupWidget SetupWidgetSP
 #else
 #include "selfdrive/ui/qt/widgets/controls.h"
 #include "selfdrive/ui/qt/onroad/onroad_home.h"
 #include "selfdrive/ui/qt/sidebar.h"
+#include "selfdrive/ui/qt/widgets/prime.h"
 #endif
 
 class OffroadHome : public QFrame {
@@ -33,6 +36,9 @@ public:
 
   signals:
     void openSettings(int index = 0, const QString &param = "");
+
+protected:
+  QHBoxLayout *home_layout;
 
 private:
   void showEvent(QShowEvent *event) override;

--- a/selfdrive/ui/qt/widgets/prime.cc
+++ b/selfdrive/ui/qt/widgets/prime.cc
@@ -221,7 +221,7 @@ SetupWidget::SetupWidget(QWidget* parent) : QFrame(parent) {
   outer_layout->addWidget(mainLayout);
 
   QWidget *content = new QWidget;
-  QVBoxLayout *content_layout = new QVBoxLayout(content);
+  content_layout = new QVBoxLayout(content);
   content_layout->setContentsMargins(0, 0, 0, 0);
   content_layout->setSpacing(30);
 

--- a/selfdrive/ui/qt/widgets/prime.h
+++ b/selfdrive/ui/qt/widgets/prime.h
@@ -63,6 +63,9 @@ public:
 signals:
   void openSettings(int index = 0, const QString &param = "");
 
+protected:
+  QVBoxLayout *content_layout;
+
 private:
   PairingPopup *popup;
   QStackedWidget *mainLayout;

--- a/selfdrive/ui/sunnypilot/SConscript
+++ b/selfdrive/ui/sunnypilot/SConscript
@@ -1,6 +1,8 @@
 widgets_src = [
   "sunnypilot/qt/widgets/toggle.cc",
   "sunnypilot/qt/widgets/controls.cc",
+  "sunnypilot/qt/widgets/drive_stats.cc",
+  "sunnypilot/qt/widgets/prime.cc",
   "sunnypilot/qt/widgets/scrollview.cc",
 ]
 

--- a/selfdrive/ui/sunnypilot/qt/home.cc
+++ b/selfdrive/ui/sunnypilot/qt/home.cc
@@ -7,6 +7,8 @@
 
 #include "selfdrive/ui/sunnypilot/qt/home.h"
 
+#include "selfdrive/ui/sunnypilot/qt/widgets/drive_stats.h"
+
 HomeWindowSP::HomeWindowSP(QWidget *parent) : HomeWindow(parent) {
 }
 

--- a/selfdrive/ui/sunnypilot/qt/offroad/offroad_home.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/offroad_home.cc
@@ -7,5 +7,14 @@
 
 #include "selfdrive/ui/sunnypilot/qt/offroad/offroad_home.h"
 
+#include <QStackedWidget>
+
+#include "selfdrive/ui/sunnypilot/qt/widgets/drive_stats.h"
+
 OffroadHomeSP::OffroadHomeSP(QWidget *parent) : OffroadHome(parent) {
+  QStackedWidget *left_widget = new QStackedWidget(this);
+  left_widget->addWidget(new DriveStats(this));
+  left_widget->setStyleSheet("border-radius: 10px;");
+
+  home_layout->insertWidget(0, left_widget);
 }

--- a/selfdrive/ui/sunnypilot/qt/widgets/drive_stats.cc
+++ b/selfdrive/ui/sunnypilot/qt/widgets/drive_stats.cc
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+ *
+ * This file is part of sunnypilot and is licensed under the MIT License.
+ * See the LICENSE.md file in the root directory for more details.
+ */
+
+#include "selfdrive/ui/sunnypilot/qt/widgets/drive_stats.h"
+
+#include <QDebug>
+#include <QGridLayout>
+#include <QVBoxLayout>
+
+#include "common/params.h"
+#include "selfdrive/ui/qt/request_repeater.h"
+#include "selfdrive/ui/qt/util.h"
+
+static QLabel* newLabel(const QString& text, const QString &type) {
+  QLabel* label = new QLabel(text);
+  label->setProperty("type", type);
+  return label;
+}
+
+DriveStats::DriveStats(QWidget* parent) : QFrame(parent) {
+  metric_ = Params().getBool("IsMetric");
+
+  QVBoxLayout* main_layout = new QVBoxLayout(this);
+  main_layout->setContentsMargins(50, 50, 50, 60);
+
+  auto add_stats_layouts = [=](const QString &title, StatsLabels& labels) {
+    QGridLayout* grid_layout = new QGridLayout;
+    grid_layout->setVerticalSpacing(10);
+    grid_layout->setContentsMargins(0, 10, 0, 10);
+
+    int row = 0;
+    grid_layout->addWidget(newLabel(title, "title"), row++, 0, 1, 3);
+    grid_layout->addItem(new QSpacerItem(0, 50), row++, 0, 1, 1);
+
+    grid_layout->addWidget(labels.routes = newLabel("0", "number"), row, 0, Qt::AlignLeft);
+    grid_layout->addWidget(labels.distance = newLabel("0", "number"), row, 1, Qt::AlignLeft);
+    grid_layout->addWidget(labels.hours = newLabel("0", "number"), row, 2, Qt::AlignLeft);
+
+    grid_layout->addWidget(newLabel((tr("Drives")), "unit"), row + 1, 0, Qt::AlignLeft);
+    grid_layout->addWidget(labels.distance_unit = newLabel(getDistanceUnit(), "unit"), row + 1, 1, Qt::AlignLeft);
+    grid_layout->addWidget(newLabel(tr("Hours"), "unit"), row + 1, 2, Qt::AlignLeft);
+
+    main_layout->addLayout(grid_layout);
+  };
+
+  add_stats_layouts(tr("ALL TIME"), all_);
+  main_layout->addStretch();
+  add_stats_layouts(tr("PAST WEEK"), week_);
+
+  if (auto dongleId = getDongleId()) {
+    QString url = CommaApi::BASE_URL + "/v1.1/devices/" + *dongleId + "/stats";
+    RequestRepeater* repeater = new RequestRepeater(this, url, "ApiCache_DriveStats", 30);
+    QObject::connect(repeater, &RequestRepeater::requestDone, this, &DriveStats::parseResponse);
+  }
+
+  setStyleSheet(R"(
+    DriveStats {
+      background-color: #333333;
+      border-radius: 10px;
+    }
+
+    QLabel[type="title"] { font-size: 51px; font-weight: 500; }
+    QLabel[type="number"] { font-size: 78px; font-weight: 500; }
+    QLabel[type="unit"] { font-size: 51px; font-weight: 300; color: #A0A0A0; }
+  )");
+}
+
+void DriveStats::updateStats() {
+  auto update = [=](const QJsonObject& obj, StatsLabels& labels) {
+    labels.routes->setText(QString::number((int)obj["routes"].toDouble()));
+    labels.distance->setText(QString::number(int(obj["distance"].toDouble() * (metric_ ? MILE_TO_KM : 1))));
+    labels.distance_unit->setText(getDistanceUnit());
+    labels.hours->setText(QString::number((int)(obj["minutes"].toDouble() / 60)));
+  };
+
+  QJsonObject json = stats_.object();
+  update(json["all"].toObject(), all_);
+  update(json["week"].toObject(), week_);
+}
+
+void DriveStats::parseResponse(const QString& response, bool success) {
+  if (!success) return;
+
+  QJsonDocument doc = QJsonDocument::fromJson(response.trimmed().toUtf8());
+  if (doc.isNull()) {
+    qDebug() << "JSON Parse failed on getting past drives statistics";
+    return;
+  }
+  stats_ = doc;
+  updateStats();
+}
+
+void DriveStats::showEvent(QShowEvent* event) {
+  bool metric = Params().getBool("IsMetric");
+  if (metric_ != metric) {
+    metric_ = metric;
+    updateStats();
+  }
+}

--- a/selfdrive/ui/sunnypilot/qt/widgets/drive_stats.h
+++ b/selfdrive/ui/sunnypilot/qt/widgets/drive_stats.h
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+ *
+ * This file is part of sunnypilot and is licensed under the MIT License.
+ * See the LICENSE.md file in the root directory for more details.
+ */
+
+#pragma once
+
+#include <QJsonDocument>
+#include <QLabel>
+
+class DriveStats : public QFrame {
+  Q_OBJECT
+
+public:
+  explicit DriveStats(QWidget* parent = 0);
+
+private:
+  void showEvent(QShowEvent *event) override;
+  void updateStats();
+  inline QString getDistanceUnit() const { return metric_ ? tr("KM") : tr("Miles"); }
+
+  bool metric_;
+  QJsonDocument stats_;
+  struct StatsLabels {
+    QLabel *routes, *distance, *distance_unit, *hours;
+  } all_, week_;
+
+private slots:
+  void parseResponse(const QString &response, bool success);
+};

--- a/selfdrive/ui/sunnypilot/qt/widgets/prime.cc
+++ b/selfdrive/ui/sunnypilot/qt/widgets/prime.cc
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+ *
+ * This file is part of sunnypilot and is licensed under the MIT License.
+ * See the LICENSE.md file in the root directory for more details.
+ */
+
+#include "selfdrive/ui/sunnypilot/qt/widgets/prime.h"
+
+SetupWidgetSP::SetupWidgetSP(QWidget *parent) : SetupWidget(parent) {
+  PrimeUserWidget *primeUser = new PrimeUserWidget;
+  content_layout->insertWidget(0, primeUser);
+
+  primeUser->setVisible(uiState()->prime_state->isSubscribed());
+
+  QObject::connect(uiState()->prime_state, &PrimeState::changed, [=]() {
+    primeUser->setVisible(uiState()->prime_state->isSubscribed());
+  });
+}

--- a/selfdrive/ui/sunnypilot/qt/widgets/prime.h
+++ b/selfdrive/ui/sunnypilot/qt/widgets/prime.h
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+ *
+ * This file is part of sunnypilot and is licensed under the MIT License.
+ * See the LICENSE.md file in the root directory for more details.
+ */
+
+#pragma once
+
+#include "selfdrive/ui/qt/widgets/prime.h"
+
+#include "selfdrive/ui/sunnypilot/ui.h"
+
+class SetupWidgetSP : public SetupWidget {
+  Q_OBJECT
+
+public:
+  explicit SetupWidgetSP(QWidget *parent = nullptr);
+};

--- a/selfdrive/ui/translations/main_ar.ts
+++ b/selfdrive/ui/translations/main_ar.ts
@@ -276,6 +276,33 @@
     </message>
 </context>
 <context>
+    <name>DriveStats</name>
+    <message>
+        <source>Drives</source>
+        <translation>القيادة</translation>
+    </message>
+    <message>
+        <source>Hours</source>
+        <translation>ساعات</translation>
+    </message>
+    <message>
+        <source>ALL TIME</source>
+        <translation>كامل الوقت</translation>
+    </message>
+    <message>
+        <source>PAST WEEK</source>
+        <translation>الأسبوع الماضي</translation>
+    </message>
+    <message>
+        <source>KM</source>
+        <translation>كم</translation>
+    </message>
+    <message>
+        <source>Miles</source>
+        <translation>ميل</translation>
+    </message>
+</context>
+<context>
     <name>DriverViewWindow</name>
     <message>
         <source>camera starting</source>

--- a/selfdrive/ui/translations/main_de.ts
+++ b/selfdrive/ui/translations/main_de.ts
@@ -276,6 +276,33 @@
     </message>
 </context>
 <context>
+    <name>DriveStats</name>
+    <message>
+        <source>Drives</source>
+        <translation>Fahrten</translation>
+    </message>
+    <message>
+        <source>Hours</source>
+        <translation>Stunden</translation>
+    </message>
+    <message>
+        <source>ALL TIME</source>
+        <translation>Gesamtzeit</translation>
+    </message>
+    <message>
+        <source>PAST WEEK</source>
+        <translation>Letzte Woche</translation>
+    </message>
+    <message>
+        <source>KM</source>
+        <translation>KM</translation>
+    </message>
+    <message>
+        <source>Miles</source>
+        <translation>Meilen</translation>
+    </message>
+</context>
+<context>
     <name>DriverViewWindow</name>
     <message>
         <source>camera starting</source>

--- a/selfdrive/ui/translations/main_es.ts
+++ b/selfdrive/ui/translations/main_es.ts
@@ -276,6 +276,33 @@
     </message>
 </context>
 <context>
+    <name>DriveStats</name>
+    <message>
+        <source>Drives</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hours</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ALL TIME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PAST WEEK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>KM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Miles</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>DriverViewWindow</name>
     <message>
         <source>camera starting</source>

--- a/selfdrive/ui/translations/main_fr.ts
+++ b/selfdrive/ui/translations/main_fr.ts
@@ -276,6 +276,33 @@
     </message>
 </context>
 <context>
+    <name>DriveStats</name>
+    <message>
+        <source>Drives</source>
+        <translation>Trajets</translation>
+    </message>
+    <message>
+        <source>Hours</source>
+        <translation>Heures</translation>
+    </message>
+    <message>
+        <source>ALL TIME</source>
+        <translation>DEPUIS TOUJOURS</translation>
+    </message>
+    <message>
+        <source>PAST WEEK</source>
+        <translation>CETTE SEMAINE</translation>
+    </message>
+    <message>
+        <source>KM</source>
+        <translation>KM</translation>
+    </message>
+    <message>
+        <source>Miles</source>
+        <translation>Miles</translation>
+    </message>
+</context>
+<context>
     <name>DriverViewWindow</name>
     <message>
         <source>camera starting</source>

--- a/selfdrive/ui/translations/main_ja.ts
+++ b/selfdrive/ui/translations/main_ja.ts
@@ -276,6 +276,33 @@
     </message>
 </context>
 <context>
+    <name>DriveStats</name>
+    <message>
+        <source>Drives</source>
+        <translation>運転履歴</translation>
+    </message>
+    <message>
+        <source>Hours</source>
+        <translation>時間</translation>
+    </message>
+    <message>
+        <source>ALL TIME</source>
+        <translation>累計</translation>
+    </message>
+    <message>
+        <source>PAST WEEK</source>
+        <translation>先週</translation>
+    </message>
+    <message>
+        <source>KM</source>
+        <translation>km</translation>
+    </message>
+    <message>
+        <source>Miles</source>
+        <translation>マイル</translation>
+    </message>
+</context>
+<context>
     <name>DriverViewWindow</name>
     <message>
         <source>camera starting</source>

--- a/selfdrive/ui/translations/main_ko.ts
+++ b/selfdrive/ui/translations/main_ko.ts
@@ -276,6 +276,33 @@
     </message>
 </context>
 <context>
+    <name>DriveStats</name>
+    <message>
+        <source>Drives</source>
+        <translation>주행</translation>
+    </message>
+    <message>
+        <source>Hours</source>
+        <translation>시간</translation>
+    </message>
+    <message>
+        <source>ALL TIME</source>
+        <translation>전체</translation>
+    </message>
+    <message>
+        <source>PAST WEEK</source>
+        <translation>지난 주</translation>
+    </message>
+    <message>
+        <source>KM</source>
+        <translation>km</translation>
+    </message>
+    <message>
+        <source>Miles</source>
+        <translation>마일</translation>
+    </message>
+</context>
+<context>
     <name>DriverViewWindow</name>
     <message>
         <source>camera starting</source>

--- a/selfdrive/ui/translations/main_pt-BR.ts
+++ b/selfdrive/ui/translations/main_pt-BR.ts
@@ -276,6 +276,33 @@
     </message>
 </context>
 <context>
+    <name>DriveStats</name>
+    <message>
+        <source>Drives</source>
+        <translation>Dirigidas</translation>
+    </message>
+    <message>
+        <source>Hours</source>
+        <translation>Horas</translation>
+    </message>
+    <message>
+        <source>ALL TIME</source>
+        <translation>TOTAL</translation>
+    </message>
+    <message>
+        <source>PAST WEEK</source>
+        <translation>SEMANA PASSADA</translation>
+    </message>
+    <message>
+        <source>KM</source>
+        <translation>KM</translation>
+    </message>
+    <message>
+        <source>Miles</source>
+        <translation>Milhas</translation>
+    </message>
+</context>
+<context>
     <name>DriverViewWindow</name>
     <message>
         <source>camera starting</source>

--- a/selfdrive/ui/translations/main_th.ts
+++ b/selfdrive/ui/translations/main_th.ts
@@ -276,6 +276,33 @@
     </message>
 </context>
 <context>
+    <name>DriveStats</name>
+    <message>
+        <source>Drives</source>
+        <translation>การขับขี่</translation>
+    </message>
+    <message>
+        <source>Hours</source>
+        <translation>ชั่วโมง</translation>
+    </message>
+    <message>
+        <source>ALL TIME</source>
+        <translation>ทั้งหมด</translation>
+    </message>
+    <message>
+        <source>PAST WEEK</source>
+        <translation>สัปดาห์ที่ผ่านมา</translation>
+    </message>
+    <message>
+        <source>KM</source>
+        <translation>กิโลเมตร</translation>
+    </message>
+    <message>
+        <source>Miles</source>
+        <translation>ไมล์</translation>
+    </message>
+</context>
+<context>
     <name>DriverViewWindow</name>
     <message>
         <source>camera starting</source>

--- a/selfdrive/ui/translations/main_tr.ts
+++ b/selfdrive/ui/translations/main_tr.ts
@@ -276,6 +276,33 @@
     </message>
 </context>
 <context>
+    <name>DriveStats</name>
+    <message>
+        <source>Drives</source>
+        <translation>Sürücüler</translation>
+    </message>
+    <message>
+        <source>Hours</source>
+        <translation>Saat</translation>
+    </message>
+    <message>
+        <source>ALL TIME</source>
+        <translation>TÜM ZAMANLAR</translation>
+    </message>
+    <message>
+        <source>PAST WEEK</source>
+        <translation>GEÇEN HAFTA</translation>
+    </message>
+    <message>
+        <source>KM</source>
+        <translation>KM</translation>
+    </message>
+    <message>
+        <source>Miles</source>
+        <translation>Mil</translation>
+    </message>
+</context>
+<context>
     <name>DriverViewWindow</name>
     <message>
         <source>camera starting</source>

--- a/selfdrive/ui/translations/main_zh-CHS.ts
+++ b/selfdrive/ui/translations/main_zh-CHS.ts
@@ -276,6 +276,33 @@
     </message>
 </context>
 <context>
+    <name>DriveStats</name>
+    <message>
+        <source>Drives</source>
+        <translation>旅程数</translation>
+    </message>
+    <message>
+        <source>Hours</source>
+        <translation>小时</translation>
+    </message>
+    <message>
+        <source>ALL TIME</source>
+        <translation>全部</translation>
+    </message>
+    <message>
+        <source>PAST WEEK</source>
+        <translation>过去一周</translation>
+    </message>
+    <message>
+        <source>KM</source>
+        <translation>公里</translation>
+    </message>
+    <message>
+        <source>Miles</source>
+        <translation>英里</translation>
+    </message>
+</context>
+<context>
     <name>DriverViewWindow</name>
     <message>
         <source>camera starting</source>

--- a/selfdrive/ui/translations/main_zh-CHT.ts
+++ b/selfdrive/ui/translations/main_zh-CHT.ts
@@ -276,6 +276,33 @@
     </message>
 </context>
 <context>
+    <name>DriveStats</name>
+    <message>
+        <source>Drives</source>
+        <translation>旅程</translation>
+    </message>
+    <message>
+        <source>Hours</source>
+        <translation>小時</translation>
+    </message>
+    <message>
+        <source>ALL TIME</source>
+        <translation>總共</translation>
+    </message>
+    <message>
+        <source>PAST WEEK</source>
+        <translation>上週</translation>
+    </message>
+    <message>
+        <source>KM</source>
+        <translation>公里</translation>
+    </message>
+    <message>
+        <source>Miles</source>
+        <translation>英里</translation>
+    </message>
+</context>
+<context>
     <name>DriverViewWindow</name>
     <message>
         <source>camera starting</source>


### PR DESCRIPTION
## Summary by Sourcery

Add drive stats to the offroad home screen.

New Features:
- Display drive stats on the offroad home screen, including total drives, distance, and hours driven, for both all time and the past week.

Updates:
- Moved comma Prime status widget above the Wi-Fi setup widget.
- Removed comma Prime ads for drive stats.