### PR TITLE
ui: fix offset with `OptionControlSP` for macOS

### DIFF
--- a/selfdrive/ui/sunnypilot/qt/widgets/controls.h
+++ b/selfdrive/ui/sunnypilot/qt/widgets/controls.h
@@ -520,7 +520,11 @@ protected:
     }
 
     // Draw the rectangle
+#ifdef __APPLE__
+    QRect rect(0, !_title.isEmpty() ? (h - 16) : 20, w, h);
+#else
     QRect rect(0, !_title.isEmpty() ? (h - 24) : 20, w, h);
+#endif
     p.setBrush(QColor(button_enabled ? "#b24a4a4a" : "#121212")); // Background color
     p.setPen(QPen(Qt::NoPen));
     p.drawRoundedRect(rect, 20, 20);


### PR DESCRIPTION
|  Before  |  After  |
| -- | -- |
| ![image](https://github.com/user-attachments/assets/891192f1-e512-4bab-b45c-ab8084ae9d72) | ![image](https://github.com/user-attachments/assets/4a28fdfe-b1f2-46fd-8554-b9cec37eb960) |


<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Bug Fixes:
- Fixes an offset issue with the `OptionControlSP` widget on macOS.