### PR TITLE
ui: deprecate `RETURN_IF_SUNNYPILOT` macro and cleanup

### DIFF
--- a/selfdrive/ui/qt/home.cc
+++ b/selfdrive/ui/qt/home.cc
@@ -3,9 +3,7 @@
 #include <QHBoxLayout>
 #include <QMouseEvent>
 
-#include "selfdrive/ui/qt/offroad/experimental_mode.h"
 #include "selfdrive/ui/qt/util.h"
-#include "selfdrive/ui/qt/widgets/prime.h"
 
 // HomeWindow: the container for the offroad and onroad UIs
 

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -356,8 +356,7 @@ void SettingsWindow::setCurrentPanel(int index, const QString &param) {
 }
 
 SettingsWindow::SettingsWindow(QWidget *parent) : QFrame(parent) {
-  RETURN_IF_SUNNYPILOT
-
+#ifndef SUNNYPILOT
   // setup two main layouts
   sidebar_widget = new QWidget;
   QVBoxLayout *sidebar_layout = new QVBoxLayout(sidebar_widget);
@@ -457,4 +456,5 @@ SettingsWindow::SettingsWindow(QWidget *parent) : QFrame(parent) {
       border-radius: 30px;
     }
   )");
+#endif
 }

--- a/selfdrive/ui/qt/util.h
+++ b/selfdrive/ui/qt/util.h
@@ -13,12 +13,6 @@
 #include "cereal/gen/cpp/car.capnp.h"
 #include "common/params.h"
 
-#ifdef SUNNYPILOT
-#define RETURN_IF_SUNNYPILOT return;
-#else
-#define RETURN_IF_SUNNYPILOT  // Do nothing
-#endif
-
 QString getVersion();
 QString getBrand();
 QString getUserAgent();

--- a/selfdrive/ui/qt/widgets/controls.cc
+++ b/selfdrive/ui/qt/widgets/controls.cc
@@ -6,7 +6,7 @@
 #include "selfdrive/ui/qt/util.h"
 
 AbstractControl::AbstractControl(const QString &title, const QString &desc, const QString &icon, QWidget *parent) : QFrame(parent) {
-  RETURN_IF_SUNNYPILOT
+#ifndef SUNNYPILOT
   QVBoxLayout *main_layout = new QVBoxLayout(this);
   main_layout->setMargin(0);
 
@@ -57,6 +57,7 @@ AbstractControl::AbstractControl(const QString &title, const QString &desc, cons
   });
 
   main_layout->addStretch();
+#endif
 }
 
 void AbstractControl::hideEvent(QHideEvent *e) {

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -111,15 +111,16 @@ UIState::UIState(QObject *parent) : QObject(parent) {
   prime_state = new PrimeState(this);
   language = QString::fromStdString(Params().get("LanguageSetting"));
 
-  RETURN_IF_SUNNYPILOT
+#ifndef SUNNYPILOT
   // update timer
   timer = new QTimer(this);
   QObject::connect(timer, &QTimer::timeout, this, &UIState::update);
   timer->start(1000 / UI_FREQ);
+#endif
 }
 
 void UIState::update() {
-  RETURN_IF_SUNNYPILOT
+#ifndef SUNNYPILOT
   update_sockets(this);
   update_state(this);
   updateStatus();
@@ -128,6 +129,7 @@ void UIState::update() {
     watchdog_kick(nanos_since_boot());
   }
   emit uiUpdate(*this);
+#endif
 }
 
 Device::Device(QObject *parent) : brightness_filter(BACKLIGHT_OFFROAD, BACKLIGHT_TS, BACKLIGHT_DT), QObject(parent) {


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Remove Sunnypilot remnants.