### PR TITLE
CI: Cache macOS Homebrew and Scons

### DIFF
--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -116,6 +116,12 @@ jobs:
           scons-${{ runner.arch }}-macos
     - name: Building openpilot
       run: . .venv/bin/activate && scons -j$(nproc)
+    - name: Save scons cache
+      if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/master-new')
+      uses: actions/cache/save@v4
+      with:
+        path: /tmp/scons_cache
+        key: scons-${{ runner.arch }}-macos-${{ env.CACHE_COMMIT_DATE }}-${{ github.sha }}
 
   static_analysis:
     name: static analysis

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -117,8 +117,8 @@ jobs:
     - name: Building openpilot
       run: . .venv/bin/activate && scons -j$(nproc)
     - name: Save scons cache
-      if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/master-new')
       uses: actions/cache/save@v4
+      if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/master-new' || github.ref == 'refs/heads/feature/ci-macos-cache')
       with:
         path: /tmp/scons_cache
         key: scons-${{ runner.arch }}-macos-${{ env.CACHE_COMMIT_DATE }}-${{ github.sha }}

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -105,6 +105,12 @@ jobs:
       env:
         # package install has DeprecationWarnings
         PYTHONWARNINGS: default
+    - name: Save Homebrew cache
+      uses: actions/cache/save@v4
+      if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/master-new' || github.head_ref == 'feature/ci-macos-cache')
+      with:
+        path: ~/Library/Caches/Homebrew
+        key: brew-macos-${{ env.CACHE_COMMIT_DATE }}-${{ github.sha }}
     - run: git lfs pull
     - name: Getting scons cache
       uses: ./.github/workflows/auto-cache

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -118,7 +118,7 @@ jobs:
       run: . .venv/bin/activate && scons -j$(nproc)
     - name: Save scons cache
       uses: actions/cache/save@v4
-      if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/master-new' || github.ref == 'refs/heads/feature/ci-macos-cache')
+      if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/master-new' || github.head_ref == 'feature/ci-macos-cache')
       with:
         path: /tmp/scons_cache
         key: scons-${{ runner.arch }}-macos-${{ env.CACHE_COMMIT_DATE }}-${{ github.sha }}

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -118,7 +118,7 @@ jobs:
       run: . .venv/bin/activate && scons -j$(nproc)
     - name: Save scons cache
       uses: actions/cache/save@v4
-      if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/master-new' || github.head_ref == 'feature/ci-macos-cache')
+      if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/master-new')
       with:
         path: /tmp/scons_cache
         key: scons-${{ runner.arch }}-macos-${{ env.CACHE_COMMIT_DATE }}-${{ github.sha }}

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -107,7 +107,7 @@ jobs:
         PYTHONWARNINGS: default
     - name: Save Homebrew cache
       uses: actions/cache/save@v4
-      if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/master-new' || github.head_ref == 'feature/ci-macos-cache')
+      if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/master-new')
       with:
         path: ~/Library/Caches/Homebrew
         key: brew-macos-${{ env.CACHE_COMMIT_DATE }}-${{ github.sha }}


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Add caching for Homebrew and scons builds on macOS CI workflows to improve build performance and reduce redundant downloads

CI:
- Implement caching for Homebrew package manager and scons build system on macOS GitHub Actions workflow
- Configure cache saving for master and master-new branches to optimize CI build times