### PR TITLE
MADS: Honda: controls, events, and cluster updates

### DIFF
--- a/selfdrive/car/car_specific.py
+++ b/selfdrive/car/car_specific.py
@@ -71,18 +71,18 @@ class CarSpecificEvents:
       if self.CP.pcmCruise and CS.vEgo < self.CP.minEnableSpeed:
         events.add(EventName.belowEngageSpeed)
 
-      if self.CP.pcmCruise:
-        # we engage when pcm is active (rising edge)
-        if CS.cruiseState.enabled and not CS_prev.cruiseState.enabled:
-          events.add(EventName.pcmEnable)
-        elif not CS.cruiseState.enabled and (CC.actuators.accel >= 0. or not self.CP.openpilotLongitudinalControl):
-          # it can happen that car cruise disables while comma system is enabled: need to
-          # keep braking if needed or if the speed is very low
-          if CS.vEgo < self.CP.minEnableSpeed + 2.:
-            # non loud alert if cruise disables below 25mph as expected (+ a little margin)
-            events.add(EventName.speedTooLow)
-          else:
-            events.add(EventName.cruiseDisabled)
+      # if self.CP.pcmCruise:
+      #   # we engage when pcm is active (rising edge)
+      #   if CS.cruiseState.enabled and not CS_prev.cruiseState.enabled:
+      #     events.add(EventName.pcmEnable)
+      #   elif not CS.cruiseState.enabled and (CC.actuators.accel >= 0. or not self.CP.openpilotLongitudinalControl):
+      #     # it can happen that car cruise disables while comma system is enabled: need to
+      #     # keep braking if needed or if the speed is very low
+      #     if CS.vEgo < self.CP.minEnableSpeed + 2.:
+      #       # non loud alert if cruise disables below 25mph as expected (+ a little margin)
+      #       events.add(EventName.speedTooLow)
+      #     else:
+      #       events.add(EventName.cruiseDisabled)
       if self.CP.minEnableSpeed > 0 and CS.vEgo < 0.001:
         events.add(EventName.manualRestart)
 

--- a/selfdrive/car/car_specific.py
+++ b/selfdrive/car/car_specific.py
@@ -71,18 +71,18 @@ class CarSpecificEvents:
       if self.CP.pcmCruise and CS.vEgo < self.CP.minEnableSpeed:
         events.add(EventName.belowEngageSpeed)
 
-      # if self.CP.pcmCruise:
-      #   # we engage when pcm is active (rising edge)
-      #   if CS.cruiseState.enabled and not CS_prev.cruiseState.enabled:
-      #     events.add(EventName.pcmEnable)
-      #   elif not CS.cruiseState.enabled and (CC.actuators.accel >= 0. or not self.CP.openpilotLongitudinalControl):
-      #     # it can happen that car cruise disables while comma system is enabled: need to
-      #     # keep braking if needed or if the speed is very low
-      #     if CS.vEgo < self.CP.minEnableSpeed + 2.:
-      #       # non loud alert if cruise disables below 25mph as expected (+ a little margin)
-      #       events.add(EventName.speedTooLow)
-      #     else:
-      #       events.add(EventName.cruiseDisabled)
+      if self.CP.pcmCruise:
+        # we engage when pcm is active (rising edge)
+        if CS.cruiseState.enabled and not CS_prev.cruiseState.enabled:
+          events.add(EventName.pcmEnable)
+        elif not CS.cruiseState.enabled and (CC.actuators.accel >= 0. or not self.CP.openpilotLongitudinalControl):
+          # it can happen that car cruise disables while comma system is enabled: need to
+          # keep braking if needed or if the speed is very low
+          if CS.vEgo < self.CP.minEnableSpeed + 2.:
+            # non loud alert if cruise disables below 25mph as expected (+ a little margin)
+            events.add(EventName.speedTooLow)
+          else:
+            events.add(EventName.cruiseDisabled)
       if self.CP.minEnableSpeed > 0 and CS.vEgo < 0.001:
         events.add(EventName.manualRestart)
 

--- a/sunnypilot/mads/mads.py
+++ b/sunnypilot/mads/mads.py
@@ -124,9 +124,11 @@ class ModularAssistiveDrivingSystem:
           self.events.add(EventName.silentLkasEnable)
 
       self.events.remove(EventName.preEnableStandstill)
+    elif not self.selfdrive.enabled:
       self.events.remove(EventName.belowEngageSpeed)
       self.events.remove(EventName.speedTooLow)
       self.events.remove(EventName.cruiseDisabled)
+      self.events.remove(EventName.manualRestart)
 
     if self.events.has(EventName.pcmEnable) or self.events.has(EventName.buttonEnable):
       update_unified_engagement_mode()

--- a/sunnypilot/mads/mads.py
+++ b/sunnypilot/mads/mads.py
@@ -124,7 +124,6 @@ class ModularAssistiveDrivingSystem:
           self.events.add(EventName.silentLkasEnable)
 
       self.events.remove(EventName.preEnableStandstill)
-    elif not self.selfdrive.enabled:
       self.events.remove(EventName.belowEngageSpeed)
       self.events.remove(EventName.speedTooLow)
       self.events.remove(EventName.cruiseDisabled)


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Update the logic for removing certain events in MADS. Remove preEnableStandstill, belowEngageSpeed, speedTooLow, and cruiseDisabled events when transitioning from paused state.  If selfdrive is not enabled, also remove manualRestart event.