### PR TITLE
Revert "MADS: Soft disable for non-Drive forward gear if in motion"

### DIFF
--- a/sunnypilot/mads/mads.py
+++ b/sunnypilot/mads/mads.py
@@ -70,7 +70,7 @@ class ModularAssistiveDrivingSystem:
       if self.events.has(EventName.seatbeltNotLatched):
         replace_event(EventName.seatbeltNotLatched, EventNameSP.silentSeatbeltNotLatched)
         transition_paused_state()
-      if self.events.has(EventName.wrongGear) and CS.standstill:
+      if self.events.has(EventName.wrongGear):
         replace_event(EventName.wrongGear, EventNameSP.silentWrongGear)
         transition_paused_state()
       if self.events.has(EventName.reverseGear):


### PR DESCRIPTION
Reverts sunnypilot/sunnypilot#784

This affects other non forward gears. Reverting and reimplementing.

## Summary by Sourcery

Bug Fixes:
- Remove the standstill condition for wrong gear events, allowing the event to be processed regardless of vehicle speed