### PR TITLE
MADS: remove `controlsAllowedLat` to maintain compatibility with stock cereal

### DIFF
--- a/cereal/log.capnp
+++ b/cereal/log.capnp
@@ -665,7 +665,6 @@ struct PandaState @0xa7649e2575e4591e {
 
   # safety stuff
   controlsAllowed @3 :Bool;
-  controlsAllowedLat @5 :Bool;
   safetyRxInvalid @19 :UInt32;
   safetyTxBlocked @24 :UInt32;
   safetyModel @14 :Car.CarParams.SafetyModel;
@@ -773,6 +772,7 @@ struct PandaState @0xa7649e2575e4591e {
   }
 
   gasInterceptorDetectedDEPRECATED @4 :Bool;
+  startedSignalDetectedDEPRECATED @5 :Bool;
   hasGpsDEPRECATED @6 :Bool;
   gmlanSendErrsDEPRECATED @9 :UInt32;
   fanSpeedRpmDEPRECATED @11 :UInt16;

--- a/selfdrive/pandad/pandad.cc
+++ b/selfdrive/pandad/pandad.cc
@@ -158,7 +158,6 @@ void fill_panda_state(cereal::PandaState::Builder &ps, cereal::PandaState::Panda
   ps.setIgnitionLine(health.ignition_line_pkt);
   ps.setIgnitionCan(health.ignition_can_pkt);
   ps.setControlsAllowed(health.controls_allowed_pkt);
-  ps.setControlsAllowedLat(health.controls_allowed_lat_pkt);
   ps.setTxBufferOverflow(health.tx_buffer_overflow_pkt);
   ps.setRxBufferOverflow(health.rx_buffer_overflow_pkt);
   ps.setPandaType(hw_type);

--- a/selfdrive/selfdrived/selfdrived.py
+++ b/selfdrive/selfdrived/selfdrived.py
@@ -489,7 +489,7 @@ class SelfdriveD(CruiseHelper):
     if not self.CP.passive and self.initialized:
       self.enabled, self.active = self.state_machine.update(self.events)
     if not self.CP.notCar:
-      self.mads.update(CS, self.sm)
+      self.mads.update(CS)
     self.update_alerts(CS)
 
     self.publish_selfdriveState(CS)

--- a/sunnypilot/mads/mads.py
+++ b/sunnypilot/mads/mads.py
@@ -48,7 +48,6 @@ class ModularAssistiveDrivingSystem:
     self.enabled = False
     self.active = False
     self.available = False
-    self.mismatch_counter = 0
     self.allow_always = False
     self.selfdrive = selfdrive
     self.selfdrive.enabled_prev = False
@@ -70,20 +69,7 @@ class ModularAssistiveDrivingSystem:
     self.main_enabled_toggle = self.mads_params.read_param("MadsMainCruiseAllowed")
     self.unified_engagement_mode = self.mads_params.read_param("MadsUnifiedEngagementMode")
 
-  def update_controls_mismatch(self, sm: messaging.SubMaster):
-    heartbeat_engaged = self.active if self.pause_lateral_on_brake_toggle else self.enabled
-
-    if not heartbeat_engaged:
-      self.mismatch_counter = 0
-
-    if heartbeat_engaged and any(not ps.controlsAllowedLat for ps in sm['pandaStates']
-                                 if ps.safetyModel not in IGNORED_SAFETY_MODES):
-      self.mismatch_counter += 1
-
-    if self.mismatch_counter >= 200:
-      self.events.add(EventName.controlsMismatchLateral)
-
-  def update_events(self, CS: car.CarState, sm: messaging.SubMaster):
+  def update_events(self, CS: car.CarState):
     def update_unified_engagement_mode():
       uem_blocked = self.enabled or (self.selfdrive.enabled and self.selfdrive.enabled_prev)
       if (self.unified_engagement_mode and uem_blocked) or not self.unified_engagement_mode:
@@ -161,13 +147,11 @@ class ModularAssistiveDrivingSystem:
     if not any(be.type in SET_SPEED_BUTTONS for be in CS.buttonEvents):
       self.events.remove(EventName.wrongCarMode)
 
-    self.update_controls_mismatch(sm)
-
-  def update(self, CS: car.CarState, sm: messaging.SubMaster):
+  def update(self, CS: car.CarState):
     if not self.enabled_toggle:
       return
 
-    self.update_events(CS, sm)
+    self.update_events(CS)
 
     if not self.selfdrive.CP.passive and self.selfdrive.initialized:
       self.enabled, self.active = self.state_machine.update(self.events)

--- a/sunnypilot/mads/mads.py
+++ b/sunnypilot/mads/mads.py
@@ -24,7 +24,7 @@ THE SOFTWARE.
 Last updated: July 29, 2024
 """
 
-from cereal import messaging, car, log, custom
+from cereal import car, log, custom
 
 from opendbc.car.hyundai.values import HyundaiFlags
 from opendbc.sunnypilot.car.hyundai.values import HyundaiFlagsSP


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Bug Fixes:
- Resolve a controls mismatch issue by removing the `controlsAllowedLat` parameter.