### PR TITLE
MADS: Properly handle gear events

### DIFF
--- a/sunnypilot/mads/mads.py
+++ b/sunnypilot/mads/mads.py
@@ -160,7 +160,7 @@ class ModularAssistiveDrivingSystem:
     self.update_events(CS)
 
     if not self.selfdrive.CP.passive and self.selfdrive.initialized:
-      self.enabled, self.active = self.state_machine.update(self.events, self.events_sp)
+      self.enabled, self.active = self.state_machine.update()
 
     # Copy of previous SelfdriveD states for MADS events handling
     self.selfdrive.enabled_prev = self.selfdrive.enabled

--- a/sunnypilot/mads/mads.py
+++ b/sunnypilot/mads/mads.py
@@ -111,7 +111,7 @@ class ModularAssistiveDrivingSystem:
           transition_paused_state()
 
       if not (self.pause_lateral_on_brake_toggle and CS.brakePressed) and \
-         not self.events.contains_in_list(GEARS_ALLOW_PAUSED_SILENT):
+         not self.events_sp.contains_in_list(GEARS_ALLOW_PAUSED_SILENT):
         if self.state_machine.state == State.paused:
           self.events_sp.add(EventNameSP.silentLkasEnable)
 

--- a/sunnypilot/mads/state.py
+++ b/sunnypilot/mads/state.py
@@ -41,8 +41,7 @@ ENABLED_STATES = (State.paused, *ACTIVE_STATES)
 GEARS_ALLOW_PAUSED_SILENT = [EventNameSP.silentWrongGear, EventNameSP.silentReverseGear, EventNameSP.silentBrakeHold,
                              EventNameSP.silentDoorOpen, EventNameSP.silentSeatbeltNotLatched, EventNameSP.silentParkBrake]
 GEARS_ALLOW_PAUSED = [EventName.wrongGear, EventName.reverseGear, EventName.brakeHold,
-                      EventName.doorOpen, EventName.seatbeltNotLatched, EventName.parkBrake,
-                      *GEARS_ALLOW_PAUSED_SILENT]
+                      EventName.doorOpen, EventName.seatbeltNotLatched, EventName.parkBrake]
 
 
 class StateMachine:
@@ -62,8 +61,8 @@ class StateMachine:
   def check_contains(self, event_type: str) -> bool:
     return bool(self._events.contains(event_type) or self._events_sp.contains(event_type))
 
-  def check_contains_in_list(self, events_list: list[int]) -> bool:
-    return bool(self._events.contains_in_list(events_list) or self._events_sp.contains_in_list(events_list))
+  def check_contains_in_list(self) -> bool:
+    return bool(self._events.contains_in_list(GEARS_ALLOW_PAUSED) or self._events_sp.contains_in_list(GEARS_ALLOW_PAUSED_SILENT))
 
   def update(self, events: Events, events_sp: EventsSP):
     # soft disable timer and current alert types are from the state machine of openpilot
@@ -141,7 +140,7 @@ class StateMachine:
     elif self.state == State.disabled:
       if self.check_contains(ET.ENABLE):
         if self.check_contains(ET.NO_ENTRY):
-          if self.check_contains_in_list(GEARS_ALLOW_PAUSED):
+          if self.check_contains_in_list():
             self.state = State.paused
           self.add_current_alert_types(ET.NO_ENTRY)
 

--- a/sunnypilot/mads/tests/test_mads_state_machine.py
+++ b/sunnypilot/mads/tests/test_mads_state_machine.py
@@ -56,7 +56,6 @@ class MockMADS:
   def __init__(self, mocker: MockerFixture):
     self.selfdrive = mocker.MagicMock()
     self.selfdrive.state_machine = mocker.MagicMock()
-    self.selfdrive.active = False
     self.selfdrive.events = Events()
     self.selfdrive.events_sp = EventsSP()
 

--- a/sunnypilot/mads/tests/test_mads_state_machine.py
+++ b/sunnypilot/mads/tests/test_mads_state_machine.py
@@ -108,8 +108,6 @@ class TestMADSStateMachine:
 
   def test_soft_disable(self):
     for state in ALL_STATES:
-      if state == State.paused:  # paused considers USER_DISABLE instead
-        continue
       for et in MAINTAIN_STATES[state]:
         self.events_sp.add(make_event([et, ET.SOFT_DISABLE]))
         self.state_machine.state = state
@@ -127,39 +125,41 @@ class TestMADSStateMachine:
       self.state_machine.update()
 
     assert self.state_machine.state == State.disabled
+    self.reset()
 
   def test_no_entry(self):
     for et in ENABLE_EVENT_TYPES:
       self.events_sp.add(make_event([ET.NO_ENTRY, et]))
-      if not self.state_machine.check_contains_in_list():
-        self.state_machine.update()
-        assert self.state_machine.state == State.disabled
-        self.reset()
+      self.state_machine.update()
+      assert self.state_machine.state == State.disabled
+      self.reset()
 
   def test_no_entry_paused(self):
     self.state_machine.state = State.paused
     self.events_sp.add(make_event([ET.NO_ENTRY]))
     self.state_machine.update()
     assert self.state_machine.state == State.paused
+    self.reset()
 
   def test_override_lateral(self):
     self.state_machine.state = State.enabled
     self.events_sp.add(make_event([ET.OVERRIDE_LATERAL]))
     self.state_machine.update()
     assert self.state_machine.state == State.overriding
+    self.reset()
 
   def test_paused_to_enabled(self):
     self.state_machine.state = State.paused
     self.events_sp.add(make_event([ET.ENABLE]))
     self.state_machine.update()
     assert self.state_machine.state == State.enabled
+    self.reset()
 
   def test_maintain_states(self):
     for state in ALL_STATES:
       for et in MAINTAIN_STATES[state]:
         self.state_machine.state = state
-        if et is not None:
-          self.events_sp.add(make_event([et]))
+        self.events_sp.add(make_event([et]))
         self.state_machine.update()
         assert self.state_machine.state == state
         self.reset()

--- a/sunnypilot/mads/tests/test_mads_state_machine.py
+++ b/sunnypilot/mads/tests/test_mads_state_machine.py
@@ -69,10 +69,9 @@ class TestMADSStateMachine:
     self.events_sp = self.mads.selfdrive.events_sp
     self.mads.selfdrive.state_machine.soft_disable_timer = int(SOFT_DISABLE_TIME / DT_CTRL)
 
-  def reset(self):
+  def clear_events(self):
     self.events.clear()
     self.events_sp.clear()
-    self.state_machine.state = State.disabled
 
   def test_immediate_disable(self):
     for state in ALL_STATES:
@@ -81,7 +80,7 @@ class TestMADSStateMachine:
         self.state_machine.state = state
         self.state_machine.update()
         assert State.disabled == self.state_machine.state
-        self.reset()
+        self.clear_events()
 
   def test_user_disable(self):
     for state in ALL_STATES:
@@ -90,7 +89,7 @@ class TestMADSStateMachine:
         self.state_machine.state = state
         self.state_machine.update()
         assert State.disabled == self.state_machine.state
-        self.reset()
+        self.clear_events()
 
   def test_user_disable_to_paused(self):
     paused_events = (EventNameSP.silentLkasDisable, EventNameSP.silentBrakeHold)
@@ -103,7 +102,7 @@ class TestMADSStateMachine:
           self.state_machine.update()
           final_state = State.paused if self.events_sp.has(en) and state != State.disabled else State.disabled
           assert self.state_machine.state == final_state
-          self.reset()
+          self.clear_events()
 
   def test_soft_disable(self):
     for state in ALL_STATES:
@@ -112,7 +111,7 @@ class TestMADSStateMachine:
         self.state_machine.state = state
         self.state_machine.update()
         assert self.state_machine.state == State.disabled if state == State.disabled else State.softDisabling
-        self.reset()
+        self.clear_events()
 
   def test_soft_disable_timer(self):
     self.state_machine.state = State.enabled
@@ -124,35 +123,35 @@ class TestMADSStateMachine:
       self.state_machine.update()
 
     assert self.state_machine.state == State.disabled
-    self.reset()
+    self.clear_events()
 
   def test_no_entry(self):
     for et in ENABLE_EVENT_TYPES:
       self.events_sp.add(make_event([ET.NO_ENTRY, et]))
       self.state_machine.update()
       assert self.state_machine.state == State.disabled
-      self.reset()
+      self.clear_events()
 
   def test_no_entry_paused(self):
     self.state_machine.state = State.paused
     self.events_sp.add(make_event([ET.NO_ENTRY]))
     self.state_machine.update()
     assert self.state_machine.state == State.paused
-    self.reset()
+    self.clear_events()
 
   def test_override_lateral(self):
     self.state_machine.state = State.enabled
     self.events_sp.add(make_event([ET.OVERRIDE_LATERAL]))
     self.state_machine.update()
     assert self.state_machine.state == State.overriding
-    self.reset()
+    self.clear_events()
 
   def test_paused_to_enabled(self):
     self.state_machine.state = State.paused
     self.events_sp.add(make_event([ET.ENABLE]))
     self.state_machine.update()
     assert self.state_machine.state == State.enabled
-    self.reset()
+    self.clear_events()
 
   def test_maintain_states(self):
     for state in ALL_STATES:
@@ -161,4 +160,4 @@ class TestMADSStateMachine:
         self.events_sp.add(make_event([et]))
         self.state_machine.update()
         assert self.state_machine.state == state
-        self.reset()
+        self.clear_events()

--- a/sunnypilot/mads/tests/test_mads_state_machine.py
+++ b/sunnypilot/mads/tests/test_mads_state_machine.py
@@ -29,7 +29,7 @@ from pytest_mock import MockerFixture
 
 from cereal import custom
 from openpilot.common.realtime import DT_CTRL
-from openpilot.sunnypilot.mads.state import StateMachine, SOFT_DISABLE_TIME, GEARS_ALLOW_PAUSED
+from openpilot.sunnypilot.mads.state import StateMachine, SOFT_DISABLE_TIME
 from openpilot.selfdrive.selfdrived.events import ET, NormalPermanentAlert
 from openpilot.sunnypilot.selfdrive.selfdrived.events import EVENTS_SP
 
@@ -129,7 +129,7 @@ class TestMADSStateMachine:
   def test_no_entry(self):
     for et in ENABLE_EVENT_TYPES:
       self.events_sp.add(make_event([ET.NO_ENTRY, et]))
-      if not self.state_machine.check_contains_in_list(GEARS_ALLOW_PAUSED):
+      if not self.state_machine.check_contains_in_list():
         self.state_machine.update(self.events, self.events_sp)
         assert self.state_machine.state == State.disabled
         self.reset()


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Bug Fixes:
- Fix a bug where the MADS state machine did not properly handle gear events, causing unexpected behavior in certain scenarios.