### PR TITLE
HKG Longitudinal tuning

### DIFF
--- a/common/params_keys.h
+++ b/common/params_keys.h
@@ -153,6 +153,8 @@ inline static std::unordered_map<std::string, uint32_t> keys = {
     {"HyundaiRadarTracksConfirmed", PERSISTENT},
     {"HyundaiRadarTracksPersistent", PERSISTENT},
     {"HyundaiRadarTracksToggle", PERSISTENT},
+    {"HyundaiLongTune", PERSISTENT},
+    {"HyundaiSmootherBraking", PERSISTENT},
 
     {"DynamicExperimentalControl", PERSISTENT},
 };

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle_panel.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle_panel.cc
@@ -39,7 +39,7 @@ VehiclePanel::VehiclePanel(QWidget *parent) : QFrame(parent) {
   std::vector<QString> tuning_buttons { tr("Off"), tr("Long Tune"), tr("Tune + Even Smoother Braking") };
   hkgtuningToggle = new ButtonParamControlSP(
     "HyundaiLongTune",
-    tr("Chubbs Tune"),
+    tr("HKG Tuning"),
     tr("Select tuning mode. Off means no tuning is currently applied. Long Tune is an dynamic accel/brake tuning tuned to your specific car. "
         "Tune + Smoother Braking is the dynamic tuning but with smoother braking applied."),
     "../assets/offroad/icon_shell.png",

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle_panel.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle_panel.h
@@ -17,13 +17,34 @@ class VehiclePanel : public QFrame {
 public:
   explicit VehiclePanel(QWidget *parent = nullptr);
   void showEvent(QShowEvent *event) override;
-
+  // Toggle states
+  enum class ToggleState {
+    ENABLED,
+    DISABLED_LONGITUDINAL,
+    DISABLED_DRIVING
+  };
 public slots:
   void updatePanel(bool _offroad);
 
 private:
+  // UI elements
   QStackedLayout* main_layout = nullptr;
   QWidget* vehicleScreen = nullptr;
   PlatformSelector *platformSelector = nullptr;
+  // Tuning control using ButtonParamControlSP with the buttonToggled signal.
+  ButtonParamControlSP* hkgtuningToggle = nullptr;
   bool offroad;
+
+  // State tracking
+  Params params;
+  int hkg_state = 0;
+
+  // Helper methods
+  ToggleState getToggleState(bool hasOpenpilotLong) const;
+  void updateToggleState(AbstractControlSP* toggle, bool hasOpenpilotLong);
+
+private slots:
+  void updateCarToggles();
+  void updateToggles(bool offroad_transition);
+  void handleToggleAction(AbstractControlSP* toggle, bool checked);
 };

--- a/system/manager/manager.py
+++ b/system/manager/manager.py
@@ -50,6 +50,8 @@ def manager_init() -> None:
     ("MadsUnifiedEngagementMode", "1"),
     ("ModelManager_LastSyncTime", "0"),
     ("ModelManager_ModelsCache", "")
+    ("HyundaiLongTune", "0"),
+    ("HyundaiSmootherBraking", "0"),
   ]
 
   if params.get_bool("RecordFrontLock"):


### PR DESCRIPTION
Custom tuning for HKG vehicles, taking into account lower, upper jerk, and comfort bands. When the user selects toggles, these plus interface tuning will be applied. Furthermore, if the user presses the button to enable smoother braking, my custom accel logic will be utilized to greatly filter and smoothen accel/braking transitions for a more chill open pilot experience.

Current issue:
--While CB calculation works excellent to limit rough transitions from acceleration costs, there needs to be changes in the logic so it is zero'd out for now.

## Summary by Sourcery

Adds a new "Chubbs Tune" feature for Hyundai vehicles that allows users to select different tuning modes for longitudinal control, including a smoother braking option. The selected mode is persisted in a parameter and applied dynamically.

New Features:
- Introduces a new "Chubbs Tune" feature for Hyundai vehicles, offering different longitudinal tuning modes.
- Adds a smoother braking option as part of the "Chubbs Tune" feature, which filters and smooths acceleration/braking transitions.