### PR TITLE
ci: Update PR title formatting for Squash and Merge

### DIFF
--- a/release/ci/squash_and_merge_prs.py
+++ b/release/ci/squash_and_merge_prs.py
@@ -147,7 +147,7 @@ def process_pr(pr_data, source_branch, target_branch, squash_script_path):
           squash_script_path,
           '--target', target_branch,
           '--source', branch,
-          '--title', f"{title} (#{pr_number})",
+          '--title', f"{title} (PR-{pr_number})",
         ], check=True)
 
         print(f"Successfully processed PR #{pr_number}")


### PR DESCRIPTION
Changed the PR reference format from (`#123`) to (PR-123) in squash commit messages to prevent GitHub from automatically adding reference comments to PRs when `master-dev-c3-new` is force pushed.

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

