### PR TITLE
Revert "ci: generate Trips settings panel for ui preview"

### DIFF
--- a/selfdrive/ui/tests/test_ui/run.py
+++ b/selfdrive/ui/tests/test_ui/run.py
@@ -231,7 +231,6 @@ CASES.update({
   "settings_sunnylink": setup_settings_sunnylink,
   "settings_sunnypilot": setup_settings_sunnypilot,
   "settings_sunnypilot_mads": setup_settings_sunnypilot_mads,
-  "settings_trips": setup_settings_trips,
 })
 
 TEST_DIR = pathlib.Path(__file__).parent


### PR DESCRIPTION
Reverts sunnypilot/sunnypilot#546

## Summary by Sourcery

CI:
- Revert the generation of the Trips settings panel for the UI preview.