### PR TITLE
ui: vertical space for `ListWidget`

### DIFF
--- a/selfdrive/ui/sunnypilot/qt/widgets/controls.cc
+++ b/selfdrive/ui/sunnypilot/qt/widgets/controls.cc
@@ -22,6 +22,13 @@ QFrame *horizontal_line(QWidget *parent) {
   return line;
 }
 
+QFrame *vertical_space(int height, QWidget *parent) {
+  QFrame *v_space = new QFrame(parent);
+  v_space->setFrameShape(QFrame::StyledPanel);
+  v_space->setFixedHeight(height);
+  return v_space;
+}
+
 // AbstractControlSP
 
 AbstractControlSP::AbstractControlSP(const QString &title, const QString &desc, const QString &icon, QWidget *parent)

--- a/selfdrive/ui/sunnypilot/qt/widgets/controls.h
+++ b/selfdrive/ui/sunnypilot/qt/widgets/controls.h
@@ -18,6 +18,7 @@
 #include "selfdrive/ui/sunnypilot/qt/widgets/toggle.h"
 
 QFrame *horizontal_line(QWidget *parent = nullptr);
+QFrame *vertical_space(int height = 10, QWidget *parent = nullptr);
 
 inline void ReplaceWidget(QWidget *old_widget, QWidget *new_widget) {
   if (old_widget && old_widget->parentWidget() && old_widget->parentWidget()->layout()) {


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Adds a `vertical_space` widget to `controls.cc` and `controls.h`. This widget creates a vertical space with a specified height.