### PR TITLE
CI: allow 1 retry for first time contributor and fork and skip sync lfs on fork PRs

### DIFF
--- a/.github/workflows/lfs-maintenance.yaml
+++ b/.github/workflows/lfs-maintenance.yaml
@@ -23,7 +23,7 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     # Skip if PR is in draft mode
-    if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
+    if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) || !github.event.pull_request.head.repo.fork
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/setup/action.yaml
+++ b/.github/workflows/setup/action.yaml
@@ -19,7 +19,7 @@ runs:
     - shell: bash
       name: No retries!
       run: |
-        if [ "${{ github.run_attempt }}" -gt 1 ]; then
+        if [ "${{ github.run_attempt }}" -gt ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' && 2 || 1}} ]; then
           echo -e "\033[0;31m##################################################"
           echo -e "\033[0;31m    Retries not allowed! Fix the flaky test!      "
           echo -e "\033[0;31m##################################################\033[0m"


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Update GitHub Actions workflows to improve handling of pull requests from forked repositories and adjust retry logic for contributors.

CI:
- Update GitHub Actions workflow to skip sync job for pull requests from forked repositories.
- Modify retry logic in setup action to allow retries for non-first-time contributors from forked repositories.