### PR TITLE
NNLC: Fix exact match consistency

### DIFF
--- a/sunnypilot/selfdrive/controls/lib/nnlc/helpers.py
+++ b/sunnypilot/selfdrive/controls/lib/nnlc/helpers.py
@@ -43,12 +43,13 @@ def get_nn_model_path(CP: structs.CarParams) -> tuple[str, str, bool]:
     nn_candidate = car_fingerprint
 
   model_path, max_similarity = check_nn_path(nn_candidate)
-
   exact_match = max_similarity >= 0.99
 
   if car_fingerprint not in model_path or 0.0 <= max_similarity < 0.9:
     nn_candidate = car_fingerprint
     model_path, max_similarity = check_nn_path(nn_candidate)
+    exact_match = max_similarity >= 0.99
+
     if 0.0 <= max_similarity < 0.9:
       with open(TORQUE_NN_MODEL_SUBSTITUTE_PATH, 'rb') as f:
         sub = tomllib.load(f)


### PR DESCRIPTION
Move the exact_match calculation after updating model_path and max_similarity to ensure consistency. This prevents potential discrepancies when rechecking NN paths and enhances code maintainability.

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Bug Fixes:
- Ensure exact match calculation is consistent by moving it after updating model_path and max_similarity.