### PR TITLE
CI: Disable `process_replay` and remove `fakedata`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,7 +9,6 @@
 *.ttf filter=lfs diff=lfs merge=lfs -text
 *.wav filter=lfs diff=lfs merge=lfs -text
 
-selfdrive/test/process_replay/fakedata/*.zst filter=lfs diff=lfs merge=lfs -text
 selfdrive/car/tests/test_models_segs.txt filter=lfs diff=lfs merge=lfs -text
 system/hardware/tici/updater filter=lfs diff=lfs merge=lfs -text
 selfdrive/ui/qt/spinner_larch64 filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -160,6 +160,7 @@ jobs:
 
   process_replay:
     name: process replay
+    if: github.repository == 'commaai/openpilot'  # disable process_replay for forks
     runs-on:
       - ${{ ((github.repository == 'commaai/openpilot') && ((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.full_name == 'commaai/openpilot'))) && 'namespace-profile-amd64-8x16' || 'ubuntu-24.04' }}
       - ${{ ((github.repository == 'commaai/openpilot') && ((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.full_name == 'commaai/openpilot'))) && 'namespace-experiments:docker.builds.local-cache=separate' || 'ubuntu-24.04' }}

--- a/scripts/lint/lint.sh
+++ b/scripts/lint/lint.sh
@@ -13,7 +13,7 @@ cd $ROOT
 
 FAILED=0
 
-IGNORED_FILES="uv\.lock|docs\/CARS.md|LICENSE\.md|.*\.zst"
+IGNORED_FILES="uv\.lock|docs\/CARS.md|LICENSE\.md"
 IGNORED_DIRS="^third_party.*|^msgq.*|^msgq_repo.*|^opendbc.*|^opendbc_repo.*|^cereal.*|^panda.*|^rednose.*|^rednose_repo.*|^tinygrad.*|^tinygrad_repo.*|^teleoprtc.*|^teleoprtc_repo.*"
 
 function run() {

--- a/selfdrive/test/process_replay/.gitignore
+++ b/selfdrive/test/process_replay/.gitignore
@@ -1,1 +1,1 @@
-!fakedata/*
+fakedata/

--- a/selfdrive/test/process_replay/fakedata/regen1CA7A48E6F7|2024-08-30--02-45-08--0_calibrationd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regen1CA7A48E6F7|2024-08-30--02-45-08--0_calibrationd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:00a555e2b8cb5a846ca7aa21d9cb6474ec28cf16dfee7ee4eab2c24b3e41c84c
-size 1883

--- a/selfdrive/test/process_replay/fakedata/regen1CA7A48E6F7|2024-08-30--02-45-08--0_card_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regen1CA7A48E6F7|2024-08-30--02-45-08--0_card_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a518e8ddeaf9998688e922c1e880c8ed87cd4d017ace099fb5d12b49495c0a60
-size 356259

--- a/selfdrive/test/process_replay/fakedata/regen1CA7A48E6F7|2024-08-30--02-45-08--0_controlsd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regen1CA7A48E6F7|2024-08-30--02-45-08--0_controlsd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8ec364c58a24d2b061da26db823ad9f9b022939acc69bf173c5e7692b369ffc2
-size 167913

--- a/selfdrive/test/process_replay/fakedata/regen1CA7A48E6F7|2024-08-30--02-45-08--0_dmonitoringd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regen1CA7A48E6F7|2024-08-30--02-45-08--0_dmonitoringd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9b56b74cb9e31cc7ca3e5017b4f90375bec2f640690cb08cba01b6084a3911f6
-size 3502

--- a/selfdrive/test/process_replay/fakedata/regen1CA7A48E6F7|2024-08-30--02-45-08--0_locationd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regen1CA7A48E6F7|2024-08-30--02-45-08--0_locationd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6f99286c35614806801ae4c77477fdaefa0fa7d960c047b6315edb593c67d5e0
-size 112449

--- a/selfdrive/test/process_replay/fakedata/regen1CA7A48E6F7|2024-08-30--02-45-08--0_paramsd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regen1CA7A48E6F7|2024-08-30--02-45-08--0_paramsd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b8d37d1a2c609393cbbe2b7f517967f37ddcc6a57873625b7dc30ea59294a79e
-size 41741

--- a/selfdrive/test/process_replay/fakedata/regen1CA7A48E6F7|2024-08-30--02-45-08--0_plannerd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regen1CA7A48E6F7|2024-08-30--02-45-08--0_plannerd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d9d552eff00311b0e777a80a10d3fcd61fac4fc1f660ef5d915ad66c4478ffa5
-size 256497

--- a/selfdrive/test/process_replay/fakedata/regen1CA7A48E6F7|2024-08-30--02-45-08--0_radard_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regen1CA7A48E6F7|2024-08-30--02-45-08--0_radard_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b396d49350f43fa1ace5f96c46e46a80e305c99e59a487092ef23472a2b37fb6
-size 51100

--- a/selfdrive/test/process_replay/fakedata/regen1CA7A48E6F7|2024-08-30--02-45-08--0_selfdrived_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regen1CA7A48E6F7|2024-08-30--02-45-08--0_selfdrived_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a0ea35f1a0517a7117219d7bba72a9e4bda05ba351840f37f3cda934033103f8
-size 29356

--- a/selfdrive/test/process_replay/fakedata/regen1CA7A48E6F7|2024-08-30--02-45-08--0_torqued_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regen1CA7A48E6F7|2024-08-30--02-45-08--0_torqued_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:217fcbe96795f4e05fe20d7720ab0a73c2d88196cf72a79f8aeaa31161ac648a
-size 1348

--- a/selfdrive/test/process_replay/fakedata/regen1CA7A48E6F7|2024-08-30--02-45-08--0_ubloxd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regen1CA7A48E6F7|2024-08-30--02-45-08--0_ubloxd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f7b1411e8b4a91b4df94322023d83f5f2f27245fa761db73ffafd06b91068062
-size 284390

--- a/selfdrive/test/process_replay/fakedata/regen306779F6870|2024-10-03--04-03-23--0_card_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regen306779F6870|2024-10-03--04-03-23--0_card_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b554294ad2b5b4baed3679a003d62145affc1794e8fdba4ee08bf8062456314e
-size 332430

--- a/selfdrive/test/process_replay/fakedata/regen4B38A7428CD|2024-08-30--02-56-31--0_card_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regen4B38A7428CD|2024-08-30--02-56-31--0_card_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bb44217a08fe15883c54910ce0d1d1cdf5c472121eda0e2d80314c33ae1ec000
-size 269005

--- a/selfdrive/test/process_replay/fakedata/regen4CE950B0267|2024-08-30--02-51-30--0_card_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regen4CE950B0267|2024-08-30--02-51-30--0_card_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2adcaa7886a8da13d84179f29564da2ac09c55c816a1f5f451ba1d1d55910364
-size 436913

--- a/selfdrive/test/process_replay/fakedata/regen58464878D07|2024-08-30--03-15-31--0_card_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regen58464878D07|2024-08-30--03-15-31--0_card_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:985aed3994ae595864532241d9ce0fdf4eb4044ab6beaae4da742b3a2b90c2da
-size 308576

--- a/selfdrive/test/process_replay/fakedata/regen6E484EDAB96|2024-08-30--02-47-37--0_card_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regen6E484EDAB96|2024-08-30--02-47-37--0_card_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:facf728f1536c7d00acafd257dad09c2ed1367148aa1b5164a07b2cdbe4dde9e
-size 392223

--- a/selfdrive/test/process_replay/fakedata/regen720F2BA4CF6|2024-08-30--03-09-15--0_card_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regen720F2BA4CF6|2024-08-30--03-09-15--0_card_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:690d8fe201590bbc90c37b7c380671cb690efe7da63600be6dfb022b305aa76d
-size 334370

--- a/selfdrive/test/process_replay/fakedata/regen756F8230C21|2024-11-07--00-08-24--0_calibrationd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regen756F8230C21|2024-11-07--00-08-24--0_calibrationd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:65e3a6f26f52c1e1f67849facb102f625bb0c5913aa1d376a35d324f5542d794
-size 1860

--- a/selfdrive/test/process_replay/fakedata/regen756F8230C21|2024-11-07--00-08-24--0_card_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regen756F8230C21|2024-11-07--00-08-24--0_card_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:635726ad56629526a25eb8d83da083bf45873d7011e3b82fab5b286306daf03f
-size 470468

--- a/selfdrive/test/process_replay/fakedata/regen756F8230C21|2024-11-07--00-08-24--0_controlsd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regen756F8230C21|2024-11-07--00-08-24--0_controlsd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dfc601f9cbcafe611033a4c3a43fd9adcb0e2dbde21fa6fb8238e9de84fca48d
-size 201759

--- a/selfdrive/test/process_replay/fakedata/regen756F8230C21|2024-11-07--00-08-24--0_dmonitoringd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regen756F8230C21|2024-11-07--00-08-24--0_dmonitoringd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a96509ec410b10459c62af0614366740e1138c1551fadc0afde6672f15516815
-size 7909

--- a/selfdrive/test/process_replay/fakedata/regen756F8230C21|2024-11-07--00-08-24--0_locationd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regen756F8230C21|2024-11-07--00-08-24--0_locationd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e887d050e6d5a6d18123956f10ce174bdd9957b1820dbcbe6f608fcd89372bab
-size 112454

--- a/selfdrive/test/process_replay/fakedata/regen756F8230C21|2024-11-07--00-08-24--0_paramsd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regen756F8230C21|2024-11-07--00-08-24--0_paramsd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8c3cc2bc6ff6eb2a9777eded8090e7e76f80bd8c29e51bdb2fd0782c785d6e33
-size 40767

--- a/selfdrive/test/process_replay/fakedata/regen756F8230C21|2024-11-07--00-08-24--0_plannerd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regen756F8230C21|2024-11-07--00-08-24--0_plannerd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6a672f9201b037026f1f9b35a381aa1eee3aadca8f57ee0a22e203af465fb100
-size 260202

--- a/selfdrive/test/process_replay/fakedata/regen756F8230C21|2024-11-07--00-08-24--0_radard_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regen756F8230C21|2024-11-07--00-08-24--0_radard_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fc8b42f793728cf1cb9bc9868a106e7171527c1d6549de1afcfe4c6db163b799
-size 52725

--- a/selfdrive/test/process_replay/fakedata/regen756F8230C21|2024-11-07--00-08-24--0_selfdrived_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regen756F8230C21|2024-11-07--00-08-24--0_selfdrived_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ed0cfd5fff468b94c14ea0d965b0a6d9f827b14f31c87657f4015137f7811e82
-size 29648

--- a/selfdrive/test/process_replay/fakedata/regen756F8230C21|2024-11-07--00-08-24--0_torqued_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regen756F8230C21|2024-11-07--00-08-24--0_torqued_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1c4d73bd47043fd6bdbd0625299bda7a5b94cf2f63f1813cd1ec683be8b7ce09
-size 1199

--- a/selfdrive/test/process_replay/fakedata/regen756F8230C21|2024-11-07--00-08-24--0_ubloxd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regen756F8230C21|2024-11-07--00-08-24--0_ubloxd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4223262ea5da92b081a6024d135c2ed892901363c7b2b8be0b121578ee9eb4aa
-size 234609

--- a/selfdrive/test/process_replay/fakedata/regen9ADBECBCD1C|2024-08-30--03-13-04--0_card_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regen9ADBECBCD1C|2024-08-30--03-13-04--0_card_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6be0f9379ea542e8031df14ed1335a887dd500705dcc501517b2c156d206d389
-size 217490

--- a/selfdrive/test/process_replay/fakedata/regen9CBD921E93E|2024-08-30--02-38-51--0_calibrationd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regen9CBD921E93E|2024-08-30--02-38-51--0_calibrationd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:803b782e30fc48b51e677ef2c50ac80f3f6283799205b0ed8829d3c6ac61b49c
-size 1712

--- a/selfdrive/test/process_replay/fakedata/regen9CBD921E93E|2024-08-30--02-38-51--0_card_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regen9CBD921E93E|2024-08-30--02-38-51--0_card_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:87f21c10d37eeb254843bb0f22ed366bdc7cdd064bc7b232fba615dd218cca7f
-size 293058

--- a/selfdrive/test/process_replay/fakedata/regen9CBD921E93E|2024-08-30--02-38-51--0_controlsd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regen9CBD921E93E|2024-08-30--02-38-51--0_controlsd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a4ddb9bfa5f1d835cbf42e2d1a066eca81e29c801046e0ce5ac2f5a3803bfbd1
-size 163958

--- a/selfdrive/test/process_replay/fakedata/regen9CBD921E93E|2024-08-30--02-38-51--0_dmonitoringd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regen9CBD921E93E|2024-08-30--02-38-51--0_dmonitoringd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b4341d37146f3b0fd0b8355a3213d2a1b596bf7a2a41c061f1aebbbaa6aa1172
-size 3552

--- a/selfdrive/test/process_replay/fakedata/regen9CBD921E93E|2024-08-30--02-38-51--0_locationd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regen9CBD921E93E|2024-08-30--02-38-51--0_locationd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e072d812c3355091fde157a40523b1818a96db3ade15a7810c54a05282288c12
-size 112322

--- a/selfdrive/test/process_replay/fakedata/regen9CBD921E93E|2024-08-30--02-38-51--0_paramsd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regen9CBD921E93E|2024-08-30--02-38-51--0_paramsd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:13d8632b9f98b91ec9d723c8eb81ed877884f238f6cbcebcbe42541309f0b820
-size 35670

--- a/selfdrive/test/process_replay/fakedata/regen9CBD921E93E|2024-08-30--02-38-51--0_plannerd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regen9CBD921E93E|2024-08-30--02-38-51--0_plannerd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1e73741d22e1ec73a2cb183b83a55c648a48f4d71874b9d0c9c86e71cbbf8c90
-size 259709

--- a/selfdrive/test/process_replay/fakedata/regen9CBD921E93E|2024-08-30--02-38-51--0_radard_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regen9CBD921E93E|2024-08-30--02-38-51--0_radard_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fa9767fe8370fc49e455d5746b6b34a489681ec9103df5a2de2953524ae4c319
-size 17917

--- a/selfdrive/test/process_replay/fakedata/regen9CBD921E93E|2024-08-30--02-38-51--0_selfdrived_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regen9CBD921E93E|2024-08-30--02-38-51--0_selfdrived_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1b602ecb28c53366eddb90efec1e2560f2ce021cf9d6d7a2fbd2fb4d06f0db86
-size 29487

--- a/selfdrive/test/process_replay/fakedata/regen9CBD921E93E|2024-08-30--02-38-51--0_torqued_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regen9CBD921E93E|2024-08-30--02-38-51--0_torqued_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ad0392cb8f44222127f06df95a278fb05cfecfa1ef641ddf590a3b50fa5b4b74
-size 1223

--- a/selfdrive/test/process_replay/fakedata/regen9CBD921E93E|2024-08-30--02-38-51--0_ubloxd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regen9CBD921E93E|2024-08-30--02-38-51--0_ubloxd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e48e881d04b6aeec25b07b3f6c6b7c38eeac10877b50b3c6a909e579a18a4f57
-size 102222

--- a/selfdrive/test/process_replay/fakedata/regenA67A128BCD8|2024-08-30--02-36-22--0_card_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regenA67A128BCD8|2024-08-30--02-36-22--0_card_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:887555d2eb5e38bfe8672914b96d9e5764ffc4494ba32b56158aaa24eacc793f
-size 100084

--- a/selfdrive/test/process_replay/fakedata/regenAA1FF48CF1F|2024-08-30--03-06-45--0_calibrationd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regenAA1FF48CF1F|2024-08-30--03-06-45--0_calibrationd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a75473ce388cf1d6fb54c38400a481464c7ec36765d3807addf16267315f52b8
-size 1912

--- a/selfdrive/test/process_replay/fakedata/regenAA1FF48CF1F|2024-08-30--03-06-45--0_card_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regenAA1FF48CF1F|2024-08-30--03-06-45--0_card_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5bde2554aabaf6fb32a8fb088d44e355227290f1650e8483633bc1ae76982502
-size 262853

--- a/selfdrive/test/process_replay/fakedata/regenAA1FF48CF1F|2024-08-30--03-06-45--0_controlsd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regenAA1FF48CF1F|2024-08-30--03-06-45--0_controlsd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:91a900de57315a5f15fa1bdfb3f7f6b254b11f4278cf8203d9b91d01b4840716
-size 259422

--- a/selfdrive/test/process_replay/fakedata/regenAA1FF48CF1F|2024-08-30--03-06-45--0_dmonitoringd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regenAA1FF48CF1F|2024-08-30--03-06-45--0_dmonitoringd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b0602bdf2a3736b1d38f807b9a5029222721a327ee13c0a1d4ad7e3cadc4d5a1
-size 6841

--- a/selfdrive/test/process_replay/fakedata/regenAA1FF48CF1F|2024-08-30--03-06-45--0_locationd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regenAA1FF48CF1F|2024-08-30--03-06-45--0_locationd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5b1e513b97426cc282e6f367b2750030ada2c3c11689189239991aa580f9e91a
-size 113046

--- a/selfdrive/test/process_replay/fakedata/regenAA1FF48CF1F|2024-08-30--03-06-45--0_paramsd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regenAA1FF48CF1F|2024-08-30--03-06-45--0_paramsd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b3f1c5a027ac87927bf52cd6a7996bfe0a67a1b50f94df16063884f6b5ff3b46
-size 41696

--- a/selfdrive/test/process_replay/fakedata/regenAA1FF48CF1F|2024-08-30--03-06-45--0_plannerd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regenAA1FF48CF1F|2024-08-30--03-06-45--0_plannerd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8b970e2ba2a9cc7f9f192a15d80760cbda8ff48b0c26c0137dcea8c8ada2d905
-size 258873

--- a/selfdrive/test/process_replay/fakedata/regenAA1FF48CF1F|2024-08-30--03-06-45--0_radard_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regenAA1FF48CF1F|2024-08-30--03-06-45--0_radard_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:67316952f7551b69c46a8b35fb1cb205034aec2a0f5d94833bc7aec5298a0e8e
-size 53039

--- a/selfdrive/test/process_replay/fakedata/regenAA1FF48CF1F|2024-08-30--03-06-45--0_selfdrived_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regenAA1FF48CF1F|2024-08-30--03-06-45--0_selfdrived_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2c052a93ca810f2ab4e32950ba95b60169586a9a36a668c74d7afdeeedd8a5fa
-size 30396

--- a/selfdrive/test/process_replay/fakedata/regenAA1FF48CF1F|2024-08-30--03-06-45--0_torqued_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regenAA1FF48CF1F|2024-08-30--03-06-45--0_torqued_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a2da9e9adaf35f6d525c32f2695d678b0286b1e1db30dc1a07541714af292e95
-size 1292

--- a/selfdrive/test/process_replay/fakedata/regenAA1FF48CF1F|2024-08-30--03-06-45--0_ubloxd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regenAA1FF48CF1F|2024-08-30--03-06-45--0_ubloxd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:98817a342f7e90f2dd943e116fa1f6a7fe774d2b1588822daec9905bed1cc34b
-size 193195

--- a/selfdrive/test/process_replay/fakedata/regenACF84CCF482|2024-08-30--03-21-55--0_card_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regenACF84CCF482|2024-08-30--03-21-55--0_card_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:96037da3c8fc6c5d42f381cda22eda741f53950c5748a3ddc71339b7e83c63a8
-size 268153

--- a/selfdrive/test/process_replay/fakedata/regenC8F0D6ADC5C|2024-08-30--02-54-01--0_calibrationd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regenC8F0D6ADC5C|2024-08-30--02-54-01--0_calibrationd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c34d0a968f789548d507be6e2aa42a308ea76fa29204f00287e07119b725bc90
-size 1863

--- a/selfdrive/test/process_replay/fakedata/regenC8F0D6ADC5C|2024-08-30--02-54-01--0_card_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regenC8F0D6ADC5C|2024-08-30--02-54-01--0_card_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c101d544a1e827b3387545e755581947a6db2b3151bc7d5f4357fe4f45a54e0a
-size 305095

--- a/selfdrive/test/process_replay/fakedata/regenC8F0D6ADC5C|2024-08-30--02-54-01--0_controlsd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regenC8F0D6ADC5C|2024-08-30--02-54-01--0_controlsd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ec49b06b23bcd461cdcfbc4c94157c775d2dd91633e8f6648e4ce50732224335
-size 280914

--- a/selfdrive/test/process_replay/fakedata/regenC8F0D6ADC5C|2024-08-30--02-54-01--0_dmonitoringd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regenC8F0D6ADC5C|2024-08-30--02-54-01--0_dmonitoringd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d3add3cdb9c13d8d00b013e5f54dff9040ef6f97972c25cd0375939424fa385e
-size 4481

--- a/selfdrive/test/process_replay/fakedata/regenC8F0D6ADC5C|2024-08-30--02-54-01--0_locationd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regenC8F0D6ADC5C|2024-08-30--02-54-01--0_locationd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8ff53a8d947ed2a4de660f3289f56c2b800c0147418237a0d256acbe48476b77
-size 112877

--- a/selfdrive/test/process_replay/fakedata/regenC8F0D6ADC5C|2024-08-30--02-54-01--0_paramsd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regenC8F0D6ADC5C|2024-08-30--02-54-01--0_paramsd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3a5110e087689d493419a20ae06c0e781d1ee41cd02878f532645815ef7f41a8
-size 41026

--- a/selfdrive/test/process_replay/fakedata/regenC8F0D6ADC5C|2024-08-30--02-54-01--0_plannerd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regenC8F0D6ADC5C|2024-08-30--02-54-01--0_plannerd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:72844828a02ab576b582a7acf9cc6f7f2bbd1fe3f38d2044d3fd0cc11d0f1fa1
-size 255784

--- a/selfdrive/test/process_replay/fakedata/regenC8F0D6ADC5C|2024-08-30--02-54-01--0_radard_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regenC8F0D6ADC5C|2024-08-30--02-54-01--0_radard_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f7c84b169e3284c28985c71bd88431f6e750f71ad8274f85e2522be4b8cb60ba
-size 16708

--- a/selfdrive/test/process_replay/fakedata/regenC8F0D6ADC5C|2024-08-30--02-54-01--0_selfdrived_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regenC8F0D6ADC5C|2024-08-30--02-54-01--0_selfdrived_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9fd65f8c4769f5cd41d9399c8218f2dd2c876d2ccea6504dc5838eee652234a8
-size 30366

--- a/selfdrive/test/process_replay/fakedata/regenC8F0D6ADC5C|2024-08-30--02-54-01--0_torqued_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regenC8F0D6ADC5C|2024-08-30--02-54-01--0_torqued_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9796b749a3cbd3b30336b1e4ac9cefd17586ffc523c9955ffe8cb07c504d15b2
-size 1196

--- a/selfdrive/test/process_replay/fakedata/regenC8F0D6ADC5C|2024-08-30--02-54-01--0_ubloxd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regenC8F0D6ADC5C|2024-08-30--02-54-01--0_ubloxd_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:925cd984b03fbb2a43f06da107611303382c6596a140f2f36ef8c0b8541a5c72
-size 265878

--- a/selfdrive/test/process_replay/fakedata/regenDB02684E00A|2024-08-30--03-02-54--0_card_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regenDB02684E00A|2024-08-30--03-02-54--0_card_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:057a7299ad30d26f1254f41681742653433ae8aea491fafddde7f6b1392629a3
-size 271984

--- a/selfdrive/test/process_replay/fakedata/regenED976DEB757|2024-08-30--03-18-02--0_card_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regenED976DEB757|2024-08-30--03-18-02--0_card_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:463aee6453d8b4a16c091d49022c6c86381e8eba5b9efd7c15e3ac5352f1e108
-size 332382

--- a/selfdrive/test/process_replay/fakedata/regenF3DBBA9E8DF|2024-08-30--02-59-03--0_card_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
+++ b/selfdrive/test/process_replay/fakedata/regenF3DBBA9E8DF|2024-08-30--02-59-03--0_card_a0a1635c552b2909fe808726ca0cd9201fcaea6a.zst
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0e04f4f74317af38c82643f986c1acd90244504bf4fd912526c87e6cb6745d6c
-size 294484


### PR DESCRIPTION
## Summary by Sourcery

Disable the `process_replay` CI job for forks and remove the associated `fakedata` directory.

CI:
- Disable the `process_replay` CI job for forks.
- Remove the `fakedata` directory.