### PR TITLE
ui: Hide regulatory button on non-comma devices

### DIFF
--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/device_panel.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/device_panel.cc
@@ -24,10 +24,21 @@ DevicePanelSP::DevicePanelSP(SettingsWindowSP *parent) : DevicePanel(parent) {
     {"translateBtn", tr("Language")},
   };
 
+  int row = 0, col = 0;
   for (int i = 0; i < device_btns.size(); i++) {
+    if (device_btns[i].first == "regulatoryBtn" && !Hardware::TICI()) {
+      continue;
+    }
+
     auto *btn = new PushButtonSP(device_btns[i].second, 720, this);
-    device_grid_layout->addWidget(btn, i / 2, i % 2);
+    device_grid_layout->addWidget(btn, row, col);
     buttons[device_btns[i].first] = btn;
+
+    col++;
+    if (col > 1) {
+      col = 0;
+      row++;
+    }
   }
 
   connect(buttons["dcamBtn"], &PushButtonSP::clicked, [this]() {
@@ -48,8 +59,6 @@ DevicePanelSP::DevicePanelSP(SettingsWindowSP *parent) : DevicePanel(parent) {
       const std::string txt = util::read_file("../assets/offroad/fcc.html");
       ConfirmationDialog::rich(QString::fromStdString(txt), this);
     });
-  } else {
-    buttons["regulatoryBtn"]->setEnabled(false);
   }
 
   connect(buttons["translateBtn"], &PushButtonSP::clicked, [=]() {


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Bug Fixes:
- Removed the regulatory button on non-comma devices to avoid confusion.