### PR TITLE
CI: adjust allow 1 retry for first time contributor and fork and skip sync lfs on fork PRs

### DIFF
--- a/.github/workflows/lfs-maintenance.yaml
+++ b/.github/workflows/lfs-maintenance.yaml
@@ -23,7 +23,7 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     # Skip if PR is in draft mode
-    if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
+    if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) || !github.event.pull_request.head.repo.fork
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/lfs-maintenance.yaml
+++ b/.github/workflows/lfs-maintenance.yaml
@@ -23,7 +23,7 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     # Skip if PR is in draft mode
-    if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) || !github.event.pull_request.head.repo.fork
+    if: (github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)) && !github.event.pull_request.head.repo.fork
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/setup/action.yaml
+++ b/.github/workflows/setup/action.yaml
@@ -19,7 +19,7 @@ runs:
     - shell: bash
       name: No retries!
       run: |
-        if [ "${{ github.run_attempt }}" -gt 1 ]; then
+        if [ "${{ github.run_attempt }}" -gt ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' && 2 || 1}} ]; then
           echo -e "\033[0;31m##################################################"
           echo -e "\033[0;31m    Retries not allowed! Fix the flaky test!      "
           echo -e "\033[0;31m##################################################\033[0m"

--- a/.github/workflows/setup/action.yaml
+++ b/.github/workflows/setup/action.yaml
@@ -19,7 +19,7 @@ runs:
     - shell: bash
       name: No retries!
       run: |
-        if [ "${{ github.run_attempt }}" -gt ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' && 2 || 1}} ]; then
+        if [ "${{ github.run_attempt }}" -gt ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.author_association == 'NONE' && 2 || 1}} ]; then
           echo -e "\033[0;31m##################################################"
           echo -e "\033[0;31m    Retries not allowed! Fix the flaky test!      "
           echo -e "\033[0;31m##################################################\033[0m"

--- a/.github/workflows/setup/action.yaml
+++ b/.github/workflows/setup/action.yaml
@@ -19,10 +19,10 @@ runs:
     - shell: bash
       name: No retries!
       run: |
-        echo github.event.pull_request.head.repo.fork: ${{ github.event.pull_request.head.repo.fork }}
+        echo github.event.pull_request.head.repo.fork: ${{ !github.event.pull_request.head.repo.fork }}
         echo github.event.pull_request.author_association: ${{ github.event.pull_request.author_association }}
         echo github.run_attempt: ${{ github.run_attempt }}
-        echo github.event.pull_request.head.repo.fork == 'false' && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' : ${{ github.event.pull_request.head.repo.fork == 'false' && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' }}
+        echo github.event.pull_request.head.repo.fork == 'false' && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' : ${{ !github.event.pull_request.head.repo.fork && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' }}
         if [ "${{ github.run_attempt }}" -gt ${{ github.event.pull_request.head.repo.fork == 'false' && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' && 2 || 1}} ]; then
           echo -e "\033[0;31m##################################################"
           echo -e "\033[0;31m    Retries not allowed! Fix the flaky test!      "

--- a/.github/workflows/setup/action.yaml
+++ b/.github/workflows/setup/action.yaml
@@ -19,18 +19,12 @@ runs:
     - shell: bash
       name: No retries!
       run: |
-        echo github.event.pull_request.head.repo.fork: ${{ !github.event.pull_request.head.repo.fork }}
-        echo github.event.pull_request.author_association: ${{ github.event.pull_request.author_association }}
-        echo github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR': ${{ github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' }}
-        echo github.run_attempt: ${{ github.run_attempt }}
-        echo github.event.pull_request.head.repo.fork == 'false' && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' : ${{ !github.event.pull_request.head.repo.fork && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' }}
-        if [ "${{ github.run_attempt }}" -gt ${{ github.event.pull_request.head.repo.fork == 'false' && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' && 2 || 1}} ]; then
+        if [ "${{ github.run_attempt }}" -gt ${{ !github.event.pull_request.head.repo.fork && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' && 2 || 1}} ]; then
           echo -e "\033[0;31m##################################################"
           echo -e "\033[0;31m    Retries not allowed! Fix the flaky test!      "
           echo -e "\033[0;31m##################################################\033[0m"
           exit 1
         fi
-        echo '${{ toJSON(github.event) }}'
 
     # do this after checkout to ensure our custom LFS config is used to pull from GitLab
     - shell: bash

--- a/.github/workflows/setup/action.yaml
+++ b/.github/workflows/setup/action.yaml
@@ -19,6 +19,9 @@ runs:
     - shell: bash
       name: No retries!
       run: |
+        echo github.event.pull_request.head.repo.fork: ${{ github.event.pull_request.head.repo.fork }}
+        echo github.event.pull_request.author_association: ${{ github.event.pull_request.author_association }}
+        echo github.run_attempt: ${{ github.run_attempt }}
         if [ "${{ github.run_attempt }}" -gt ${{ github.event.pull_request.head.repo.fork == 'false' && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' && 2 || 1}} ]; then
           echo -e "\033[0;31m##################################################"
           echo -e "\033[0;31m    Retries not allowed! Fix the flaky test!      "

--- a/.github/workflows/setup/action.yaml
+++ b/.github/workflows/setup/action.yaml
@@ -22,6 +22,7 @@ runs:
         echo github.event.pull_request.head.repo.fork: ${{ github.event.pull_request.head.repo.fork }}
         echo github.event.pull_request.author_association: ${{ github.event.pull_request.author_association }}
         echo github.run_attempt: ${{ github.run_attempt }}
+        echo github.event.pull_request.head.repo.fork == 'false' && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' : ${{ github.event.pull_request.head.repo.fork == 'false' && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' }}
         if [ "${{ github.run_attempt }}" -gt ${{ github.event.pull_request.head.repo.fork == 'false' && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' && 2 || 1}} ]; then
           echo -e "\033[0;31m##################################################"
           echo -e "\033[0;31m    Retries not allowed! Fix the flaky test!      "

--- a/.github/workflows/setup/action.yaml
+++ b/.github/workflows/setup/action.yaml
@@ -19,7 +19,7 @@ runs:
     - shell: bash
       name: No retries!
       run: |
-        echo ${{ github.event }}
+        echo ${{ toJSON(github.event) }}
         if [ "${{ github.run_attempt }}" -gt ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' && 2 || 1}} ]; then
           echo -e "\033[0;31m##################################################"
           echo -e "\033[0;31m    Retries not allowed! Fix the flaky test!      "

--- a/.github/workflows/setup/action.yaml
+++ b/.github/workflows/setup/action.yaml
@@ -20,7 +20,7 @@ runs:
       name: No retries!
       run: |
         echo ${{ toJSON(github.event) }}
-        if [ "${{ github.run_attempt }}" -gt ${{ github.event.pull_request.head.repo.fork != 'true' && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' && 2 || 1}} ]; then
+        if [ "${{ github.run_attempt }}" -gt ${{ github.event.pull_request.head.repo.fork == 'false' && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' && 2 || 1}} ]; then
           echo -e "\033[0;31m##################################################"
           echo -e "\033[0;31m    Retries not allowed! Fix the flaky test!      "
           echo -e "\033[0;31m##################################################\033[0m"

--- a/.github/workflows/setup/action.yaml
+++ b/.github/workflows/setup/action.yaml
@@ -19,13 +19,13 @@ runs:
     - shell: bash
       name: No retries!
       run: |
-        echo ${{ toJSON(github.event) }}
         if [ "${{ github.run_attempt }}" -gt ${{ github.event.pull_request.head.repo.fork == 'false' && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' && 2 || 1}} ]; then
           echo -e "\033[0;31m##################################################"
           echo -e "\033[0;31m    Retries not allowed! Fix the flaky test!      "
           echo -e "\033[0;31m##################################################\033[0m"
           exit 1
         fi
+        echo '${{ toJSON(github.event) }}'
 
     # do this after checkout to ensure our custom LFS config is used to pull from GitLab
     - shell: bash

--- a/.github/workflows/setup/action.yaml
+++ b/.github/workflows/setup/action.yaml
@@ -21,6 +21,7 @@ runs:
       run: |
         echo github.event.pull_request.head.repo.fork: ${{ !github.event.pull_request.head.repo.fork }}
         echo github.event.pull_request.author_association: ${{ github.event.pull_request.author_association }}
+        echo github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR': ${{ github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' }}
         echo github.run_attempt: ${{ github.run_attempt }}
         echo github.event.pull_request.head.repo.fork == 'false' && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' : ${{ !github.event.pull_request.head.repo.fork && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' }}
         if [ "${{ github.run_attempt }}" -gt ${{ github.event.pull_request.head.repo.fork == 'false' && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' && 2 || 1}} ]; then

--- a/.github/workflows/setup/action.yaml
+++ b/.github/workflows/setup/action.yaml
@@ -19,6 +19,7 @@ runs:
     - shell: bash
       name: No retries!
       run: |
+        echo ${{ github.event }}
         if [ "${{ github.run_attempt }}" -gt ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' && 2 || 1}} ]; then
           echo -e "\033[0;31m##################################################"
           echo -e "\033[0;31m    Retries not allowed! Fix the flaky test!      "

--- a/.github/workflows/setup/action.yaml
+++ b/.github/workflows/setup/action.yaml
@@ -20,7 +20,7 @@ runs:
       name: No retries!
       run: |
         echo ${{ toJSON(github.event) }}
-        if [ "${{ github.run_attempt }}" -gt ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' && 2 || 1}} ]; then
+        if [ "${{ github.run_attempt }}" -gt ${{ github.event.pull_request.head.repo.fork != 'true' && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' && 2 || 1}} ]; then
           echo -e "\033[0;31m##################################################"
           echo -e "\033[0;31m    Retries not allowed! Fix the flaky test!      "
           echo -e "\033[0;31m##################################################\033[0m"

--- a/.github/workflows/setup/action.yaml
+++ b/.github/workflows/setup/action.yaml
@@ -19,7 +19,7 @@ runs:
     - shell: bash
       name: No retries!
       run: |
-        if [ "${{ github.run_attempt }}" -gt ${{ !github.event.pull_request.head.repo.fork && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' && 2 || 1}} ]; then
+        if [ "${{ github.run_attempt }}" -gt ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' && 2 || 1}} ]; then
           echo -e "\033[0;31m##################################################"
           echo -e "\033[0;31m    Retries not allowed! Fix the flaky test!      "
           echo -e "\033[0;31m##################################################\033[0m"


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Fixes an issue where GitHub Actions were not working correctly for contributors who have forked the repository. The workflow now correctly determines whether a pull request is from a fork and adjusts the retry logic accordingly. Also, the LFS maintenance workflow is adjusted to run for pull requests that are not from a fork.

CI:
- Adjusts the retry logic in the setup action to allow one retry for first-time contributors from forks.
- Modifies the LFS maintenance workflow to run for pull requests that are not from a fork.