### PR TITLE
Refactor `get_non_essential_params_sp` to simplify arguments

### DIFF
--- a/selfdrive/car/tests/test_car_interfaces.py
+++ b/selfdrive/car/tests/test_car_interfaces.py
@@ -40,7 +40,7 @@ class TestCarInterfaces:
 
     car_params = CarInterface.get_params(car_name, args['fingerprints'], args['car_fw'],
                                          experimental_long=args['experimental_long'], docs=False)
-    car_params, car_params_sp = CarInterface.get_params_sp(car_params, car_name, args['fingerprints'], args['car_fw'],
+    car_params_sp = CarInterface.get_params_sp(car_params, car_name, args['fingerprints'], args['car_fw'],
                                                            experimental_long=args['experimental_long'], docs=False)
     car_params = car_params.as_reader()
     car_interface = CarInterface(car_params, car_params_sp, CarController, CarState)

--- a/selfdrive/car/tests/test_models.py
+++ b/selfdrive/car/tests/test_models.py
@@ -159,7 +159,7 @@ class TestCarModelBase(unittest.TestCase):
 
     cls.CarInterface, cls.CarController, cls.CarState, cls.RadarInterface = interfaces[cls.platform]
     cls.CP = cls.CarInterface.get_params(cls.platform,  cls.fingerprint, car_fw, experimental_long, docs=False)
-    cls.CP, cls.CP_SP = cls.CarInterface.get_params_sp(cls.CP, cls.platform,  cls.fingerprint, car_fw, experimental_long, docs=False)
+    cls.CP_SP = cls.CarInterface.get_params_sp(cls.CP, cls.platform,  cls.fingerprint, car_fw, experimental_long, docs=False)
     assert cls.CP
     assert cls.CP_SP
     assert cls.CP.carFingerprint == cls.platform

--- a/selfdrive/controls/lib/tests/test_latcontrol.py
+++ b/selfdrive/controls/lib/tests/test_latcontrol.py
@@ -18,7 +18,8 @@ class TestLatControl:
   @parameterized.expand([(HONDA.HONDA_CIVIC, LatControlPID), (TOYOTA.TOYOTA_RAV4, LatControlTorque),  (NISSAN.NISSAN_LEAF, LatControlAngle)])
   def test_saturation(self, car_name, controller):
     CarInterface, CarController, CarState, RadarInterface = interfaces[car_name]
-    CP, CP_SP = CarInterface.get_non_essential_params_sp(car_name)
+    CP = CarInterface.get_non_essential_params(car_name)
+    CP_SP = CarInterface.get_non_essential_params_sp(CP, car_name)
     CI = CarInterface(CP, CP_SP, CarController, CarState)
     VM = VehicleModel(CP)
 

--- a/selfdrive/controls/lib/tests/test_latcontrol.py
+++ b/selfdrive/controls/lib/tests/test_latcontrol.py
@@ -18,8 +18,7 @@ class TestLatControl:
   @parameterized.expand([(HONDA.HONDA_CIVIC, LatControlPID), (TOYOTA.TOYOTA_RAV4, LatControlTorque),  (NISSAN.NISSAN_LEAF, LatControlAngle)])
   def test_saturation(self, car_name, controller):
     CarInterface, CarController, CarState, RadarInterface = interfaces[car_name]
-    CP = CarInterface.get_non_essential_params(car_name)
-    CP, CP_SP = CarInterface.get_non_essential_params_sp(CP, car_name)
+    CP, CP_SP = CarInterface.get_non_essential_params_sp(car_name)
     CI = CarInterface(CP, CP_SP, CarController, CarState)
     VM = VehicleModel(CP)
 

--- a/selfdrive/test/process_replay/process_replay.py
+++ b/selfdrive/test/process_replay/process_replay.py
@@ -343,7 +343,8 @@ def get_car_params_callback(rc, pm, msgs, fingerprint):
   params = Params()
   if fingerprint:
     CarInterface, _, _, _ = interfaces[fingerprint]
-    CP, CP_SP = CarInterface.get_non_essential_params_sp(fingerprint)
+    CP = CarInterface.get_non_essential_params(fingerprint)
+    CP_SP = CarInterface.get_non_essential_params_sp(CP, fingerprint)
   else:
     can = DummySocket()
     sendcan = DummySocket()

--- a/selfdrive/test/process_replay/process_replay.py
+++ b/selfdrive/test/process_replay/process_replay.py
@@ -343,8 +343,7 @@ def get_car_params_callback(rc, pm, msgs, fingerprint):
   params = Params()
   if fingerprint:
     CarInterface, _, _, _ = interfaces[fingerprint]
-    CP = CarInterface.get_non_essential_params(fingerprint)
-    CP, CP_SP = CarInterface.get_non_essential_params_sp(CP, fingerprint)
+    CP, CP_SP = CarInterface.get_non_essential_params_sp(fingerprint)
   else:
     can = DummySocket()
     sendcan = DummySocket()


### PR DESCRIPTION
Simplify the method by removing redundant input arguments and adjusting its return structure. These changes improve readability and maintain consistency with other related methods. Adjustments are also reflected in the corresponding test and process replay code.

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Enhancements:
- Removed a redundant input argument from the `get_non_essential_params_sp` method and updated its return structure.