### PR TITLE
TSK Keyboard

### DIFF
--- a/selfdrive/ui/SConscript
+++ b/selfdrive/ui/SConscript
@@ -24,7 +24,7 @@ qt_env['CXXFLAGS'] += ["-Wno-deprecated-declarations"]
 
 qt_util = qt_env.Library("qt_util", ["#selfdrive/ui/qt/api.cc", "#selfdrive/ui/qt/util.cc"] + sp_qt_util, LIBS=base_libs)
 widgets_src = ["qt/widgets/input.cc", "qt/widgets/wifi.cc", "qt/prime_state.cc",
-               "qt/widgets/ssh_keys.cc", "qt/widgets/toggle.cc", "qt/widgets/controls.cc",
+               "qt/widgets/ssh_keys.cc", "qt/widgets/toggle.cc", "qt/widgets/tsk_keyboard.cc", "qt/widgets/controls.cc",
                "qt/widgets/offroad_alerts.cc", "qt/widgets/prime.cc", "qt/widgets/keyboard.cc",
                "qt/widgets/scrollview.cc", "qt/widgets/cameraview.cc", "#third_party/qrcode/QrCode.cc",
                "qt/request_repeater.cc", "qt/qt_window.cc", "qt/network/networking.cc", "qt/network/wifi_manager.cc"] + sp_widgets_src

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -14,6 +14,7 @@
 #include "selfdrive/ui/qt/qt_window.h"
 #include "selfdrive/ui/qt/widgets/prime.h"
 #include "selfdrive/ui/qt/widgets/scrollview.h"
+#include "selfdrive/ui/qt/widgets/tsk_keyboard.h"
 #include "selfdrive/ui/qt/offroad/developer_panel.h"
 
 TogglesPanel::TogglesPanel(SettingsWindow *parent) : ListWidget(parent) {
@@ -204,6 +205,8 @@ DevicePanel::DevicePanel(SettingsWindow *parent) : ListWidget(parent) {
   addItem(pair_device);
 
   // offroad-only buttons
+
+  addItem(new TSKKeyboard());
 
   auto dcamBtn = new ButtonControl(tr("Driver Camera"), tr("PREVIEW"),
                                    tr("Preview the driver facing camera to ensure that driver monitoring has good visibility. (vehicle must be off)"));

--- a/selfdrive/ui/qt/widgets/tsk_keyboard.cc
+++ b/selfdrive/ui/qt/widgets/tsk_keyboard.cc
@@ -1,0 +1,95 @@
+#include "selfdrive/ui/qt/widgets/tsk_keyboard.h"
+
+#include "common/params.h"
+#include "selfdrive/ui/qt/api.h"
+#include "selfdrive/ui/qt/widgets/input.h"
+
+TSKKeyboard::TSKKeyboard() :
+  ButtonControl("TSK Keyboard (tap to see installed)", "INSTALL", "") {
+
+  QObject::connect(this, &ButtonControl::clicked, [=]() {
+    setEnabled(false);
+
+    QString installed = QString::fromStdString(params.get("SecOCKey"));
+    QString archived = getArchive();
+
+    QString defaultText = "";
+    if (installed.length()) {
+      // Currently installed is the preferred default text
+      defaultText = installed;
+    } else if (archived.length()) {
+      // Else, use the archived key if exists
+      defaultText = archived;
+    }
+
+    // Show the archived key as a hint
+    QString subtitle = "";
+    if (archived.length()) {
+      subtitle = QString("Archived key: ") +  archived;
+    }
+
+    QString key = InputDialog::getText("Enter your Toyota Security Key", this, subtitle, false, 32, defaultText);
+    if (key.length() != 0) {
+      if (isValid(key)) {
+        params.put("SecOCKey", key.toStdString());
+      } else {
+        ConfirmationDialog::alert(tr("Invalid key: %1").arg(key), this);
+      }
+    }
+
+    refresh(); // Live update
+  });
+
+  refresh(); // Initial draw
+}
+
+void TSKKeyboard::refresh() {
+  QString key = QString::fromStdString(params.get("SecOCKey"));
+  if (!key.length()) {
+    key = "Not Installed";
+  }
+  setDescription(key);
+  setEnabled(true);
+}
+
+QString TSKKeyboard::getArchive() {
+  QFile archiveFile("/persist/tsk/key");
+
+  // Archived key file doesn't exist
+  if (!archiveFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
+    return "";
+  }
+
+  QTextStream in(&archiveFile);
+  QString key = in.readAll();
+  archiveFile.close();
+
+  // Archived key file can't be read
+  if (in.status() != QTextStream::Ok) {
+    return "";
+  }
+
+  // Archived key is not a valid key
+  if (!isValid(key)) {
+    return "";
+  }
+
+  // Return the key
+  return key;
+}
+
+// Check if the key is a 32 characters long hexadecimal string
+bool TSKKeyboard::isValid(QString key) {
+  if (key.length() != 32) {
+    return false;
+  }
+
+  // Check if each character is a valid hexadecimal digit (0-9, a-f)
+  for (QChar c : key) {
+    if (!c.isDigit() && !(c.isLower() && c >= 'a' && c <= 'f')) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/selfdrive/ui/qt/widgets/tsk_keyboard.h
+++ b/selfdrive/ui/qt/widgets/tsk_keyboard.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <QPushButton>
+#include <QFile>
+
+#include "system/hardware/hw.h"
+
+#ifdef SUNNYPILOT
+#include "selfdrive/ui/sunnypilot/qt/widgets/controls.h"
+#define ButtonControl ButtonControlSP
+#define ToggleControl ToggleControlSP
+#else
+#include "selfdrive/ui/qt/widgets/controls.h"
+#endif
+
+class TSKKeyboard : public ButtonControl {
+  Q_OBJECT
+
+public:
+  TSKKeyboard();
+
+private:
+  Params params;
+
+  QString getArchive();
+  bool isValid(QString);
+  void refresh();
+};


### PR DESCRIPTION
This PR has a significantly reduced scope as compared to #536 .

1. It doesn't include the extractor.
2. And thus it doesn't kill the openpilot process.
3. The button is in the offroad-only section, so it's only ever useful while the car is off.
4. It simply shows and hides the keyboard (in reality it's a full screen app run & exit).
5. The keyboard reads from `/persist/tsk/key` but only ever writes to `/data/params/d/SecOCKey`.

This feature is useful for those who have already extracted the key, either through SSH or by using a standalone TSK Manager. It allows such people to install SP and easily enter the security key without using SSH.

## Summary by Sourcery

New Features:
- A TSK keyboard is added to the offroad settings screen to allow users to enter their security key without SSH.

## Summary by Sourcery

Add a TSK keyboard to the offroad settings screen to allow users to enter their security key without SSH.

New Features:
- Added a TSK keyboard in the offroad settings.

Tests:
- Added tests for the TSK keyboard.