### PR TITLE
ui: reset all sunnypilot settings

### DIFF
--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/device_panel.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/device_panel.cc
@@ -21,6 +21,7 @@ DevicePanelSP::DevicePanelSP(SettingsWindowSP *parent) : DevicePanel(parent) {
     {"retrainingBtn", tr("Training Guide")},
     {"regulatoryBtn", tr("Regulatory")},
     {"translateBtn", tr("Language")},
+    {"resetParams", tr("Reset Settings")},
   };
 
   int row = 0, col = 0;
@@ -63,6 +64,15 @@ DevicePanelSP::DevicePanelSP(SettingsWindowSP *parent) : DevicePanel(parent) {
       params.put("LanguageSetting", langs[selection].toStdString());
       qApp->exit(18);
       watchdog_kick(0);
+    }
+  });
+
+  connect(buttons["resetParams"], &PushButtonSP::clicked, [=]() {
+    if (ConfirmationDialog::confirm(tr("Are you sure you want to reset all sunnypilot settings? This cannot be undone."), tr("Reset"), this)) {
+      int rm = std::system("sudo rm -rf /data/params/d/*");
+      if (rm == 0) {
+        Hardware::reboot();
+      }
     }
   });
 

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/device_panel.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/device_panel.cc
@@ -68,7 +68,7 @@ DevicePanelSP::DevicePanelSP(SettingsWindowSP *parent) : DevicePanel(parent) {
   });
 
   connect(buttons["resetParams"], &PushButtonSP::clicked, [=]() {
-    if (ConfirmationDialog::confirm(tr("Are you sure you want to reset all sunnypilot settings? This cannot be undone."), tr("Reset"), this)) {
+    if (ConfirmationDialog::confirm(tr("Are you sure you want to reset all sunnypilot settings to default ? This cannot be undone."), tr("Reset"), this)) {
       int rm = std::system("sudo rm -rf /data/params/d/*");
       if (rm == 0) {
         Hardware::reboot();


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Chores:
- Adds a button to reset all sunnypilot settings.