### PR TITLE
NNLC: use torque substitutes as fuzzy fingerprints

### DIFF
--- a/sunnypilot/selfdrive/controls/lib/nnlc/helpers.py
+++ b/sunnypilot/selfdrive/controls/lib/nnlc/helpers.py
@@ -55,8 +55,6 @@ def get_nn_model_path(CP: structs.CarParams) -> tuple[str, str, bool]:
 
       for candidate in [car_fingerprint, sub_candidate]:
         model_path, max_similarity = check_nn_path(candidate)
-        if max_similarity >= 0.8:
-          break
 
       exact_match = False
 

--- a/sunnypilot/selfdrive/controls/lib/nnlc/helpers.py
+++ b/sunnypilot/selfdrive/controls/lib/nnlc/helpers.py
@@ -21,6 +21,7 @@ def similarity(s1: str, s2: str) -> float:
 
 
 def get_nn_model_path(CP: structs.CarParams) -> tuple[str, str, bool]:
+  exact_match = True
   car_fingerprint = CP.carFingerprint
   eps_fw = str(next((fw.fwVersion for fw in CP.carFw if fw.ecu == "eps"), ""))
 
@@ -55,10 +56,11 @@ def get_nn_model_path(CP: structs.CarParams) -> tuple[str, str, bool]:
       for candidate in [car_fingerprint, sub_candidate]:
         model_path, max_similarity = check_nn_path(candidate)
 
+      exact_match = False
+
   if CP.steerControlType == structs.CarParams.SteerControlType.angle:
     model_path = MOCK_MODEL_PATH
 
   model_name = os.path.splitext(os.path.basename(model_path))[0]
-  exact_match = max_similarity >= 0.99
 
   return model_path, model_name, exact_match

--- a/sunnypilot/selfdrive/controls/lib/nnlc/helpers.py
+++ b/sunnypilot/selfdrive/controls/lib/nnlc/helpers.py
@@ -21,7 +21,6 @@ def similarity(s1: str, s2: str) -> float:
 
 
 def get_nn_model_path(CP: structs.CarParams) -> tuple[str, str, bool]:
-  exact_match = True
   car_fingerprint = CP.carFingerprint
   eps_fw = str(next((fw.fwVersion for fw in CP.carFw if fw.ecu == "eps"), ""))
 
@@ -44,6 +43,8 @@ def get_nn_model_path(CP: structs.CarParams) -> tuple[str, str, bool]:
     nn_candidate = car_fingerprint
 
   model_path, max_similarity = check_nn_path(nn_candidate)
+
+  exact_match = max_similarity >= 0.99
 
   if car_fingerprint not in model_path or 0.0 <= max_similarity < 0.8:
     nn_candidate = car_fingerprint

--- a/sunnypilot/selfdrive/controls/lib/nnlc/helpers.py
+++ b/sunnypilot/selfdrive/controls/lib/nnlc/helpers.py
@@ -55,6 +55,8 @@ def get_nn_model_path(CP: structs.CarParams) -> tuple[str, str, bool]:
 
       for candidate in [car_fingerprint, sub_candidate]:
         model_path, max_similarity = check_nn_path(candidate)
+        if max_similarity >= 0.8:
+          break
 
       exact_match = False
 

--- a/sunnypilot/selfdrive/controls/lib/nnlc/helpers.py
+++ b/sunnypilot/selfdrive/controls/lib/nnlc/helpers.py
@@ -5,12 +5,14 @@ This file is part of sunnypilot and is licensed under the MIT License.
 See the LICENSE.md file in the root directory for more details.
 """
 import os
+import tomllib
 from difflib import SequenceMatcher
 
 from opendbc.car import structs
 from openpilot.common.basedir import BASEDIR
 
 TORQUE_NN_MODEL_PATH = os.path.join(BASEDIR, "sunnypilot", "neural_network_data", "neural_network_lateral_control")
+TORQUE_NN_MODEL_SUBSTITUTE_PATH = os.path.join(BASEDIR, "opendbc", "car", "torque_data/substitute.toml")
 MOCK_MODEL_PATH = os.path.join(TORQUE_NN_MODEL_PATH, "MOCK.json")
 
 
@@ -46,7 +48,12 @@ def get_nn_model_path(CP: structs.CarParams) -> tuple[str, str, bool]:
     nn_candidate = car_fingerprint
     model_path, max_similarity = check_nn_path(nn_candidate)
     if 0.0 <= max_similarity < 0.8:
-      model_path = MOCK_MODEL_PATH
+      with open(TORQUE_NN_MODEL_SUBSTITUTE_PATH, 'rb') as f:
+        sub = tomllib.load(f)
+      sub_candidate = sub.get(car_fingerprint, car_fingerprint)
+
+      for candidate in [car_fingerprint, sub_candidate]:
+        model_path, max_similarity = check_nn_path(candidate)
 
   if CP.steerControlType == structs.CarParams.SteerControlType.angle:
     model_path = MOCK_MODEL_PATH

--- a/sunnypilot/selfdrive/controls/lib/nnlc/tests/test_load_model.py
+++ b/sunnypilot/selfdrive/controls/lib/nnlc/tests/test_load_model.py
@@ -1,4 +1,3 @@
-from numpy.ma.testutils import assert_equal
 from parameterized import parameterized
 
 from opendbc.car.car_helpers import interfaces

--- a/sunnypilot/selfdrive/controls/lib/nnlc/tests/test_load_model.py
+++ b/sunnypilot/selfdrive/controls/lib/nnlc/tests/test_load_model.py
@@ -13,8 +13,8 @@ from openpilot.sunnypilot.selfdrive.car import interfaces as sunnypilot_interfac
 
 class TestNNTorqueModel:
 
-  @parameterized.expand([(HONDA.HONDA_CIVIC, True), (TOYOTA.TOYOTA_RAV4, True), (HYUNDAI.HYUNDAI_SANTA_CRUZ_1ST_GEN, False)])
-  def test_load_model(self, car_name, should_load_model):
+  @parameterized.expand([HONDA.HONDA_CIVIC, TOYOTA.TOYOTA_RAV4, HYUNDAI.HYUNDAI_SANTA_CRUZ_1ST_GEN])
+  def test_load_model(self, car_name):
     params = Params()
     params.put_bool("NeuralNetworkLateralControl", True)
 
@@ -29,4 +29,4 @@ class TestNNTorqueModel:
 
     controller = LatControlTorque(CP.as_reader(), CP_SP.as_reader(), CI)
 
-    assert_equal(should_load_model, controller.extension.has_nn_model)
+    assert controller.extension.has_nn_model


### PR DESCRIPTION
for extra nnlc model path checks, take the first one that passes.

## Summary by Sourcery

Enhancements:
- Prioritizes the first NNLC model path that passes the similarity check.