### PR TITLE
Sentry: sets environment tag

### DIFF
--- a/system/sentry.py
+++ b/system/sentry.py
@@ -116,12 +116,8 @@ def get_properties() -> tuple[str, str, str]:
 
 def init(project: SentryProject) -> bool:
   build_metadata = get_build_metadata()
-  # forks like to mess with this, so double check
-  # comma_remote = build_metadata.openpilot.comma_remote and "commaai" in build_metadata.openpilot.git_origin
-  # if not comma_remote or not is_registered_device() or PC:
-  #   return False
 
-  env = "release" if build_metadata.tested_channel else "master"
+  env = build_metadata.channel_type
   dongle_id, git_username, sunnylink_dongle_id = get_properties()
 
   integrations = []

--- a/system/version.py
+++ b/system/version.py
@@ -10,8 +10,10 @@ from openpilot.common.basedir import BASEDIR
 from openpilot.common.swaglog import cloudlog
 from openpilot.common.git import get_commit, get_origin, get_branch, get_short_branch, get_commit_date
 
-RELEASE_BRANCHES = ['release3-staging', 'release3', 'nightly']
-TESTED_BRANCHES = RELEASE_BRANCHES + ['devel', 'devel-staging', 'nightly-dev']
+RELEASE_SP_BRANCHES = ['release-c3']
+TESTED_SP_BRANCHES = ['staging-c3', 'staging-c3-new']
+RELEASE_BRANCHES = ['release3-staging', 'release3', 'nightly'] + RELEASE_SP_BRANCHES
+TESTED_BRANCHES = RELEASE_BRANCHES + ['devel', 'devel-staging', 'nightly-dev'] + TESTED_SP_BRANCHES
 
 BUILD_METADATA_FILENAME = "build.json"
 
@@ -109,6 +111,17 @@ class BuildMetadata:
   @property
   def ui_description(self) -> str:
     return f"{self.openpilot.version} / {self.openpilot.git_commit[:6]} / {self.channel}"
+
+  @property
+  def channel_type(self) -> str:
+    if self.channel.startswith("dev-"):
+      return "development"
+    elif self.channel.startswith("staging-"):
+      return "staging"
+    elif self.tested_channel:
+      return "release"
+    else:
+      return "master"
 
 
 def build_metadata_from_dict(build_metadata: dict) -> BuildMetadata:

--- a/system/version.py
+++ b/system/version.py
@@ -12,6 +12,7 @@ from openpilot.common.git import get_commit, get_origin, get_branch, get_short_b
 
 RELEASE_SP_BRANCHES = ['release-c3']
 TESTED_SP_BRANCHES = ['staging-c3', 'staging-c3-new']
+MASTER_SP_BRANCHES = ['master', 'master-new']
 RELEASE_BRANCHES = ['release3-staging', 'release3', 'nightly'] + RELEASE_SP_BRANCHES
 TESTED_BRANCHES = RELEASE_BRANCHES + ['devel', 'devel-staging', 'nightly-dev'] + TESTED_SP_BRANCHES
 
@@ -113,15 +114,21 @@ class BuildMetadata:
     return f"{self.openpilot.version} / {self.openpilot.git_commit[:6]} / {self.channel}"
 
   @property
+  def master_channel(self) -> bool:
+    return self.channel in MASTER_SP_BRANCHES
+
+  @property
   def channel_type(self) -> str:
     if self.channel.startswith("dev-"):
       return "development"
     elif self.channel.startswith("staging-"):
       return "staging"
+    elif self.master_channel:
+      return "master"
     elif self.tested_channel:
       return "release"
     else:
-      return "master"
+      return "feature"
 
 
 def build_metadata_from_dict(build_metadata: dict) -> BuildMetadata:


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Enhancements:
- Use the channel type to determine the Sentry environment.