### PR TITLE
ui: Fix NNLC toggle not staying in persistent state

### DIFF
--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/lateral/neural_network_lateral_control.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/lateral/neural_network_lateral_control.cc
@@ -13,10 +13,6 @@ NeuralNetworkLateralControl::NeuralNetworkLateralControl() :
   updateToggle();
 }
 
-void NeuralNetworkLateralControl::showEvent(QShowEvent *event) {
-  updateToggle();
-}
-
 void NeuralNetworkLateralControl::updateToggle() {
   QString statusInitText = "<font color='yellow'>" + STATUS_CHECK_COMPATIBILITY + "</font>";
   QString notLoadedText = "<font color='yellow'>" + STATUS_NOT_LOADED + "</font>";

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/lateral/neural_network_lateral_control.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/lateral/neural_network_lateral_control.h
@@ -18,15 +18,12 @@ class NeuralNetworkLateralControl : public ParamControl {
 
 public:
   NeuralNetworkLateralControl();
-  void showEvent(QShowEvent *event) override;
 
 public slots:
   void updateToggle();
 
 private:
   Params params;
-
-  void refresh();
 
   // Status messages
   const QString STATUS_NOT_AVAILABLE = tr("NNLC is currently not available on this platform.");

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/lateral_panel.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/lateral_panel.cc
@@ -85,6 +85,7 @@ LateralPanel::LateralPanel(SettingsWindowSP *parent) : QFrame(parent) {
 }
 
 void LateralPanel::showEvent(QShowEvent *event) {
+  nnlcToggle->updateToggle();
   updateToggles(offroad);
 }
 


### PR DESCRIPTION
The `showEvent` method in `NeuralNetworkLateralControl` was removed as it duplicated functionality now handled in `LateralPanel`. The unused `refresh` method was also removed to streamline the code and improve maintainability.

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Fix the NNLC toggle persistence issue by updating the toggle state in LateralPanel's showEvent method and remove redundant methods from NeuralNetworkLateralControl for code maintainability.

Bug Fixes:
- Fix the NNLC toggle not maintaining its state by ensuring the updateToggle method is called in the LateralPanel's showEvent method.

Enhancements:
- Remove the redundant showEvent method from NeuralNetworkLateralControl as its functionality is now handled by LateralPanel.
- Remove the unused refresh method from NeuralNetworkLateralControl to streamline the code.