### PR TITLE
ci: Add support for "settings_network" and "settings_network_advanced" scene in UI tests

### DIFF
--- a/.github/workflows/ui_preview.yaml
+++ b/.github/workflows/ui_preview.yaml
@@ -86,7 +86,7 @@ jobs:
         run: >-
           sudo apt-get install -y imagemagick
 
-          scenes="homescreen settings_device settings_software settings_sunnylink settings_toggles settings_sunnypilot settings_sunnypilot_mads settings_trips settings_developer offroad_alert update_available prime onroad onroad_disengaged onroad_override onroad_sidebar onroad_wide onroad_wide_sidebar onroad_alert_small onroad_alert_mid onroad_alert_full driver_camera body keyboard keyboard_uppercase"
+          scenes="homescreen settings_device settings_network settings_software settings_sunnylink settings_toggles settings_sunnypilot settings_sunnypilot_mads settings_trips settings_developer offroad_alert update_available prime onroad onroad_disengaged onroad_override onroad_sidebar onroad_wide onroad_wide_sidebar onroad_alert_small onroad_alert_mid onroad_alert_full driver_camera body keyboard keyboard_uppercase"
           A=($scenes)
 
           DIFF=""

--- a/.github/workflows/ui_preview.yaml
+++ b/.github/workflows/ui_preview.yaml
@@ -86,7 +86,7 @@ jobs:
         run: >-
           sudo apt-get install -y imagemagick
 
-          scenes="homescreen settings_device settings_network settings_software settings_sunnylink settings_toggles settings_sunnypilot settings_sunnypilot_mads settings_trips settings_developer offroad_alert update_available prime onroad onroad_disengaged onroad_override onroad_sidebar onroad_wide onroad_wide_sidebar onroad_alert_small onroad_alert_mid onroad_alert_full driver_camera body keyboard keyboard_uppercase"
+          scenes="homescreen settings_device settings_network settings_network_advanced settings_software settings_sunnylink settings_toggles settings_sunnypilot settings_sunnypilot_mads settings_trips settings_developer offroad_alert update_available prime onroad onroad_disengaged onroad_override onroad_sidebar onroad_wide onroad_wide_sidebar onroad_alert_small onroad_alert_mid onroad_alert_full driver_camera body keyboard keyboard_uppercase"
           A=($scenes)
 
           DIFF=""

--- a/selfdrive/ui/tests/test_ui/run.py
+++ b/selfdrive/ui/tests/test_ui/run.py
@@ -39,7 +39,7 @@ def setup_homescreen(click, pm: PubMaster, scroll=None):
 
 def setup_settings_device(click, pm: PubMaster, scroll=None):
   click(100, 100)
- 
+
 def setup_settings_network(click, pm: PubMaster, scroll=None):
   setup_settings_device(click, pm)
   click(278, 405)

--- a/selfdrive/ui/tests/test_ui/run.py
+++ b/selfdrive/ui/tests/test_ui/run.py
@@ -39,6 +39,10 @@ def setup_homescreen(click, pm: PubMaster, scroll=None):
 
 def setup_settings_device(click, pm: PubMaster, scroll=None):
   click(100, 100)
+ 
+def setup_settings_network(click, pm: PubMaster, scroll=None):
+  setup_settings_device(click, pm)
+  click(278, 405)
 
 def setup_settings_toggles(click, pm: PubMaster, scroll=None):
   setup_settings_device(click, pm)
@@ -212,6 +216,7 @@ CASES = {
   "prime": setup_homescreen,
   "pair_device": setup_pair_device,
   "settings_device": setup_settings_device,
+  "settings_network": setup_settings_network,
   "settings_toggles": setup_settings_toggles,
   "settings_software": setup_settings_software,
   "settings_developer": setup_settings_developer,

--- a/selfdrive/ui/tests/test_ui/run.py
+++ b/selfdrive/ui/tests/test_ui/run.py
@@ -44,6 +44,10 @@ def setup_settings_network(click, pm: PubMaster, scroll=None):
   setup_settings_device(click, pm)
   click(278, 405)
 
+def setup_settings_network_advanced(click, pm: PubMaster, scroll=None):
+  setup_settings_network(click, pm)
+  click(1913, 90)
+
 def setup_settings_toggles(click, pm: PubMaster, scroll=None):
   setup_settings_device(click, pm)
   click(278, 632)
@@ -217,6 +221,7 @@ CASES = {
   "pair_device": setup_pair_device,
   "settings_device": setup_settings_device,
   "settings_network": setup_settings_network,
+  "settings_network_advanced": setup_settings_network_advanced,
   "settings_toggles": setup_settings_toggles,
   "settings_software": setup_settings_software,
   "settings_developer": setup_settings_developer,


### PR DESCRIPTION
Updated the workflow and test script to include the "settings_network" scene. Introduced a new setup function for "settings_network" and registered it in the scene-to-function mapping. This ensures proper handling and testing of network settings in the UI.

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Tests:
- Added UI tests for the network settings scene.