### PR TITLE
ci: remove sunnylink pairing QR code from UI preview

### DIFF
--- a/selfdrive/ui/tests/test_ui/run.py
+++ b/selfdrive/ui/tests/test_ui/run.py
@@ -212,11 +212,6 @@ def setup_settings_sunnylink_sponsor_button(click, pm: PubMaster, scroll=None):
   click(1967, 225)
   time.sleep(UI_DELAY)
 
-def setup_settings_sunnylink_pair_button(click, pm: PubMaster, scroll=None):
-  setup_settings_sunnylink(click, pm)
-  click(1967, 432)
-  time.sleep(UI_DELAY)
-
 def setup_settings_sunnypilot(click, pm: PubMaster, scroll=None):
   setup_settings_device(click, pm)
   click(278, 852)
@@ -279,7 +274,6 @@ CASES = {
 CASES.update({
   "settings_sunnylink": setup_settings_sunnylink,
   "settings_sunnylink_sponsor_button": setup_settings_sunnylink_sponsor_button,
-  "settings_sunnylink_pair_button": setup_settings_sunnylink_pair_button,
   "settings_sunnypilot": setup_settings_sunnypilot,
   "settings_sunnypilot_mads": setup_settings_sunnypilot_mads,
   "settings_trips": setup_settings_trips,


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Chores:
- Removes the sunnylink pairing QR code from the UI preview.