### PR TITLE
MADS: Soft disable for non-Drive forward gear if in motion

### DIFF
--- a/sunnypilot/mads/mads.py
+++ b/sunnypilot/mads/mads.py
@@ -71,7 +71,7 @@ class ModularAssistiveDrivingSystem:
       if self.events.has(EventName.seatbeltNotLatched):
         replace_event(EventName.seatbeltNotLatched, EventNameSP.silentSeatbeltNotLatched)
         transition_paused_state()
-      if self.events.has(EventName.wrongGear):
+      if self.events.has(EventName.wrongGear) and CS.standstill:
         replace_event(EventName.wrongGear, EventNameSP.silentWrongGear)
         transition_paused_state()
       if self.events.has(EventName.reverseGear):

--- a/sunnypilot/mads/mads.py
+++ b/sunnypilot/mads/mads.py
@@ -72,7 +72,7 @@ class ModularAssistiveDrivingSystem:
         replace_event(EventName.seatbeltNotLatched, EventNameSP.silentSeatbeltNotLatched)
         transition_paused_state()
       if self.events.has(EventName.wrongGear) and CS.standstill:
-        replace_event(EventName.wrongGear, EventNameSP.silentWrongGear)
+        replace_event(EventName.wrongGear, EventNameSP.silentWrongGear) # test
         transition_paused_state()
       if self.events.has(EventName.reverseGear):
         replace_event(EventName.reverseGear, EventNameSP.silentReverseGear)

--- a/sunnypilot/mads/mads.py
+++ b/sunnypilot/mads/mads.py
@@ -72,7 +72,7 @@ class ModularAssistiveDrivingSystem:
         replace_event(EventName.seatbeltNotLatched, EventNameSP.silentSeatbeltNotLatched)
         transition_paused_state()
       if self.events.has(EventName.wrongGear) and CS.standstill:
-        replace_event(EventName.wrongGear, EventNameSP.silentWrongGear) # test
+        replace_event(EventName.wrongGear, EventNameSP.silentWrongGear)
         transition_paused_state()
       if self.events.has(EventName.reverseGear):
         replace_event(EventName.reverseGear, EventNameSP.silentReverseGear)

--- a/tools/lib/framereader.py
+++ b/tools/lib/framereader.py
@@ -490,7 +490,7 @@ class GOPFrameReader(BaseFrameReader):
 
       ret = decompress_video_data(rawdat, self.vid_fmt, self.w, self.h, pix_fmt)
       ret = ret[skip_frames:]
-      assert ret.shape[0] == num_frames
+      # assert ret.shape[0] == num_frames
 
       for i in range(ret.shape[0]):
         self.frame_cache[(frame_b+i, pix_fmt)] = ret[i]

--- a/tools/lib/framereader.py
+++ b/tools/lib/framereader.py
@@ -490,7 +490,7 @@ class GOPFrameReader(BaseFrameReader):
 
       ret = decompress_video_data(rawdat, self.vid_fmt, self.w, self.h, pix_fmt)
       ret = ret[skip_frames:]
-      # assert ret.shape[0] == num_frames
+      assert ret.shape[0] == num_frames
 
       for i in range(ret.shape[0]):
         self.frame_cache[(frame_b+i, pix_fmt)] = ret[i]


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Bug Fixes:
- Add a condition to only trigger soft disable for wrong gear when the vehicle is not moving (at standstill)