### PR TITLE
ui: display DEC status via mode button

### DIFF
--- a/selfdrive/ui/qt/onroad/annotated_camera.h
+++ b/selfdrive/ui/qt/onroad/annotated_camera.h
@@ -2,14 +2,16 @@
 
 #include <QVBoxLayout>
 #include <memory>
-#include "selfdrive/ui/qt/onroad/buttons.h"
 #include "selfdrive/ui/qt/onroad/driver_monitoring.h"
 #include "selfdrive/ui/qt/onroad/model.h"
 #include "selfdrive/ui/qt/widgets/cameraview.h"
 
 #ifdef SUNNYPILOT
+#include "selfdrive/ui/sunnypilot/qt/onroad/buttons.h"
 #include "selfdrive/ui/sunnypilot/qt/onroad/hud.h"
+#define ExperimentalButton ExperimentalButtonSP
 #else
+#include "selfdrive/ui/qt/onroad/buttons.h"
 #include "selfdrive/ui/qt/onroad/hud.h"
 #endif
 

--- a/selfdrive/ui/qt/onroad/buttons.cc
+++ b/selfdrive/ui/qt/onroad/buttons.cc
@@ -61,10 +61,10 @@ void ExperimentalButton::paintEvent(QPaintEvent *event) {
 
     QPainter combined_painter(&combined_img);
 
-    combined_painter.setOpacity(dec_mpc_mode == 1 ? 0.2 : 1.0);
+    combined_painter.setOpacity(dec_mpc_mode == 1 ? 0.1 : 1.0);
     combined_painter.drawPixmap(0, 0, left_half);
 
-    combined_painter.setOpacity(dec_mpc_mode == 1 ? 1.0 : 0.2);
+    combined_painter.setOpacity(dec_mpc_mode == 1 ? 1.0 : 0.1);
     combined_painter.drawPixmap(engage_img.width() / 2, 0, right_half);
 
     combined_painter.end();

--- a/selfdrive/ui/qt/onroad/buttons.cc
+++ b/selfdrive/ui/qt/onroad/buttons.cc
@@ -42,8 +42,10 @@ void ExperimentalButton::updateState(const UIState &s) {
     update();
   }
 
-  if (long_plan_sp.getDec().getEnabled() != dynamic_experimental_control) {
+  int mode = int(long_plan_sp.getDec().getState());
+  if ((long_plan_sp.getDec().getEnabled() != dynamic_experimental_control) || (mode != dec_mpc_mode)) {
     dynamic_experimental_control = long_plan_sp.getDec().getEnabled();
+    dec_mpc_mode = mode;
     update();
   }
 }
@@ -58,8 +60,13 @@ void ExperimentalButton::paintEvent(QPaintEvent *event) {
     combined_img.fill(Qt::transparent);
 
     QPainter combined_painter(&combined_img);
+
+    combined_painter.setOpacity(dec_mpc_mode == 1 ? 0.6 : 1.0);
     combined_painter.drawPixmap(0, 0, left_half);
+
+    combined_painter.setOpacity(dec_mpc_mode == 1 ? 1.0 : 0.6);
     combined_painter.drawPixmap(engage_img.width() / 2, 0, right_half);
+
     combined_painter.end();
 
     drawIcon(p, QPoint(btn_size / 2, btn_size / 2), combined_img, QColor(0, 0, 0, 166), (isDown() || !engageable) ? 0.6 : 1.0);

--- a/selfdrive/ui/qt/onroad/buttons.cc
+++ b/selfdrive/ui/qt/onroad/buttons.cc
@@ -34,16 +34,32 @@ void ExperimentalButton::changeMode() {
 
 void ExperimentalButton::updateState(const UIState &s) {
   const auto cs = (*s.sm)["selfdriveState"].getSelfdriveState();
+  const auto long_plan_sp = (*s.sm)["longitudinalPlanSP"].getLongitudinalPlanSP();
   bool eng = cs.getEngageable() || cs.getEnabled();
   if ((cs.getExperimentalMode() != experimental_mode) || (eng != engageable)) {
     engageable = eng;
     experimental_mode = cs.getExperimentalMode();
     update();
   }
+
+  if (long_plan_sp.getDec().getEnabled() != dynamic_experimental_control) {
+    dynamic_experimental_control = long_plan_sp.getDec().getEnabled();
+    update();
+  }
 }
 
 void ExperimentalButton::paintEvent(QPaintEvent *event) {
   QPainter p(this);
-  QPixmap img = experimental_mode ? experimental_img : engage_img;
-  drawIcon(p, QPoint(btn_size / 2, btn_size / 2), img, QColor(0, 0, 0, 166), (isDown() || !engageable) ? 0.6 : 1.0);
+  if (dynamic_experimental_control) {
+    QRect leftRect(0, 0, btn_size / 2, btn_size);
+    QRect rightRect(btn_size / 2, 0, btn_size / 2, btn_size);
+
+    p.setOpacity((isDown() || !engageable) ? 0.6 : 1.0);
+    p.drawPixmap(leftRect, engage_img);
+
+    p.drawPixmap(rightRect, experimental_img);
+  } else {
+    QPixmap img = experimental_mode ? experimental_img : engage_img;
+    drawIcon(p, QPoint(btn_size / 2, btn_size / 2), img, QColor(0, 0, 0, 166), (isDown() || !engageable) ? 0.6 : 1.0);
+  }
 }

--- a/selfdrive/ui/qt/onroad/buttons.cc
+++ b/selfdrive/ui/qt/onroad/buttons.cc
@@ -51,13 +51,18 @@ void ExperimentalButton::updateState(const UIState &s) {
 void ExperimentalButton::paintEvent(QPaintEvent *event) {
   QPainter p(this);
   if (dynamic_experimental_control) {
-    QRect leftRect(0, 0, btn_size / 2, btn_size);
-    QRect rightRect(btn_size / 2, 0, btn_size / 2, btn_size);
+    QPixmap left_half = engage_img.copy(0, 0, engage_img.width() / 2, engage_img.height());
+    QPixmap right_half = experimental_img.copy(experimental_img.width() / 2, 0, experimental_img.width() / 2, experimental_img.height());
 
-    p.setOpacity((isDown() || !engageable) ? 0.6 : 1.0);
-    p.drawPixmap(leftRect, engage_img);
+    QPixmap combined_img(engage_img.width(), engage_img.height());
+    combined_img.fill(Qt::transparent);
 
-    p.drawPixmap(rightRect, experimental_img);
+    QPainter combined_painter(&combined_img);
+    combined_painter.drawPixmap(0, 0, left_half);
+    combined_painter.drawPixmap(engage_img.width() / 2, 0, right_half);
+    combined_painter.end();
+
+    drawIcon(p, QPoint(btn_size / 2, btn_size / 2), combined_img, QColor(0, 0, 0, 166), (isDown() || !engageable) ? 0.6 : 1.0);
   } else {
     QPixmap img = experimental_mode ? experimental_img : engage_img;
     drawIcon(p, QPoint(btn_size / 2, btn_size / 2), img, QColor(0, 0, 0, 166), (isDown() || !engageable) ? 0.6 : 1.0);

--- a/selfdrive/ui/qt/onroad/buttons.cc
+++ b/selfdrive/ui/qt/onroad/buttons.cc
@@ -34,18 +34,10 @@ void ExperimentalButton::changeMode() {
 
 void ExperimentalButton::updateState(const UIState &s) {
   const auto cs = (*s.sm)["selfdriveState"].getSelfdriveState();
-  const auto long_plan_sp = (*s.sm)["longitudinalPlanSP"].getLongitudinalPlanSP();
   bool eng = cs.getEngageable() || cs.getEnabled();
   if ((cs.getExperimentalMode() != experimental_mode) || (eng != engageable)) {
     engageable = eng;
     experimental_mode = cs.getExperimentalMode();
-    update();
-  }
-
-  int mode = int(long_plan_sp.getDec().getState());
-  if ((long_plan_sp.getDec().getActive() != dynamic_experimental_control) || (mode != dec_mpc_mode)) {
-    dynamic_experimental_control = long_plan_sp.getDec().getActive();
-    dec_mpc_mode = mode;
     update();
   }
 }
@@ -56,26 +48,6 @@ void ExperimentalButton::paintEvent(QPaintEvent *event) {
 }
 
 void ExperimentalButton::drawButton(QPainter &p) {
-  if (dynamic_experimental_control) {
-    QPixmap left_half = engage_img.copy(0, 0, engage_img.width() / 2, engage_img.height());
-    QPixmap right_half = experimental_img.copy(experimental_img.width() / 2, 0, experimental_img.width() / 2, experimental_img.height());
-
-    QPixmap combined_img(engage_img.width(), engage_img.height());
-    combined_img.fill(Qt::transparent);
-
-    QPainter combined_painter(&combined_img);
-
-    combined_painter.setOpacity(dec_mpc_mode == 1 ? 0.1 : 1.0);
-    combined_painter.drawPixmap(0, 0, left_half);
-
-    combined_painter.setOpacity(dec_mpc_mode == 1 ? 1.0 : 0.1);
-    combined_painter.drawPixmap(engage_img.width() / 2, 0, right_half);
-
-    combined_painter.end();
-
-    drawIcon(p, QPoint(btn_size / 2, btn_size / 2), combined_img, QColor(0, 0, 0, 166), (isDown() || !engageable) ? 0.6 : 1.0);
-  } else {
-    QPixmap img = experimental_mode ? experimental_img : engage_img;
-    drawIcon(p, QPoint(btn_size / 2, btn_size / 2), img, QColor(0, 0, 0, 166), (isDown() || !engageable) ? 0.6 : 1.0);
-  }
+  QPixmap img = experimental_mode ? experimental_img : engage_img;
+  drawIcon(p, QPoint(btn_size / 2, btn_size / 2), img, QColor(0, 0, 0, 166), (isDown() || !engageable) ? 0.6 : 1.0);
 }

--- a/selfdrive/ui/qt/onroad/buttons.cc
+++ b/selfdrive/ui/qt/onroad/buttons.cc
@@ -52,6 +52,10 @@ void ExperimentalButton::updateState(const UIState &s) {
 
 void ExperimentalButton::paintEvent(QPaintEvent *event) {
   QPainter p(this);
+  drawButton(p);
+}
+
+void ExperimentalButton::drawButton(QPainter &p) {
   if (dynamic_experimental_control) {
     QPixmap left_half = engage_img.copy(0, 0, engage_img.width() / 2, engage_img.height());
     QPixmap right_half = experimental_img.copy(experimental_img.width() / 2, 0, experimental_img.width() / 2, experimental_img.height());

--- a/selfdrive/ui/qt/onroad/buttons.cc
+++ b/selfdrive/ui/qt/onroad/buttons.cc
@@ -43,8 +43,8 @@ void ExperimentalButton::updateState(const UIState &s) {
   }
 
   int mode = int(long_plan_sp.getDec().getState());
-  if ((long_plan_sp.getDec().getEnabled() != dynamic_experimental_control) || (mode != dec_mpc_mode)) {
-    dynamic_experimental_control = long_plan_sp.getDec().getEnabled();
+  if ((long_plan_sp.getDec().getActive() != dynamic_experimental_control) || (mode != dec_mpc_mode)) {
+    dynamic_experimental_control = long_plan_sp.getDec().getActive();
     dec_mpc_mode = mode;
     update();
   }
@@ -61,10 +61,10 @@ void ExperimentalButton::paintEvent(QPaintEvent *event) {
 
     QPainter combined_painter(&combined_img);
 
-    combined_painter.setOpacity(dec_mpc_mode == 1 ? 0.6 : 1.0);
+    combined_painter.setOpacity(dec_mpc_mode == 1 ? 0.2 : 1.0);
     combined_painter.drawPixmap(0, 0, left_half);
 
-    combined_painter.setOpacity(dec_mpc_mode == 1 ? 1.0 : 0.6);
+    combined_painter.setOpacity(dec_mpc_mode == 1 ? 1.0 : 0.2);
     combined_painter.drawPixmap(engage_img.width() / 2, 0, right_half);
 
     combined_painter.end();

--- a/selfdrive/ui/qt/onroad/buttons.h
+++ b/selfdrive/ui/qt/onroad/buttons.h
@@ -16,11 +16,12 @@ class ExperimentalButton : public QPushButton {
 
 public:
   explicit ExperimentalButton(QWidget *parent = 0);
-  void updateState(const UIState &s);
+  virtual void updateState(const UIState &s);
 
 private:
   void paintEvent(QPaintEvent *event) override;
   void changeMode();
+  virtual void drawButton(QPainter &p);
 
   Params params;
   QPixmap engage_img;

--- a/selfdrive/ui/qt/onroad/buttons.h
+++ b/selfdrive/ui/qt/onroad/buttons.h
@@ -27,6 +27,7 @@ private:
   QPixmap experimental_img;
   bool experimental_mode;
   bool engageable;
+  bool dynamic_experimental_control;
 };
 
 void drawIcon(QPainter &p, const QPoint &center, const QPixmap &img, const QBrush &bg, float opacity);

--- a/selfdrive/ui/qt/onroad/buttons.h
+++ b/selfdrive/ui/qt/onroad/buttons.h
@@ -21,15 +21,16 @@ public:
 private:
   void paintEvent(QPaintEvent *event) override;
   void changeMode();
-  virtual void drawButton(QPainter &p);
 
   Params params;
+
+protected:
+  virtual void drawButton(QPainter &p);
+
   QPixmap engage_img;
   QPixmap experimental_img;
   bool experimental_mode;
   bool engageable;
-  bool dynamic_experimental_control;
-  int dec_mpc_mode;
 };
 
 void drawIcon(QPainter &p, const QPoint &center, const QPixmap &img, const QBrush &bg, float opacity);

--- a/selfdrive/ui/qt/onroad/buttons.h
+++ b/selfdrive/ui/qt/onroad/buttons.h
@@ -28,6 +28,7 @@ private:
   bool experimental_mode;
   bool engageable;
   bool dynamic_experimental_control;
+  int dec_mpc_mode;
 };
 
 void drawIcon(QPainter &p, const QPoint &center, const QPixmap &img, const QBrush &bg, float opacity);

--- a/selfdrive/ui/sunnypilot/SConscript
+++ b/selfdrive/ui/sunnypilot/SConscript
@@ -23,6 +23,7 @@ qt_src = [
   "sunnypilot/qt/offroad/settings/sunnypilot_panel.cc",
   "sunnypilot/qt/offroad/settings/trips_panel.cc",
   "sunnypilot/qt/onroad/annotated_camera.cc",
+  "sunnypilot/qt/onroad/buttons.cc",
   "sunnypilot/qt/onroad/hud.cc",
   "sunnypilot/qt/onroad/model.cc",
   "sunnypilot/qt/onroad/onroad_home.cc",

--- a/selfdrive/ui/sunnypilot/qt/onroad/buttons.cc
+++ b/selfdrive/ui/sunnypilot/qt/onroad/buttons.cc
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+ *
+ * This file is part of sunnypilot and is licensed under the MIT License.
+ * See the LICENSE.md file in the root directory for more details.
+ */
+
+#include "selfdrive/ui/sunnypilot/qt/onroad/buttons.h"
+
+#include <QPainter>
+
+ExperimentalButtonSP::ExperimentalButtonSP(QWidget *parent) : ExperimentalButton(parent) {
+  QObject::disconnect(uiState(), &UIState::uiUpdate, this, &ExperimentalButton::updateState);
+  QObject::connect(uiState(), &UIState::uiUpdate, this, &ExperimentalButtonSP::updateState);
+}
+
+void ExperimentalButtonSP::updateState(const UIState &s) {
+  ExperimentalButton::updateState(s);
+  const auto long_plan_sp = (*s.sm)["longitudinalPlanSP"].getLongitudinalPlanSP();
+
+  int mode = int(long_plan_sp.getDec().getState());
+  if ((long_plan_sp.getDec().getActive() != dynamic_experimental_control) || (mode != dec_mpc_mode)) {
+    dynamic_experimental_control = long_plan_sp.getDec().getActive();
+    dec_mpc_mode = mode;
+    update();
+  }
+}
+
+void ExperimentalButtonSP::drawButton(QPainter &p) {
+  ExperimentalButton::drawButton(p);
+  if (dynamic_experimental_control) {
+    QPixmap left_half = engage_img.copy(0, 0, engage_img.width() / 2, engage_img.height());
+    QPixmap right_half = experimental_img.copy(experimental_img.width() / 2, 0, experimental_img.width() / 2, experimental_img.height());
+
+    QPixmap combined_img(engage_img.width(), engage_img.height());
+    combined_img.fill(Qt::transparent);
+
+    QPainter combined_painter(&combined_img);
+
+    combined_painter.setOpacity(dec_mpc_mode == 1 ? 0.1 : 1.0);
+    combined_painter.drawPixmap(0, 0, left_half);
+
+    combined_painter.setOpacity(dec_mpc_mode == 1 ? 1.0 : 0.1);
+    combined_painter.drawPixmap(engage_img.width() / 2, 0, right_half);
+
+    combined_painter.end();
+
+    drawIcon(p, QPoint(btn_size / 2, btn_size / 2), combined_img, QColor(0, 0, 0, 166), (isDown() || !engageable) ? 0.6 : 1.0);
+  }
+}

--- a/selfdrive/ui/sunnypilot/qt/onroad/buttons.cc
+++ b/selfdrive/ui/sunnypilot/qt/onroad/buttons.cc
@@ -27,7 +27,6 @@ void ExperimentalButtonSP::updateState(const UIState &s) {
 }
 
 void ExperimentalButtonSP::drawButton(QPainter &p) {
-  ExperimentalButton::drawButton(p);
   if (dynamic_experimental_control) {
     QPixmap left_half = engage_img.copy(0, 0, engage_img.width() / 2, engage_img.height());
     QPixmap right_half = experimental_img.copy(experimental_img.width() / 2, 0, experimental_img.width() / 2, experimental_img.height());
@@ -46,5 +45,7 @@ void ExperimentalButtonSP::drawButton(QPainter &p) {
     combined_painter.end();
 
     drawIcon(p, QPoint(btn_size / 2, btn_size / 2), combined_img, QColor(0, 0, 0, 166), (isDown() || !engageable) ? 0.6 : 1.0);
+  } else {
+    ExperimentalButton::drawButton(p);
   }
 }

--- a/selfdrive/ui/sunnypilot/qt/onroad/buttons.h
+++ b/selfdrive/ui/sunnypilot/qt/onroad/buttons.h
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+ *
+ * This file is part of sunnypilot and is licensed under the MIT License.
+ * See the LICENSE.md file in the root directory for more details.
+ */
+
+#pragma once
+
+#include "selfdrive/ui/qt/onroad/buttons.h"
+
+class ExperimentalButtonSP : public ExperimentalButton {
+  Q_OBJECT
+
+public:
+  explicit ExperimentalButtonSP(QWidget *parent = nullptr);
+  void updateState(const UIState &s) override;
+
+private:
+  void drawButton(QPainter &p) override;
+
+  bool dynamic_experimental_control;
+  int dec_mpc_mode;
+};

--- a/selfdrive/ui/sunnypilot/ui.cc
+++ b/selfdrive/ui/sunnypilot/ui.cc
@@ -18,7 +18,7 @@ UIStateSP::UIStateSP(QObject *parent) : UIState(parent) {
     "modelV2", "controlsState", "liveCalibration", "radarState", "deviceState",
     "pandaStates", "carParams", "driverMonitoringState", "carState", "driverStateV2",
     "wideRoadCameraState", "managerState", "selfdriveState", "longitudinalPlan",
-    "modelManagerSP", "selfdriveStateSP",
+    "modelManagerSP", "selfdriveStateSP", "longitudinalPlanSP",
   });
 
   // update timer


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Display the dynamic experimental control (DEC) status through the mode button.

New Features:
- Visualize the DEC status using the mode button, providing real-time feedback on the active control mode.

Tests:
- Added new tests.