### PR TITLE
MADS: cleanup param assignments

### DIFF
--- a/selfdrive/car/card.py
+++ b/selfdrive/car/card.py
@@ -24,7 +24,7 @@ from openpilot.selfdrive.car.cruise import VCruiseHelper
 from openpilot.selfdrive.car.car_specific import MockCarState
 from openpilot.selfdrive.car.helpers import convert_carControlSP, convert_to_capnp
 
-from openpilot.sunnypilot.mads.mads import MadsParams
+from openpilot.sunnypilot.mads.helpers import set_alternative_experience, set_car_specific_params
 from openpilot.sunnypilot.selfdrive.car import interfaces as sunnypilot_interfaces
 
 REPLAY = "REPLAY" in os.environ
@@ -126,8 +126,8 @@ class Car:
       self.CP.alternativeExperience |= ALTERNATIVE_EXPERIENCE.DISABLE_DISENGAGE_ON_GAS
 
     # mads
-    MadsParams().set_alternative_experience(self.CP)
-    MadsParams().set_car_specific_params(self.CP, self.CP_SP)
+    set_alternative_experience(self.CP, self.params)
+    set_car_specific_params(self.CP, self.CP_SP, self.params)
 
     # Dynamic Experimental Control
     self.dynamic_experimental_control = self.params.get_bool("DynamicExperimentalControl")

--- a/sunnypilot/mads/helpers.py
+++ b/sunnypilot/mads/helpers.py
@@ -6,43 +6,37 @@ See the LICENSE.md file in the root directory for more details.
 """
 
 from openpilot.common.params import Params
-
+from opendbc.car import structs
 from opendbc.safety import ALTERNATIVE_EXPERIENCE
 from opendbc.sunnypilot.car.hyundai.values import HyundaiFlagsSP, HyundaiSafetyFlagsSP
 
 
-class MadsParams:
-  def __init__(self):
-    self.params = Params()
+def set_alternative_experience(CP: structs.CarParams, params: Params):
+  enabled = params.get_bool("Mads")
+  pause_lateral_on_brake = params.get_bool("MadsPauseLateralOnBrake")
 
-  def read_param(self, key: str):
-    return self.params.get_bool(key)
+  if enabled:
+    CP.alternativeExperience |= ALTERNATIVE_EXPERIENCE.ENABLE_MADS
 
-  def set_alternative_experience(self, CP):
-    enabled = self.read_param("Mads")
-    pause_lateral_on_brake = self.read_param("MadsPauseLateralOnBrake")
+    if pause_lateral_on_brake:
+      CP.alternativeExperience |= ALTERNATIVE_EXPERIENCE.DISENGAGE_LATERAL_ON_BRAKE
 
-    if enabled:
-      CP.alternativeExperience |= ALTERNATIVE_EXPERIENCE.ENABLE_MADS
 
-      if pause_lateral_on_brake:
-        CP.alternativeExperience |= ALTERNATIVE_EXPERIENCE.DISENGAGE_LATERAL_ON_BRAKE
+def set_car_specific_params(CP: structs.CarParams, CP_SP: structs.CarParamsSP, params: Params):
+  if CP.brand == "hyundai":
+    # TODO-SP: This should be separated from MADS module for future implementations
+    #          Use "HyundaiLongitudinalMainCruiseToggleable" param
+    hyundai_cruise_main_toggleable = True
+    if hyundai_cruise_main_toggleable:
+      CP_SP.flags |= HyundaiFlagsSP.LONGITUDINAL_MAIN_CRUISE_TOGGLEABLE.value
+      CP_SP.safetyParam |= HyundaiSafetyFlagsSP.LONG_MAIN_CRUISE_TOGGLEABLE
 
-  def set_car_specific_params(self, CP, CP_SP):
-    if CP.brand == "hyundai":
-      # TODO-SP: This should be separated from MADS module for future implementations
-      #          Use "HyundaiLongitudinalMainCruiseToggleable" param
-      hyundai_cruise_main_toggleable = True
-      if hyundai_cruise_main_toggleable:
-        CP_SP.flags |= HyundaiFlagsSP.LONGITUDINAL_MAIN_CRUISE_TOGGLEABLE.value
-        CP_SP.safetyParam |= HyundaiSafetyFlagsSP.LONG_MAIN_CRUISE_TOGGLEABLE
+  # MADS is currently not supported in Tesla due to lack of consistent states to engage controls
+  # TODO-SP: To enable MADS for Tesla, identify consistent signals for MADS toggling
+  if CP.brand == "tesla":
+    params.remove("Mads")
 
-    # MADS is currently not supported in Tesla due to lack of consistent states to engage controls
-    # TODO-SP: To enable MADS for Tesla, identify consistent signals for MADS toggling
-    if CP.brand == "tesla":
-      self.params.remove("Mads")
-
-    # MADS is currently not supported in Rivian due to lack of consistent states to engage controls
-    # TODO-SP: To enable MADS for Rivian, identify consistent signals for MADS toggling
-    if CP.brand == "rivian":
-      self.params.remove("Mads")
+  # MADS is currently not supported in Rivian due to lack of consistent states to engage controls
+  # TODO-SP: To enable MADS for Rivian, identify consistent signals for MADS toggling
+  if CP.brand == "rivian":
+    params.remove("Mads")

--- a/sunnypilot/mads/mads.py
+++ b/sunnypilot/mads/mads.py
@@ -8,8 +8,6 @@ See the LICENSE.md file in the root directory for more details.
 from cereal import car, log, custom
 
 from opendbc.car.hyundai.values import HyundaiFlags
-
-from openpilot.sunnypilot.mads.helpers import MadsParams
 from openpilot.sunnypilot.mads.state import StateMachine, GEARS_ALLOW_PAUSED_SILENT
 
 State = custom.ModularAssistiveDrivingSystem.ModularAssistiveDrivingSystemState
@@ -24,7 +22,7 @@ IGNORED_SAFETY_MODES = (SafetyModel.silent, SafetyModel.noOutput)
 
 class ModularAssistiveDrivingSystem:
   def __init__(self, selfdrive):
-    self.mads_params = MadsParams()
+    self.params = selfdrive.params
 
     self.enabled = False
     self.active = False
@@ -41,14 +39,14 @@ class ModularAssistiveDrivingSystem:
         self.allow_always = True
 
     # read params on init
-    self.enabled_toggle = self.mads_params.read_param("Mads")
-    self.main_enabled_toggle = self.mads_params.read_param("MadsMainCruiseAllowed")
-    self.pause_lateral_on_brake_toggle = self.mads_params.read_param("MadsPauseLateralOnBrake")
-    self.unified_engagement_mode = self.mads_params.read_param("MadsUnifiedEngagementMode")
+    self.enabled_toggle = self.params.get_bool("Mads")
+    self.main_enabled_toggle = self.params.get_bool("MadsMainCruiseAllowed")
+    self.pause_lateral_on_brake_toggle = self.params.get_bool("MadsPauseLateralOnBrake")
+    self.unified_engagement_mode = self.params.get_bool("MadsUnifiedEngagementMode")
 
   def read_params(self):
-    self.main_enabled_toggle = self.mads_params.read_param("MadsMainCruiseAllowed")
-    self.unified_engagement_mode = self.mads_params.read_param("MadsUnifiedEngagementMode")
+    self.main_enabled_toggle = self.params.get_bool("MadsMainCruiseAllowed")
+    self.unified_engagement_mode = self.params.get_bool("MadsUnifiedEngagementMode")
 
   def update_events(self, CS: car.CarState):
     def update_unified_engagement_mode():


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Refactors the MADS module to remove the MadsParams class and directly use the Params class for reading and writing parameters. This simplifies the code and reduces redundancy.

Enhancements:
- Removes the MadsParams class and uses the Params class directly.
- Moves the set_alternative_experience and set_car_specific_params functions to helpers.py.