### PR TITLE
CI: Increase test report creation timeout and improve build times

### DIFF
--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -352,7 +352,7 @@ jobs:
       - name: Build openpilot
         run: ${{ env.RUN }} "scons -j$(nproc)"
       - name: Create Test Report
-        timeout-minutes: ${{ ((steps.frames-cache.outputs.cache-hit == 'true') && 1 || 3) }}
+        timeout-minutes: ${{ ((steps.frames-cache.outputs.cache-hit == 'true') && 2 || 4) }}
         run: >
             ${{ env.RUN }} "PYTHONWARNINGS=ignore &&
                             source selfdrive/test/setup_xvfb.sh &&

--- a/.github/workflows/sunnypilot-build-model.yaml
+++ b/.github/workflows/sunnypilot-build-model.yaml
@@ -38,11 +38,12 @@ jobs:
           path: ${{env.SCONS_CACHE_DIR}}
           key: scons-${{ runner.os }}-${{ runner.arch }}-${{ github.head_ref || github.ref_name }}-model-${{ github.sha }}
           restore-keys: |
-            scons-${{ runner.os }}-${{ runner.arch }}-${{ github.head_ref || github.ref_name }}-model-${{ github.sha }}
             scons-${{ runner.os }}-${{ runner.arch }}-${{ github.head_ref || github.ref_name }}-model
             scons-${{ runner.os }}-${{ runner.arch }}-${{ github.head_ref || github.ref_name }}
-            scons-${{ runner.os }}-${{ runner.arch }}-master-new
-            scons-${{ runner.os }}-${{ runner.arch }}-master
+            scons-${{ runner.os }}-${{ runner.arch }}-${{ env.MASTER_NEW_BRANCH }}-model
+            scons-${{ runner.os }}-${{ runner.arch }}-${{ env.MASTER_BRANCH }}-model
+            scons-${{ runner.os }}-${{ runner.arch }}-${{ env.MASTER_NEW_BRANCH }}
+            scons-${{ runner.os }}-${{ runner.arch }}-${{ env.MASTER_BRANCH }}
             scons-${{ runner.os }}-${{ runner.arch }}
 
       - name: Setup build environment

--- a/.github/workflows/sunnypilot-build-model.yaml
+++ b/.github/workflows/sunnypilot-build-model.yaml
@@ -37,6 +37,8 @@ jobs:
         with:
           path: ${{env.SCONS_CACHE_DIR}}
           key: scons-${{ runner.os }}-${{ runner.arch }}-${{ github.head_ref || github.ref_name }}-model-${{ github.sha }}
+          # Note: GitHub Actions enforces cache isolation between different build sources (PR builds, workflow dispatches, etc.) 
+          #   for security. Only caches from the default branch are shared across all builds. This is by design and cannot be overridden.
           restore-keys: |
             scons-${{ runner.os }}-${{ runner.arch }}-${{ github.head_ref || github.ref_name }}-model
             scons-${{ runner.os }}-${{ runner.arch }}-${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -52,8 +52,7 @@ jobs:
           path: ${{env.SCONS_CACHE_DIR}}
           key: scons-${{ runner.os }}-${{ runner.arch }}-${{ github.head_ref || github.ref_name }}-${{ github.sha }}
           restore-keys: |
-            scons-${{ runner.os }}-${{ runner.arch }}-${{ github.head_ref }}
-            scons-${{ runner.os }}-${{ runner.arch }}-${{ github.ref_name }}
+            scons-${{ runner.os }}-${{ runner.arch }}-${{ github.head_ref || github.ref_name }}
             scons-${{ runner.os }}-${{ runner.arch }}-${{ env.MASTER_NEW_BRANCH }}
             scons-${{ runner.os }}-${{ runner.arch }}-${{ env.MASTER_BRANCH }}
             scons-${{ runner.os }}-${{ runner.arch }}

--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -119,6 +119,7 @@ jobs:
           if [[ "${{ runner.debug }}" == "1" ]]; then
             printenv
           fi
+          ${{ github.workspace }}/scripts/disable-powersave.py
 
       - name: Build Panda
         run: |

--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -119,7 +119,7 @@ jobs:
           if [[ "${{ runner.debug }}" == "1" ]]; then
             printenv
           fi
-          PYTHONPATH=$PYTHONPATH:${{ github.workspace }}/ ${{ github.workspace }}/scripts/disable-powersave.py
+          PYTHONPATH=$PYTHONPATH:${{ github.workspace }}/ ${{ github.workspace }}/scripts/manage-powersave.py --disable
 
       - name: Build Panda
         run: |
@@ -187,6 +187,11 @@ jobs:
         with:
           name: prebuilt
           path: prebuilt.tar.gz
+
+      - name: Re-enable powersave
+        if: always()
+        run: |
+          PYTHONPATH=$PYTHONPATH:${{ github.workspace }}/ ${{ github.workspace }}/scripts/manage-powersave.py --enable
 
   publish:
     concurrency:

--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -51,6 +51,8 @@ jobs:
         with:
           path: ${{env.SCONS_CACHE_DIR}}
           key: scons-${{ runner.os }}-${{ runner.arch }}-${{ github.head_ref || github.ref_name }}-${{ github.sha }}
+          # Note: GitHub Actions enforces cache isolation between different build sources (PR builds, workflow dispatches, etc.) 
+          #   for security. Only caches from the default branch are shared across all builds. This is by design and cannot be overridden.
           restore-keys: |
             scons-${{ runner.os }}-${{ runner.arch }}-${{ github.head_ref || github.ref_name }}
             scons-${{ runner.os }}-${{ runner.arch }}-${{ env.MASTER_NEW_BRANCH }}

--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -119,7 +119,7 @@ jobs:
           if [[ "${{ runner.debug }}" == "1" ]]; then
             printenv
           fi
-          ${{ github.workspace }}/scripts/disable-powersave.py
+          PYTHONPATH=$PYTHONPATH:${{ github.workspace }}/ ${{ github.workspace }}/scripts/disable-powersave.py
 
       - name: Build Panda
         run: |

--- a/scripts/manage-powersave.py
+++ b/scripts/manage-powersave.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+import argparse
+from openpilot.system.hardware import HARDWARE
+
+
+def main():
+  parser = argparse.ArgumentParser(description='Control power saving mode')
+  parser.add_argument('--enable', action='store_true', help='Enable power saving mode')
+  parser.add_argument('--disable', action='store_true', help='Disable power saving mode')
+  args = parser.parse_args()
+
+  if args.enable and args.disable:
+    parser.error("Cannot specify both --enable and --disable")
+  elif not (args.enable or args.disable):
+    parser.error("Must specify either --enable or --disable")
+
+  HARDWARE.set_power_save(args.enable)
+
+
+if __name__ == "__main__":
+  main()

--- a/scripts/manage-powersave.py
+++ b/scripts/manage-powersave.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+import multiprocessing
 from openpilot.system.hardware import HARDWARE
 
 
@@ -15,6 +16,11 @@ def main():
     parser.error("Must specify either --enable or --disable")
 
   HARDWARE.set_power_save(args.enable)
+
+  cpu_count = multiprocessing.cpu_count()
+  state = "enabled" if args.enable else "disabled"
+  print(f"Power save mode [{state}]")
+  print(f"Number of CPU cores available: [{cpu_count}]")
 
 
 if __name__ == "__main__":

--- a/scripts/manage-powersave.py
+++ b/scripts/manage-powersave.py
@@ -15,12 +15,12 @@ def main():
   elif not (args.enable or args.disable):
     parser.error("Must specify either --enable or --disable")
 
+  print(f"Number of CPU cores available before: [{multiprocessing.cpu_count()}]")
   HARDWARE.set_power_save(args.enable)
 
-  cpu_count = multiprocessing.cpu_count()
   state = "enabled" if args.enable else "disabled"
-  print(f"Power save mode [{state}]")
-  print(f"Number of CPU cores available: [{cpu_count}]")
+  print(f"Power save mode set to: [{state}]")
+  print(f"Number of CPU cores available now: [{multiprocessing.cpu_count()}]")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adjusted the `timeout-minutes` value to allow more time for the test report creation step.

## Summary by Sourcery

Increase the timeout for the test report creation step in the CI, and add a script to manage powersave mode.

New Features:
- Add a script to manage powersave mode during CI.

CI:
- Increase the timeout for the test report creation step.