### PR TITLE
Params: support filtering by `ParamKeyType` for `allKeys`

### DIFF
--- a/common/params.cc
+++ b/common/params.cc
@@ -103,10 +103,12 @@ Params::~Params() {
   assert(queue.empty());
 }
 
-std::vector<std::string> Params::allKeys() const {
+std::vector<std::string> Params::allKeys(ParamKeyType type) const {
   std::vector<std::string> ret;
   for (auto &p : keys) {
-    ret.push_back(p.first);
+    if (type == ALL || (p.second & type)) {
+      ret.push_back(p.first);
+    }
   }
   return ret;
 }

--- a/common/params.h
+++ b/common/params.h
@@ -28,7 +28,7 @@ public:
   Params(const Params&) = delete;
   Params& operator=(const Params&) = delete;
 
-  std::vector<std::string> allKeys() const;
+  std::vector<std::string> allKeys(ParamKeyType type = ALL) const;
   bool checkKey(const std::string &key);
   ParamKeyType getKeyType(const std::string &key);
   inline std::string getParamPath(const std::string &key = {}) {

--- a/common/params_pyx.pyx
+++ b/common/params_pyx.pyx
@@ -11,6 +11,7 @@ cdef extern from "common/params.h":
     CLEAR_ON_ONROAD_TRANSITION
     CLEAR_ON_OFFROAD_TRANSITION
     DEVELOPMENT_ONLY
+    BACKUP
     ALL
 
   cdef cppclass c_Params "Params":
@@ -25,7 +26,7 @@ cdef extern from "common/params.h":
     bool checkKey(string) nogil
     string getParamPath(string) nogil
     void clearAll(ParamKeyType)
-    vector[string] allKeys()
+    vector[string] allKeys(ParamKeyType)
 
 
 def ensure_bytes(v):
@@ -119,5 +120,5 @@ cdef class Params:
     cdef string key_bytes = ensure_bytes(key)
     return self.p.getParamPath(key_bytes).decode("utf-8")
 
-  def all_keys(self):
-    return self.p.allKeys()
+  def all_keys(self, type=ParamKeyType.ALL):
+    return self.p.allKeys(type)


### PR DESCRIPTION
Split from #681

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Enhancements:
- Enable filtering of keys returned by `allKeys` based on `ParamKeyType`.