### PR TITLE
modeld: Enforce float type for `lag_adjusted_curvature`

### DIFF
--- a/sunnypilot/selfdrive/controls/lib/drive_helpers.py
+++ b/sunnypilot/selfdrive/controls/lib/drive_helpers.py
@@ -24,4 +24,4 @@ def get_lag_adjusted_curvature(steer_delay, v_ego, psis, curvatures):
                                 current_curvature_desired - max_curvature_rate * DT_MDL,
                                 current_curvature_desired + max_curvature_rate * DT_MDL)
 
-  return safe_desired_curvature
+  return float(safe_desired_curvature)


### PR DESCRIPTION
Found that when we try to fill_model_msg and the model output contains `lat_planner_solution` (BDv2 does) then the serialization of capnp fails beause the value returned by `get_lag_adjusted_curvature` is now `numpy.float64` instead of `float` as it used to be due to the removal of numpy fast and subsequent update on https://github.com/sunnypilot/sunnypilot/commit/141a7f5f72d6ed1c5b466a30ee55f5b58f3dac46 

![image](https://github.com/user-attachments/assets/ce5f2ea6-bcfb-4153-893f-1eccbdad0b25)

This will make sure the value returned is converted to python's primitive float

## Summary by Sourcery

Bug Fixes:
- Ensures that the value returned by `get_lag_adjusted_curvature` is converted to a Python float to avoid serialization errors.