### PR TITLE
car: abstract sunnypilot interfaces

### DIFF
--- a/selfdrive/car/card.py
+++ b/selfdrive/car/card.py
@@ -108,7 +108,7 @@ class Car:
       fixed_fingerprint = json.loads(self.params.get("CarPlatformBundle", encoding='utf-8') or "{}").get("platform", None)
 
       self.CI = get_car(*self.can_callbacks, obd_callback(self.params), experimental_long_allowed, num_pandas, cached_params, fixed_fingerprint)
-      sunnypilot_interfaces.setup_car_interface_sp(self.CI.CP, self.CI.CP_SP, self.params)
+      sunnypilot_interfaces.setup_interfaces(self.CI.CP, self.CI.CP_SP, self.params)
       self.RI = interfaces[self.CI.CP.carFingerprint].RadarInterface(self.CI.CP, self.CI.CP_SP)
       self.CP = self.CI.CP
       self.CP_SP = self.CI.CP_SP
@@ -274,7 +274,7 @@ class Car:
       # Initialize CarInterface, once controls are ready
       # TODO: this can make us miss at least a few cycles when doing an ECU knockout
       self.CI.init(self.CP, self.CP_SP, *self.can_callbacks)
-      sunnypilot_interfaces.initialize_car_interface_sp(self.CP, self.CP_SP, self.params, *self.can_callbacks)
+      sunnypilot_interfaces.init_interfaces(self.CP, self.CP_SP, self.params, *self.can_callbacks)
       # signal pandad to switch to car safety mode
       self.params.put_bool_nonblocking("ControlsReady", True)
 

--- a/selfdrive/car/tests/test_car_interfaces.py
+++ b/selfdrive/car/tests/test_car_interfaces.py
@@ -45,7 +45,7 @@ class TestCarInterfaces:
                                          experimental_long=args['experimental_long'], docs=False)
     car_params_sp = CarInterface.get_params_sp(car_params, car_name, args['fingerprints'], args['car_fw'],
                                                experimental_long=args['experimental_long'], docs=False)
-    sunnypilot_interfaces.setup_car_interface_sp(car_params, car_params_sp)
+    sunnypilot_interfaces.setup_interfaces(car_params, car_params_sp)
     car_params = car_params.as_reader()
     car_interface = CarInterface(car_params, car_params_sp)
     assert car_params

--- a/selfdrive/controls/lib/tests/test_latcontrol.py
+++ b/selfdrive/controls/lib/tests/test_latcontrol.py
@@ -23,7 +23,7 @@ class TestLatControl:
     CP = CarInterface.get_non_essential_params(car_name)
     CP_SP = CarInterface.get_non_essential_params_sp(CP, car_name)
     CI = CarInterface(CP, CP_SP)
-    sunnypilot_interfaces.setup_car_interface_sp(CP, CP_SP)
+    sunnypilot_interfaces.setup_interfaces(CP, CP_SP)
     CP_SP = convert_to_capnp(CP_SP)
     VM = VehicleModel(CP)
 

--- a/sunnypilot/selfdrive/car/interfaces.py
+++ b/sunnypilot/selfdrive/car/interfaces.py
@@ -47,7 +47,7 @@ def initialize_neural_network_lateral_control(CP: structs.CarParams, CP_SP: stru
   CP_SP.neuralNetworkLateralControl.fuzzyFingerprint = not exact_match
 
 
-def setup_car_interface_sp(CP: structs.CarParams, CP_SP: structs.CarParamsSP, params: Params = None):
+def initialize_radar_tracks(CP: structs.CarParams, CP_SP: structs.CarParamsSP, params: Params = None) -> None:
   if params is None:
     params = Params()
 
@@ -60,11 +60,17 @@ def setup_car_interface_sp(CP: structs.CarParams, CP_SP: structs.CarParamsSP, pa
         if params.get_bool("HyundaiRadarTracks"):
           CP.radarUnavailable = False
 
+
+def setup_car_interface_sp(CP: structs.CarParams, CP_SP: structs.CarParamsSP, params: Params = None):
   initialize_neural_network_lateral_control(CP, CP_SP, params)
+  initialize_radar_tracks(CP, CP_SP, params)
 
 
-def initialize_car_interface_sp(CP: structs.CarParams, CP_SP: structs.CarParamsSP, params, can_recv: CanRecvCallable,
-                                can_send: CanSendCallable):
+def enable_radar_tracks(CP: structs.CarParams, CP_SP: structs.CarParamsSP, can_recv: CanRecvCallable,
+                        params: Params = None) -> None:
+  if params is None:
+    params = Params()
+
   if CP.brand == 'hyundai':
     if CP_SP.flags & HyundaiFlagsSP.ENABLE_RADAR_TRACKS:
       can_recv()
@@ -79,3 +85,8 @@ def initialize_car_interface_sp(CP: structs.CarParams, CP_SP: structs.CarParamsS
       if not radar_tracks_persistent:
         params.put_bool_nonblocking("HyundaiRadarTracks", not radar_unavailable)
         params.put_bool_nonblocking("HyundaiRadarTracksPersistent", True)
+
+
+def initialize_car_interface_sp(CP: structs.CarParams, CP_SP: structs.CarParamsSP, params, can_recv: CanRecvCallable,
+                                can_send: CanSendCallable):
+  enable_radar_tracks(CP, CP_SP, can_recv, params)

--- a/sunnypilot/selfdrive/car/interfaces.py
+++ b/sunnypilot/selfdrive/car/interfaces.py
@@ -67,10 +67,7 @@ def setup_car_interface_sp(CP: structs.CarParams, CP_SP: structs.CarParamsSP, pa
 
 
 def enable_radar_tracks(CP: structs.CarParams, CP_SP: structs.CarParamsSP, can_recv: CanRecvCallable,
-                        params: Params = None) -> None:
-  if params is None:
-    params = Params()
-
+                        params: Params) -> None:
   if CP.brand == 'hyundai':
     if CP_SP.flags & HyundaiFlagsSP.ENABLE_RADAR_TRACKS:
       can_recv()
@@ -87,6 +84,6 @@ def enable_radar_tracks(CP: structs.CarParams, CP_SP: structs.CarParamsSP, can_r
         params.put_bool_nonblocking("HyundaiRadarTracksPersistent", True)
 
 
-def initialize_car_interface_sp(CP: structs.CarParams, CP_SP: structs.CarParamsSP, params, can_recv: CanRecvCallable,
-                                can_send: CanSendCallable):
+def initialize_car_interface_sp(CP: structs.CarParams, CP_SP: structs.CarParamsSP, params: Params,
+                                can_recv: CanRecvCallable, can_send: CanSendCallable):
   enable_radar_tracks(CP, CP_SP, can_recv, params)

--- a/sunnypilot/selfdrive/car/interfaces.py
+++ b/sunnypilot/selfdrive/car/interfaces.py
@@ -26,7 +26,7 @@ def log_fingerprint(CP: structs.CarParams) -> None:
     sentry.capture_fingerprint(CP.carFingerprint, CP.brand)
 
 
-def initialize_neural_network_lateral_control(CP: structs.CarParams, CP_SP: structs.CarParamsSP, params: Params = None,
+def _initialize_neural_network_lateral_control(CP: structs.CarParams, CP_SP: structs.CarParamsSP, params: Params = None,
                                               enabled: bool = False) -> None:
   if params is None:
     params = Params()
@@ -47,7 +47,7 @@ def initialize_neural_network_lateral_control(CP: structs.CarParams, CP_SP: stru
   CP_SP.neuralNetworkLateralControl.fuzzyFingerprint = not exact_match
 
 
-def initialize_radar_tracks(CP: structs.CarParams, CP_SP: structs.CarParamsSP, params: Params = None) -> None:
+def _initialize_radar_tracks(CP: structs.CarParams, CP_SP: structs.CarParamsSP, params: Params = None) -> None:
   if params is None:
     params = Params()
 
@@ -62,11 +62,11 @@ def initialize_radar_tracks(CP: structs.CarParams, CP_SP: structs.CarParamsSP, p
 
 
 def setup_interfaces(CP: structs.CarParams, CP_SP: structs.CarParamsSP, params: Params = None):
-  initialize_neural_network_lateral_control(CP, CP_SP, params)
-  initialize_radar_tracks(CP, CP_SP, params)
+  _initialize_neural_network_lateral_control(CP, CP_SP, params)
+  _initialize_radar_tracks(CP, CP_SP, params)
 
 
-def enable_radar_tracks(CP: structs.CarParams, CP_SP: structs.CarParamsSP, can_recv: CanRecvCallable,
+def _enable_radar_tracks(CP: structs.CarParams, CP_SP: structs.CarParamsSP, can_recv: CanRecvCallable,
                         params: Params) -> None:
   if CP.brand == 'hyundai':
     if CP_SP.flags & HyundaiFlagsSP.ENABLE_RADAR_TRACKS:
@@ -86,4 +86,4 @@ def enable_radar_tracks(CP: structs.CarParams, CP_SP: structs.CarParamsSP, can_r
 
 def init_interfaces(CP: structs.CarParams, CP_SP: structs.CarParamsSP, params: Params,
                                 can_recv: CanRecvCallable, can_send: CanSendCallable):
-  enable_radar_tracks(CP, CP_SP, can_recv, params)
+  _enable_radar_tracks(CP, CP_SP, can_recv, params)

--- a/sunnypilot/selfdrive/car/interfaces.py
+++ b/sunnypilot/selfdrive/car/interfaces.py
@@ -61,7 +61,7 @@ def initialize_radar_tracks(CP: structs.CarParams, CP_SP: structs.CarParamsSP, p
           CP.radarUnavailable = False
 
 
-def setup_car_interface_sp(CP: structs.CarParams, CP_SP: structs.CarParamsSP, params: Params = None):
+def setup_interfaces(CP: structs.CarParams, CP_SP: structs.CarParamsSP, params: Params = None):
   initialize_neural_network_lateral_control(CP, CP_SP, params)
   initialize_radar_tracks(CP, CP_SP, params)
 
@@ -84,6 +84,6 @@ def enable_radar_tracks(CP: structs.CarParams, CP_SP: structs.CarParamsSP, can_r
         params.put_bool_nonblocking("HyundaiRadarTracksPersistent", True)
 
 
-def initialize_car_interface_sp(CP: structs.CarParams, CP_SP: structs.CarParamsSP, params: Params,
+def init_interfaces(CP: structs.CarParams, CP_SP: structs.CarParamsSP, params: Params,
                                 can_recv: CanRecvCallable, can_send: CanSendCallable):
   enable_radar_tracks(CP, CP_SP, can_recv, params)

--- a/sunnypilot/selfdrive/controls/lib/drive_helpers.py
+++ b/sunnypilot/selfdrive/controls/lib/drive_helpers.py
@@ -24,4 +24,4 @@ def get_lag_adjusted_curvature(steer_delay, v_ego, psis, curvatures):
                                 current_curvature_desired - max_curvature_rate * DT_MDL,
                                 current_curvature_desired + max_curvature_rate * DT_MDL)
 
-  return safe_desired_curvature
+  return float(safe_desired_curvature)

--- a/sunnypilot/selfdrive/controls/lib/nnlc/tests/test_fingerprint.py
+++ b/sunnypilot/selfdrive/controls/lib/nnlc/tests/test_fingerprint.py
@@ -24,7 +24,7 @@ class TestNNLCFingerprintBase:
     CP_SP = CarInterface.get_non_essential_params_sp(CP, car_name)
     CI = CarInterface(CP, CP_SP)
 
-    sunnypilot_interfaces.setup_car_interface_sp(CP, CP_SP, Params())
+    sunnypilot_interfaces.setup_interfaces(CP, CP_SP, Params())
 
     return CI
 

--- a/sunnypilot/selfdrive/controls/lib/nnlc/tests/test_load_model.py
+++ b/sunnypilot/selfdrive/controls/lib/nnlc/tests/test_load_model.py
@@ -22,7 +22,7 @@ class TestNNTorqueModel:
     CP_SP = CarInterface.get_non_essential_params_sp(CP, car_name)
     CI = CarInterface(CP, CP_SP)
 
-    sunnypilot_interfaces.setup_car_interface_sp(CP, CP_SP, params)
+    sunnypilot_interfaces.setup_interfaces(CP, CP_SP, params)
 
     CP_SP = convert_to_capnp(CP_SP)
 


### PR DESCRIPTION
Method abstracting radar tracks in interfaces.py. This makes the code more maintainable for future implementations to this file

## Summary by Sourcery

Refactor and abstract radar track initialization methods in the car interfaces module to improve code maintainability

New Features:
- Added separate methods for initializing and enabling radar tracks
- Introduced type hints and clearer function responsibilities

Enhancements:
- Split existing methods into more focused functions for initializing and enabling radar tracks
- Improve modularity of radar track configuration logic