### PR TITLE
ui: Add Wi-Fi scan button to network settings

### DIFF
--- a/selfdrive/ui/qt/network/networking.h
+++ b/selfdrive/ui/qt/network/networking.h
@@ -97,7 +97,7 @@ public:
   void setPrimeType(PrimeState::Type type);
   WifiManager* wifi = nullptr;
 
-private:
+protected:
   QStackedLayout* main_layout = nullptr;
   QWidget* wifiScreen = nullptr;
   AdvancedNetworking* an = nullptr;

--- a/selfdrive/ui/sunnypilot/SConscript
+++ b/selfdrive/ui/sunnypilot/SConscript
@@ -4,6 +4,7 @@ widgets_src = [
   "sunnypilot/qt/widgets/drive_stats.cc",
   "sunnypilot/qt/widgets/prime.cc",
   "sunnypilot/qt/widgets/scrollview.cc",
+  "sunnypilot/qt/network/networking.cc",
 ]
 
 qt_util = [

--- a/selfdrive/ui/sunnypilot/qt/network/networking.cc
+++ b/selfdrive/ui/sunnypilot/qt/network/networking.cc
@@ -1,0 +1,52 @@
+#include "selfdrive/ui/sunnypilot/qt/network/networking.h"
+#include <QVBoxLayout>
+#include <QPushButton>
+#include <QStackedLayout>
+#include <QDebug>
+
+NetworkingSP::NetworkingSP(QWidget *parent) : Networking(parent) {
+  auto vlayout = wifiScreen->findChild<QVBoxLayout*>();
+  auto hlayout = new QHBoxLayout();
+  
+  // Create and setup scan button
+  QPushButton* scanButton = new QPushButton(tr("Scan"));
+  scanButton->setObjectName("scan_btn");
+  scanButton->setFixedSize(400, 100);
+
+  connect(wifi, &WifiManager::refreshSignal, this, [=]() { scanButton->setText(tr("Scan")); scanButton->setEnabled(true); });
+  connect(scanButton, &QPushButton::clicked, [=]() { scanButton->setText(tr("Scanning...")); scanButton->setEnabled(false); wifi->requestScan(); });
+
+  hlayout->addWidget(scanButton);
+  hlayout->addStretch(1);
+
+  // Look for an existing Advanced button
+  QPushButton* existingAdvanced = wifiScreen->findChild<QPushButton*>("advanced_btn");
+  if (existingAdvanced) {
+    // Remove it from its current layout and add it to our new layout
+    // existingAdvanced->setParent(nullptr);
+    hlayout->addWidget(existingAdvanced);
+  }
+
+  // Insert our new layout at the top of vlayout
+  vlayout->setMargin(40);
+  // vlayout->addLayout(hlayout);
+  vlayout->insertLayout(0, hlayout);
+  // vlayout->insertSpacing(2, 10);
+
+  // Add our scan button to the existing style selectors
+  auto newStyleSheet = styleSheet().replace(
+    ", #advanced_btn ",
+    ", #advanced_btn, #scan_btn "
+  ).replace(
+    ", #advanced_btn:pressed",
+    ", #advanced_btn:pressed, #scan_btn:pressed"
+  ).append(R"(
+    #scan_btn:disabled {
+      background-color: #121212;
+      color: #33FFFFFF;
+    }
+  )");
+
+  // Add only the disabled state style which isn't in the original
+  setStyleSheet(newStyleSheet);
+}

--- a/selfdrive/ui/sunnypilot/qt/network/networking.cc
+++ b/selfdrive/ui/sunnypilot/qt/network/networking.cc
@@ -2,14 +2,13 @@
 #include <QVBoxLayout>
 #include <QPushButton>
 #include <QStackedLayout>
-#include <QDebug>
 
 NetworkingSP::NetworkingSP(QWidget *parent) : Networking(parent) {
   auto vlayout = wifiScreen->findChild<QVBoxLayout*>();
   auto hlayout = new QHBoxLayout();
   
   // Create and setup scan button
-  QPushButton* scanButton = new QPushButton(tr("Scan"));
+  auto scanButton = new QPushButton(tr("Scan"));
   scanButton->setObjectName("scan_btn");
   scanButton->setFixedSize(400, 100);
 
@@ -22,16 +21,12 @@ NetworkingSP::NetworkingSP(QWidget *parent) : Networking(parent) {
   // Look for an existing Advanced button
   QPushButton* existingAdvanced = wifiScreen->findChild<QPushButton*>("advanced_btn");
   if (existingAdvanced) {
-    // Remove it from its current layout and add it to our new layout
-    // existingAdvanced->setParent(nullptr);
     hlayout->addWidget(existingAdvanced);
   }
 
   // Insert our new layout at the top of vlayout
   vlayout->setMargin(40);
-  // vlayout->addLayout(hlayout);
   vlayout->insertLayout(0, hlayout);
-  // vlayout->insertSpacing(2, 10);
 
   // Add our scan button to the existing style selectors
   auto newStyleSheet = styleSheet().replace(
@@ -46,7 +41,5 @@ NetworkingSP::NetworkingSP(QWidget *parent) : Networking(parent) {
       color: #33FFFFFF;
     }
   )");
-
-  // Add only the disabled state style which isn't in the original
   setStyleSheet(newStyleSheet);
 }

--- a/selfdrive/ui/sunnypilot/qt/network/networking.h
+++ b/selfdrive/ui/sunnypilot/qt/network/networking.h
@@ -1,0 +1,17 @@
+/**
+* Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+ *
+ * This file is part of sunnypilot and is licensed under the MIT License.
+ * See the LICENSE.md file in the root directory for more details.
+ */
+
+#pragma once
+#include "selfdrive/ui/qt/network/networking.h"
+
+
+class NetworkingSP : public Networking {
+    Q_OBJECT
+
+public:
+    explicit NetworkingSP(QWidget *parent = nullptr);
+};

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/settings.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/settings.cc
@@ -7,7 +7,6 @@
 
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/settings.h"
 
-//#include "selfdrive/ui/qt/network/networking.h"
 #include "selfdrive/ui/sunnypilot/qt/widgets/scrollview.h"
 #include "selfdrive/ui/qt/offroad/developer_panel.h"
 #include "selfdrive/ui/sunnypilot/qt/network/networking.h"

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/settings.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/settings.cc
@@ -7,9 +7,10 @@
 
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/settings.h"
 
-#include "selfdrive/ui/qt/network/networking.h"
+//#include "selfdrive/ui/qt/network/networking.h"
 #include "selfdrive/ui/sunnypilot/qt/widgets/scrollview.h"
 #include "selfdrive/ui/qt/offroad/developer_panel.h"
+#include "selfdrive/ui/sunnypilot/qt/network/networking.h"
 
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/device_panel.h"
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/software_panel.h"
@@ -66,8 +67,8 @@ SettingsWindowSP::SettingsWindowSP(QWidget *parent) : SettingsWindow(parent) {
   TogglesPanelSP *toggles = new TogglesPanelSP(this);
   QObject::connect(this, &SettingsWindowSP::expandToggleDescription, toggles, &TogglesPanel::expandToggleDescription);
 
-  auto networking = new Networking(this);
-  QObject::connect(uiState()->prime_state, &PrimeState::changed, networking, &Networking::setPrimeType);
+  auto networking = new NetworkingSP(this);
+  QObject::connect(uiState()->prime_state, &PrimeState::changed, networking, &NetworkingSP::setPrimeType);
 
   QList<PanelInfo> panels = {
     PanelInfo("   " + tr("Device"), device, "../../sunnypilot/selfdrive/assets/offroad/icon_home.svg"),

--- a/selfdrive/ui/translations/main_ar.ts
+++ b/selfdrive/ui/translations/main_ar.ts
@@ -508,6 +508,21 @@ Pause Steering: ALC will be paused after the brake pedal is manually pressed.</s
     </message>
 </context>
 <context>
+    <name>NetworkingSP</name>
+    <message>
+        <source>Advanced</source>
+        <translation type="obsolete">متقدم</translation>
+    </message>
+    <message>
+        <source>Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scanning...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>OffroadAlert</name>
     <message>
         <source>Device temperature too high. System cooling down before starting. Current internal component temperature: %1</source>

--- a/selfdrive/ui/translations/main_de.ts
+++ b/selfdrive/ui/translations/main_de.ts
@@ -504,6 +504,21 @@ Pause Steering: ALC will be paused after the brake pedal is manually pressed.</s
     </message>
 </context>
 <context>
+    <name>NetworkingSP</name>
+    <message>
+        <source>Advanced</source>
+        <translation type="obsolete">Erweitert</translation>
+    </message>
+    <message>
+        <source>Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scanning...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>OffroadAlert</name>
     <message>
         <source>Immediately connect to the internet to check for updates. If you do not connect to the internet, openpilot won&apos;t engage in %1</source>

--- a/selfdrive/ui/translations/main_es.ts
+++ b/selfdrive/ui/translations/main_es.ts
@@ -504,6 +504,17 @@ Pause Steering: ALC will be paused after the brake pedal is manually pressed.</s
     </message>
 </context>
 <context>
+    <name>NetworkingSP</name>
+    <message>
+        <source>Scan</source>
+        <translation>Escanear</translation>
+    </message>
+    <message>
+        <source>Scanning...</source>
+        <translation>Escaneando...</translation>
+    </message>
+</context>
+<context>
     <name>OffroadAlert</name>
     <message>
         <source>Device temperature too high. System cooling down before starting. Current internal component temperature: %1</source>

--- a/selfdrive/ui/translations/main_fr.ts
+++ b/selfdrive/ui/translations/main_fr.ts
@@ -504,6 +504,21 @@ Pause Steering: ALC will be paused after the brake pedal is manually pressed.</s
     </message>
 </context>
 <context>
+    <name>NetworkingSP</name>
+    <message>
+        <source>Advanced</source>
+        <translation type="obsolete">Avancé</translation>
+    </message>
+    <message>
+        <source>Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scanning...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>OffroadAlert</name>
     <message>
         <source>Device temperature too high. System cooling down before starting. Current internal component temperature: %1</source>

--- a/selfdrive/ui/translations/main_ja.ts
+++ b/selfdrive/ui/translations/main_ja.ts
@@ -503,6 +503,21 @@ Pause Steering: ALC will be paused after the brake pedal is manually pressed.</s
     </message>
 </context>
 <context>
+    <name>NetworkingSP</name>
+    <message>
+        <source>Advanced</source>
+        <translation type="obsolete">詳細</translation>
+    </message>
+    <message>
+        <source>Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scanning...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>OffroadAlert</name>
     <message>
         <source>Immediately connect to the internet to check for updates. If you do not connect to the internet, openpilot won&apos;t engage in %1</source>

--- a/selfdrive/ui/translations/main_ko.ts
+++ b/selfdrive/ui/translations/main_ko.ts
@@ -503,6 +503,21 @@ Pause Steering: ALC will be paused after the brake pedal is manually pressed.</s
     </message>
 </context>
 <context>
+    <name>NetworkingSP</name>
+    <message>
+        <source>Advanced</source>
+        <translation type="obsolete">고급 설정</translation>
+    </message>
+    <message>
+        <source>Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scanning...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>OffroadAlert</name>
     <message>
         <source>Immediately connect to the internet to check for updates. If you do not connect to the internet, openpilot won&apos;t engage in %1</source>

--- a/selfdrive/ui/translations/main_pt-BR.ts
+++ b/selfdrive/ui/translations/main_pt-BR.ts
@@ -504,6 +504,21 @@ Pause Steering: ALC will be paused after the brake pedal is manually pressed.</s
     </message>
 </context>
 <context>
+    <name>NetworkingSP</name>
+    <message>
+        <source>Advanced</source>
+        <translation type="obsolete">Avançado</translation>
+    </message>
+    <message>
+        <source>Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scanning...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>OffroadAlert</name>
     <message>
         <source>Immediately connect to the internet to check for updates. If you do not connect to the internet, openpilot won&apos;t engage in %1</source>

--- a/selfdrive/ui/translations/main_th.ts
+++ b/selfdrive/ui/translations/main_th.ts
@@ -503,6 +503,21 @@ Pause Steering: ALC will be paused after the brake pedal is manually pressed.</s
     </message>
 </context>
 <context>
+    <name>NetworkingSP</name>
+    <message>
+        <source>Advanced</source>
+        <translation type="obsolete">ขั้นสูง</translation>
+    </message>
+    <message>
+        <source>Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scanning...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>OffroadAlert</name>
     <message>
         <source>Device temperature too high. System cooling down before starting. Current internal component temperature: %1</source>

--- a/selfdrive/ui/translations/main_tr.ts
+++ b/selfdrive/ui/translations/main_tr.ts
@@ -503,6 +503,21 @@ Pause Steering: ALC will be paused after the brake pedal is manually pressed.</s
     </message>
 </context>
 <context>
+    <name>NetworkingSP</name>
+    <message>
+        <source>Advanced</source>
+        <translation type="obsolete">Gelişmiş Seçenekler</translation>
+    </message>
+    <message>
+        <source>Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scanning...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>OffroadAlert</name>
     <message>
         <source>Device temperature too high. System cooling down before starting. Current internal component temperature: %1</source>

--- a/selfdrive/ui/translations/main_zh-CHS.ts
+++ b/selfdrive/ui/translations/main_zh-CHS.ts
@@ -503,6 +503,21 @@ Pause Steering: ALC will be paused after the brake pedal is manually pressed.</s
     </message>
 </context>
 <context>
+    <name>NetworkingSP</name>
+    <message>
+        <source>Advanced</source>
+        <translation type="obsolete">高级</translation>
+    </message>
+    <message>
+        <source>Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scanning...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>OffroadAlert</name>
     <message>
         <source>Immediately connect to the internet to check for updates. If you do not connect to the internet, openpilot won&apos;t engage in %1</source>

--- a/selfdrive/ui/translations/main_zh-CHT.ts
+++ b/selfdrive/ui/translations/main_zh-CHT.ts
@@ -503,6 +503,21 @@ Pause Steering: ALC will be paused after the brake pedal is manually pressed.</s
     </message>
 </context>
 <context>
+    <name>NetworkingSP</name>
+    <message>
+        <source>Advanced</source>
+        <translation type="obsolete">進階</translation>
+    </message>
+    <message>
+        <source>Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scanning...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>OffroadAlert</name>
     <message>
         <source>Immediately connect to the internet to check for updates. If you do not connect to the internet, openpilot won&apos;t engage in %1</source>


### PR DESCRIPTION
This modification introduced a new 'NetworkingSP' class for the sunnypilot user interface. It's based on the existing Networking class, but tailored to the specific needs of the sunnypilot UI. This class adds a new 'Scan' button to the Wi-Fi screen and implements an additional layout to accommodate both 'Scan' and 'Advanced' buttons. It also contains updates to the file inclusions in 'settings.cc' to use the new class. Moreover, the accessibility of several member variables in the original Networking class has been updated from 'private' to 'protected'. This change enhances the modifiability and extensibility of the class structure.

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

New Features:
- Added a "Scan" button to the Wi-Fi settings screen, allowing users to manually scan for available networks.