### PR TITLE
NNLC: bump max similarity for higher accuracy

### DIFF
--- a/sunnypilot/selfdrive/controls/lib/nnlc/helpers.py
+++ b/sunnypilot/selfdrive/controls/lib/nnlc/helpers.py
@@ -46,10 +46,10 @@ def get_nn_model_path(CP: structs.CarParams) -> tuple[str, str, bool]:
 
   exact_match = max_similarity >= 0.99
 
-  if car_fingerprint not in model_path or 0.0 <= max_similarity < 0.8:
+  if car_fingerprint not in model_path or 0.0 <= max_similarity < 0.9:
     nn_candidate = car_fingerprint
     model_path, max_similarity = check_nn_path(nn_candidate)
-    if 0.0 <= max_similarity < 0.8:
+    if 0.0 <= max_similarity < 0.9:
       with open(TORQUE_NN_MODEL_SUBSTITUTE_PATH, 'rb') as f:
         sub = tomllib.load(f)
       sub_candidate = sub.get(car_fingerprint, car_fingerprint)


### PR DESCRIPTION
## Summary by Sourcery

Increase the minimum similarity score for selecting a neural network model from 0.8 to 0.9. This change ensures that only models with a higher degree of similarity to the vehicle's fingerprint are used, potentially improving the accuracy and reliability of the neural network-based longitudinal control.