### PR TITLE
Refactor - SLC: Simplify Dynamic Personalty Logic

### DIFF
--- a/selfdrive/controls/lib/longitudinal_mpc_lib/long_mpc.py
+++ b/selfdrive/controls/lib/longitudinal_mpc_lib/long_mpc.py
@@ -82,24 +82,10 @@ def get_T_FOLLOW(personality=custom.LongitudinalPersonalitySP.standard):
   else:
     raise NotImplementedError("Longitudinal personality not supported")
 
-
 def get_dynamic_personality(v_ego, personality=custom.LongitudinalPersonalitySP.standard):
-  if personality==custom.LongitudinalPersonalitySP.relaxed:
-    x_vel =  [0,    11,   14.5, 15,   20,   20.01,  25,    25.01,  36,  36.01]
-    y_dist = [1.5,  1.5,  1.5,  1.6,  1.76, 1.76,   1.78,  1.78,   1.8, 1.8]
-  elif personality==custom.LongitudinalPersonalitySP.standard:
-    x_vel =  [0,    11,   14.5, 15,   20,   20.01,  25,    25.01,  36,  36.01]
-    y_dist = [1.40, 1.40, 1.40, 1.50, 1.60, 1.76,   1.76,  1.78,   1.8, 1.8]
-  elif personality==custom.LongitudinalPersonalitySP.moderate:
-    x_vel =  [0,    11,   14.5, 15,   20,   20.01,  25,    25.01,  36,  36.01]
-    y_dist = [1.3,  1.3,  1.3,  1.35, 1.35, 1.385,  1.385, 1.4,   1.4,  1.45]
-  elif personality==custom.LongitudinalPersonalitySP.aggressive:
-    x_vel =  [0,     5,     5.01,  11,    14.5,   15,    20,    20.01,  25, 25.01, 36,   36.01]
-    y_dist = [1.12,  1.12,  1.12,  1.12,  1.12,  1.105, 1.105, 1.15, 1.15, 1.18, 1.20,  1.23]
-  else:
-    raise NotImplementedError("Dynamic personality not supported")
-
-  return np.interp(v_ego, x_vel, y_dist)
+  """Adjust T_FOLLOW based on vehicle speed (scales 0.75-1.0 from 0-36 m/s)."""
+  scale_factor = np.clip(np.interp(v_ego, [0, 36], [0.75, 1.0]), 0.75, 1.0)
+  return get_T_FOLLOW(personality) * scale_factor
 
 
 def get_stopped_equivalence_factor(v_lead):


### PR DESCRIPTION
**Description**

This change simplifies the logic of the dynamic personality feature. It uses the already defined standard offsets of T_FOLLOW, but adjusts them gradually from 75% to 100% from 0 to 36 speed. I think this simplifies the logic, and avoids hard coded values.

I'm not entirely sure why Kumar chose 36.01, as I could not find a PR, but for now this mirrors his logic.

**Verification**

Manually tested in Kia Sportage 2023 + Comma C3.