### PR TITLE
MADS: prevent `wrongCarMode` from disabling MADS enabled state

### DIFF
--- a/cereal/custom.capnp
+++ b/cereal/custom.capnp
@@ -136,6 +136,7 @@ struct OnroadEventSP @0xda96579883444c35 {
     controlsMismatchLateral @12;
     hyundaiRadarTracksConfirmed @13;
     experimentalModeSwitched @14;
+    wrongCarModeNoEntry @15;
   }
 }
 

--- a/cereal/custom.capnp
+++ b/cereal/custom.capnp
@@ -136,7 +136,7 @@ struct OnroadEventSP @0xda96579883444c35 {
     controlsMismatchLateral @12;
     hyundaiRadarTracksConfirmed @13;
     experimentalModeSwitched @14;
-    wrongCarModeNoEntry @15;
+    wrongCarModeAlertOnly @15;
   }
 }
 

--- a/selfdrive/selfdrived/events.py
+++ b/selfdrive/selfdrived/events.py
@@ -11,7 +11,7 @@ from openpilot.selfdrive.locationd.calibrationd import MIN_SPEED_FILTER
 
 from openpilot.sunnypilot.selfdrive.selfdrived.events_base import EventsBase, Priority, ET, Alert, \
   NoEntryAlert, SoftDisableAlert, UserSoftDisableAlert, ImmediateDisableAlert, EngagementAlert, NormalPermanentAlert, \
-  StartupAlert, AlertCallbackType
+  StartupAlert, AlertCallbackType, wrong_car_mode_alert
 
 
 AlertSize = log.SelfdriveState.AlertSize
@@ -168,13 +168,6 @@ def high_cpu_usage_alert(CP: car.CarParams, CS: car.CarState, sm: messaging.SubM
 
 def modeld_lagging_alert(CP: car.CarParams, CS: car.CarState, sm: messaging.SubMaster, metric: bool, soft_disable_time: int, personality) -> Alert:
   return NormalPermanentAlert("Driving Model Lagging", f"{sm['modelV2'].frameDropPerc:.1f}% frames dropped")
-
-
-def wrong_car_mode_alert(CP: car.CarParams, CS: car.CarState, sm: messaging.SubMaster, metric: bool, soft_disable_time: int, personality) -> Alert:
-  text = "Enable Adaptive Cruise to Engage"
-  if CP.brand == "honda":
-    text = "Enable Main Switch to Engage"
-  return NoEntryAlert(text)
 
 
 def joystick_alert(CP: car.CarParams, CS: car.CarState, sm: messaging.SubMaster, metric: bool, soft_disable_time: int, personality) -> Alert:

--- a/sunnypilot/mads/mads.py
+++ b/sunnypilot/mads/mads.py
@@ -82,8 +82,6 @@ class ModularAssistiveDrivingSystem:
       if self.events.has(EventName.parkBrake):
         replace_event(EventName.parkBrake, EventNameSP.silentParkBrake)
         transition_paused_state()
-      if self.events.has(EventName.wrongCarMode):
-        replace_event(EventName.wrongCarMode, EventNameSP.wrongCarModeAlertOnly)
 
       if self.pause_lateral_on_brake_toggle:
         if CS.brakePressed:
@@ -129,7 +127,9 @@ class ModularAssistiveDrivingSystem:
     self.events.remove(EventName.buttonCancel)
     self.events.remove(EventName.pedalPressed)
     self.events.remove(EventName.wrongCruiseMode)
-    if not any(be.type in SET_SPEED_BUTTONS for be in CS.buttonEvents):
+    if any(be.type in SET_SPEED_BUTTONS for be in CS.buttonEvents):
+      replace_event(EventName.wrongCarMode, EventNameSP.wrongCarModeAlertOnly)
+    else:
       self.events.remove(EventName.wrongCarMode)
 
   def update(self, CS: car.CarState):

--- a/sunnypilot/mads/mads.py
+++ b/sunnypilot/mads/mads.py
@@ -83,7 +83,7 @@ class ModularAssistiveDrivingSystem:
         replace_event(EventName.parkBrake, EventNameSP.silentParkBrake)
         transition_paused_state()
       if self.events.has(EventName.wrongCarMode):
-        replace_event(EventName.wrongCarMode, EventNameSP.wrongCarModeNoEntry)
+        replace_event(EventName.wrongCarMode, EventNameSP.wrongCarModeAlertOnly)
 
       if self.pause_lateral_on_brake_toggle:
         if CS.brakePressed:

--- a/sunnypilot/mads/mads.py
+++ b/sunnypilot/mads/mads.py
@@ -82,6 +82,8 @@ class ModularAssistiveDrivingSystem:
       if self.events.has(EventName.parkBrake):
         replace_event(EventName.parkBrake, EventNameSP.silentParkBrake)
         transition_paused_state()
+      if self.events.has(EventName.wrongCarMode):
+        replace_event(EventName.wrongCarMode, EventNameSP.wrongCarModeNoEntry)
 
       if self.pause_lateral_on_brake_toggle:
         if CS.brakePressed:

--- a/sunnypilot/mads/mads.py
+++ b/sunnypilot/mads/mads.py
@@ -128,7 +128,8 @@ class ModularAssistiveDrivingSystem:
     self.events.remove(EventName.pedalPressed)
     self.events.remove(EventName.wrongCruiseMode)
     if any(be.type in SET_SPEED_BUTTONS for be in CS.buttonEvents):
-      replace_event(EventName.wrongCarMode, EventNameSP.wrongCarModeAlertOnly)
+      if self.events.has(EventName.wrongCarMode):
+        replace_event(EventName.wrongCarMode, EventNameSP.wrongCarModeAlertOnly)
     else:
       self.events.remove(EventName.wrongCarMode)
 

--- a/sunnypilot/selfdrive/selfdrived/events.py
+++ b/sunnypilot/selfdrive/selfdrived/events.py
@@ -130,7 +130,7 @@ EVENTS_SP: dict[int, dict[str, Alert | AlertCallbackType]] = {
     ET.WARNING: NormalPermanentAlert("Experimental Mode Switched", duration=1.5)
   },
 
-  EventNameSP.wrongCarModeNoEntry: {
+  EventNameSP.wrongCarModeAlertOnly: {
     ET.WARNING: wrong_car_mode_alert,
   },
 

--- a/sunnypilot/selfdrive/selfdrived/events.py
+++ b/sunnypilot/selfdrive/selfdrived/events.py
@@ -131,7 +131,7 @@ EVENTS_SP: dict[int, dict[str, Alert | AlertCallbackType]] = {
   },
 
   EventNameSP.wrongCarModeNoEntry: {
-    ET.NO_ENTRY: wrong_car_mode_alert,
+    ET.WARNING: wrong_car_mode_alert,
   },
 
 }

--- a/sunnypilot/selfdrive/selfdrived/events.py
+++ b/sunnypilot/selfdrive/selfdrived/events.py
@@ -1,6 +1,6 @@
 from cereal import log, car, custom
 from openpilot.sunnypilot.selfdrive.selfdrived.events_base import EventsBase, Priority, ET, Alert, \
-  NoEntryAlert, ImmediateDisableAlert, EngagementAlert, NormalPermanentAlert, AlertCallbackType
+  NoEntryAlert, ImmediateDisableAlert, EngagementAlert, NormalPermanentAlert, AlertCallbackType, wrong_car_mode_alert
 
 
 AlertSize = log.SelfdriveState.AlertSize
@@ -128,6 +128,10 @@ EVENTS_SP: dict[int, dict[str, Alert | AlertCallbackType]] = {
 
   EventNameSP.experimentalModeSwitched: {
     ET.WARNING: NormalPermanentAlert("Experimental Mode Switched", duration=1.5)
-  }
+  },
+
+  EventNameSP.wrongCarModeNoEntry: {
+    ET.NO_ENTRY: wrong_car_mode_alert,
+  },
 
 }

--- a/sunnypilot/selfdrive/selfdrived/events_base.py
+++ b/sunnypilot/selfdrive/selfdrived/events_base.py
@@ -37,6 +37,13 @@ class ET:
   PERMANENT = 'permanent'
 
 
+def wrong_car_mode_alert(CP: car.CarParams, CS: car.CarState, sm: messaging.SubMaster, metric: bool, soft_disable_time: int, personality) -> Alert:
+  text = "Enable Adaptive Cruise to Engage"
+  if CP.brand == "honda":
+    text = "Enable Main Switch to Engage"
+  return NoEntryAlert(text)
+
+
 class Alert:
   def __init__(self,
                alert_text_1: str,

--- a/sunnypilot/selfdrive/selfdrived/events_base.py
+++ b/sunnypilot/selfdrive/selfdrived/events_base.py
@@ -37,13 +37,6 @@ class ET:
   PERMANENT = 'permanent'
 
 
-def wrong_car_mode_alert(CP: car.CarParams, CS: car.CarState, sm: messaging.SubMaster, metric: bool, soft_disable_time: int, personality) -> Alert:
-  text = "Enable Adaptive Cruise to Engage"
-  if CP.brand == "honda":
-    text = "Enable Main Switch to Engage"
-  return NoEntryAlert(text)
-
-
 class Alert:
   def __init__(self,
                alert_text_1: str,
@@ -88,6 +81,16 @@ class AlertBase(Alert):
 
 
 AlertCallbackType = Callable[[car.CarParams, car.CarState, messaging.SubMaster, bool, int, log.ControlsState], Alert]
+
+
+# ********** alert callback functions **********
+
+
+def wrong_car_mode_alert(CP: car.CarParams, CS: car.CarState, sm: messaging.SubMaster, metric: bool, soft_disable_time: int, personality) -> Alert:
+  text = "Enable Adaptive Cruise to Engage"
+  if CP.brand == "honda":
+    text = "Enable Main Switch to Engage"
+  return NoEntryAlert(text)
 
 
 class EventsBase:


### PR DESCRIPTION
## Summary by Sourcery

Modify the handling of wrong car mode event to prevent disabling MADS (Modular Assistive Driving System) enabled state

New Features:
- Introduce a new event type `wrongCarModeAlertOnly` that provides an alert without disabling the driving system

Enhancements:
- Customize alert text for wrong car mode based on car brand
- Create a separate alert callback function for wrong car mode events

Chores:
- Update custom event definitions to include the new `wrongCarModeAlertOnly` event