### PR TITLE
Test revert encoding changes

### DIFF
--- a/system/camerad/sensors/ox03c10_registers.h
+++ b/system/camerad/sensors/ox03c10_registers.h
@@ -65,7 +65,7 @@ const struct i2c_random_wr_payload init_array_ox03c10[] = {
   {0x3008, 0x80}, // io_pad_sel
 
   // FSIN (frame sync) with external pulses
-  {0x3822, 0x33},  // wait for pulse before first frame
+  //{0x3822, 0x33},  // wait for pulse before first frame 
   {0x3009, 0x2},
   {0x3015, 0x2},
   {0x383E, 0x80},


### PR DESCRIPTION
Test for https://github.com/sunnypilot/sunnypilot/issues/703

## Summary by Sourcery

This PR improves camera stability by adjusting buffer depth based on output type and refining request ID validation. It also modifies the V4LEncoder to set a fixed denominator for the timeperframe parameter.

Enhancements:
- Adjusts the IFE buffer depth based on the camera configuration's output type, increasing it to 4 when the output type is ISP_RAW_OUTPUT.
- Refines the request ID validation logic in SpectraCamera to prevent skipping requests.
- Removes unnecessary timestamp check in handle_camera_event.
- Removes unused last_requeue_ts variable from SpectraCamera.
- Updates the stress_test function to reduce memory usage and improve readability.
- Sets a fixed denominator for the timeperframe parameter in V4LEncoder.