### PR TITLE
MADS: Filter disengage events without lateral control impact

### DIFF
--- a/sunnypilot/mads/mads.py
+++ b/sunnypilot/mads/mads.py
@@ -124,6 +124,9 @@ class ModularAssistiveDrivingSystem:
           self.events.add(EventName.silentLkasEnable)
 
       self.events.remove(EventName.preEnableStandstill)
+      self.events.remove(EventName.belowEngageSpeed)
+      self.events.remove(EventName.speedTooLow)
+      self.events.remove(EventName.cruiseDisabled)
 
     if self.events.has(EventName.pcmEnable) or self.events.has(EventName.buttonEnable):
       update_unified_engagement_mode()


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Removed `belowEngageSpeed`, `speedTooLow`, `cruiseDisabled`, and `preEnableStandstill` events from the `transition_paused_state` function.