### PR TITLE
ci: squash and merge script update to allow merging less restrictively

### DIFF
--- a/release/ci/squash_and_merge_prs.py
+++ b/release/ci/squash_and_merge_prs.py
@@ -73,7 +73,7 @@ def validate_pr(pr):
     if not merge_data.get('mergeable'):
         return False, "Merge conflicts detected"
 
-    if (mergeStateStatus := merge_data.get('mergeStateStatus')) != "CLEAN":
+    if (mergeStateStatus := merge_data.get('mergeStateStatus')) == "BEHIND":
         return False, f"Branch is `{mergeStateStatus}`"
 
     return True, None


### PR DESCRIPTION
Previously, any non-"CLEAN" status prevented merging. The check now specifically fails only if the branch is "BEHIND", allowing other statuses to proceed if valid. This ensures more accurate merge validations.

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Bug Fixes:
- Fix branch status check to allow merging when the branch status is not "CLEAN", but also not "BEHIND".