### PR TITLE
UI: Update `AbstractControlSP_SELECTOR` and `OptionControlSP`

### DIFF
--- a/selfdrive/ui/sunnypilot/qt/widgets/controls.cc
+++ b/selfdrive/ui/sunnypilot/qt/widgets/controls.cc
@@ -132,10 +132,7 @@ AbstractControlSP_SELECTOR::AbstractControlSP_SELECTOR(const QString &title, con
 
         if (isVisible && spacingItem) {
           main_layout->removeItem(spacingItem);
-          delete spacingItem;
-          spacingItem = nullptr;
-        } else if (!isVisible && spacingItem == nullptr) {
-          spacingItem = new QSpacerItem(44, 44, QSizePolicy::Minimum, QSizePolicy::Fixed);
+        } else if (!isVisible && spacingItem != nullptr && main_layout->indexOf(spacingItem) == -1) {
           main_layout->insertItem(main_layout->indexOf(description), spacingItem);
         }
       }
@@ -145,8 +142,7 @@ AbstractControlSP_SELECTOR::AbstractControlSP_SELECTOR(const QString &title, con
   }
 
   main_layout->addLayout(hlayout);
-  if (!desc.isEmpty() && spacingItem == nullptr) {
-    spacingItem = new QSpacerItem(44, 44, QSizePolicy::Minimum, QSizePolicy::Fixed);
+  if (!desc.isEmpty() && spacingItem != nullptr && main_layout->indexOf(spacingItem) == -1) {
     main_layout->insertItem(main_layout->count(), spacingItem);
   }
 
@@ -166,8 +162,7 @@ void AbstractControlSP_SELECTOR::hideEvent(QHideEvent *e) {
     description->hide();
   }
 
-  if (spacingItem == nullptr) {
-    spacingItem = new QSpacerItem(44, 44, QSizePolicy::Minimum, QSizePolicy::Fixed);
+  if (spacingItem != nullptr && main_layout->indexOf(spacingItem) == -1) {
     main_layout->insertItem(main_layout->indexOf(description), spacingItem);
   }
 }

--- a/selfdrive/ui/sunnypilot/qt/widgets/controls.cc
+++ b/selfdrive/ui/sunnypilot/qt/widgets/controls.cc
@@ -82,8 +82,8 @@ void AbstractControlSP::hideEvent(QHideEvent *e) {
   }
 }
 
-AbstractControlSP_SELECTOR::AbstractControlSP_SELECTOR(const QString &title, const QString &desc, const QString &icon, QWidget *parent, const bool inline_layout)
-    : AbstractControlSP(title, desc, icon, parent), isInlineLayout(inline_layout) {
+AbstractControlSP_SELECTOR::AbstractControlSP_SELECTOR(const QString &title, const QString &desc, const QString &icon, QWidget *parent)
+    : AbstractControlSP(title, desc, icon, parent) {
 
   if (title_label != nullptr) {
     delete title_label;
@@ -119,12 +119,7 @@ AbstractControlSP_SELECTOR::AbstractControlSP_SELECTOR(const QString &title, con
     title_label = new QPushButton(title);
     title_label->setFixedHeight(120);
     title_label->setStyleSheet("font-size: 50px; font-weight: 450; text-align: left; border: none; padding: 20 0 0 0");
-    if (isInlineLayout) {
-      hlayout->addWidget(title_label, 1);
-    } else {
-      main_layout->addWidget(title_label, 1);
-    }
-
+    main_layout->addWidget(title_label, 1);
 
     connect(title_label, &QPushButton::clicked, [=]() {
       if (!description->isVisible()) {
@@ -139,7 +134,7 @@ AbstractControlSP_SELECTOR::AbstractControlSP_SELECTOR(const QString &title, con
           main_layout->removeItem(spacingItem);
           delete spacingItem;
           spacingItem = nullptr;
-        } else if (!isVisible && spacingItem == nullptr && !isInlineLayout) {
+        } else if (!isVisible && spacingItem == nullptr) {
           spacingItem = new QSpacerItem(44, 44, QSizePolicy::Minimum, QSizePolicy::Fixed);
           main_layout->insertItem(main_layout->indexOf(description), spacingItem);
         }
@@ -150,7 +145,7 @@ AbstractControlSP_SELECTOR::AbstractControlSP_SELECTOR(const QString &title, con
   }
 
   main_layout->addLayout(hlayout);
-  if (!desc.isEmpty() && spacingItem == nullptr && !isInlineLayout) {
+  if (!desc.isEmpty() && spacingItem == nullptr) {
     spacingItem = new QSpacerItem(44, 44, QSizePolicy::Minimum, QSizePolicy::Fixed);
     main_layout->insertItem(main_layout->count(), spacingItem);
   }
@@ -171,7 +166,7 @@ void AbstractControlSP_SELECTOR::hideEvent(QHideEvent *e) {
     description->hide();
   }
 
-  if (spacingItem == nullptr && !isInlineLayout) {
+  if (spacingItem == nullptr) {
     spacingItem = new QSpacerItem(44, 44, QSizePolicy::Minimum, QSizePolicy::Fixed);
     main_layout->insertItem(main_layout->indexOf(description), spacingItem);
   }

--- a/selfdrive/ui/sunnypilot/qt/widgets/controls.cc
+++ b/selfdrive/ui/sunnypilot/qt/widgets/controls.cc
@@ -82,7 +82,7 @@ void AbstractControlSP::hideEvent(QHideEvent *e) {
   }
 }
 
-AbstractControlSP_SELECTOR::AbstractControlSP_SELECTOR(const QString &title, const QString &desc, const QString &icon, QWidget *parent)
+AbstractControlSP_SELECTOR::AbstractControlSP_SELECTOR(const QString &title, const QString &desc, const QString &icon, QWidget *parent, const bool inline_layout)
     : AbstractControlSP(title, desc, icon, parent) {
 
   if (title_label != nullptr) {
@@ -114,12 +114,22 @@ AbstractControlSP_SELECTOR::AbstractControlSP_SELECTOR(const QString &title, con
   hlayout->setMargin(0);
   hlayout->setSpacing(0);
 
+  innerLayout = new QHBoxLayout;
+  innerLayout->setMargin(0);
+  innerLayout->setSpacing(0);
+  isInlineLayout = inline_layout;
+
   // title
   if (!title.isEmpty()) {
     title_label = new QPushButton(title);
     title_label->setFixedHeight(120);
     title_label->setStyleSheet("font-size: 50px; font-weight: 450; text-align: left; border: none; padding: 20 0 0 0");
-    main_layout->addWidget(title_label, 1);
+    if (isInlineLayout) {
+      hlayout->addWidget(title_label, 1);
+    } else {
+      main_layout->addWidget(title_label, 1);
+    }
+
 
     connect(title_label, &QPushButton::clicked, [=]() {
       if (!description->isVisible()) {
@@ -134,7 +144,7 @@ AbstractControlSP_SELECTOR::AbstractControlSP_SELECTOR(const QString &title, con
           main_layout->removeItem(spacingItem);
           delete spacingItem;
           spacingItem = nullptr;
-        } else if (!isVisible && spacingItem == nullptr) {
+        } else if (!isVisible && spacingItem == nullptr && !isInlineLayout) {
           spacingItem = new QSpacerItem(44, 44, QSizePolicy::Minimum, QSizePolicy::Fixed);
           main_layout->insertItem(main_layout->indexOf(description), spacingItem);
         }
@@ -145,7 +155,7 @@ AbstractControlSP_SELECTOR::AbstractControlSP_SELECTOR(const QString &title, con
   }
 
   main_layout->addLayout(hlayout);
-  if (!desc.isEmpty() && spacingItem == nullptr) {
+  if (!desc.isEmpty() && spacingItem == nullptr && !isInlineLayout) {
     spacingItem = new QSpacerItem(44, 44, QSizePolicy::Minimum, QSizePolicy::Fixed);
     main_layout->insertItem(main_layout->count(), spacingItem);
   }
@@ -166,7 +176,7 @@ void AbstractControlSP_SELECTOR::hideEvent(QHideEvent *e) {
     description->hide();
   }
 
-  if (spacingItem == nullptr) {
+  if (spacingItem == nullptr && !isInlineLayout) {
     spacingItem = new QSpacerItem(44, 44, QSizePolicy::Minimum, QSizePolicy::Fixed);
     main_layout->insertItem(main_layout->indexOf(description), spacingItem);
   }

--- a/selfdrive/ui/sunnypilot/qt/widgets/controls.cc
+++ b/selfdrive/ui/sunnypilot/qt/widgets/controls.cc
@@ -83,7 +83,7 @@ void AbstractControlSP::hideEvent(QHideEvent *e) {
 }
 
 AbstractControlSP_SELECTOR::AbstractControlSP_SELECTOR(const QString &title, const QString &desc, const QString &icon, QWidget *parent, const bool inline_layout)
-    : AbstractControlSP(title, desc, icon, parent) {
+    : AbstractControlSP(title, desc, icon, parent), isInlineLayout(inline_layout) {
 
   if (title_label != nullptr) {
     delete title_label;
@@ -113,11 +113,6 @@ AbstractControlSP_SELECTOR::AbstractControlSP_SELECTOR(const QString &title, con
   hlayout = new QHBoxLayout;
   hlayout->setMargin(0);
   hlayout->setSpacing(0);
-
-  innerLayout = new QHBoxLayout;
-  innerLayout->setMargin(0);
-  innerLayout->setSpacing(0);
-  isInlineLayout = inline_layout;
 
   // title
   if (!title.isEmpty()) {

--- a/selfdrive/ui/sunnypilot/qt/widgets/controls.h
+++ b/selfdrive/ui/sunnypilot/qt/widgets/controls.h
@@ -98,8 +98,6 @@ class AbstractControlSP_SELECTOR : public AbstractControlSP {
 protected:
   AbstractControlSP_SELECTOR(const QString &title, const QString &desc = "", const QString &icon = "", QWidget *parent = nullptr, const bool inline_layout = false);
   void hideEvent(QHideEvent *e) override;
-
-  QHBoxLayout *innerLayout;
   bool isInlineLayout;
 
 private:
@@ -420,6 +418,8 @@ class OptionControlSP : public AbstractControlSP_SELECTOR {
   Q_OBJECT
 
 private:
+  QHBoxLayout *optionSelectorLayout = isInlineLayout ? new QHBoxLayout() : hlayout;
+  
   struct MinMaxValue {
     int min_value;
     int max_value;
@@ -459,6 +459,11 @@ public:
       }
     )";
 
+    if (inline_layout) {
+      optionSelectorLayout->setMargin(0);
+      optionSelectorLayout->setSpacing(0);
+    }
+
     label.setStyleSheet(label_enabled_style);
     label.setFixedWidth(inline_layout ? 350 : 300);
     label.setAlignment(Qt::AlignCenter);
@@ -474,9 +479,9 @@ public:
       QPushButton *button = new QPushButton(button_texts[i], this);
       button->setStyleSheet(style + ((i == 0) ? "QPushButton { text-align: left; }" :
                                                 "QPushButton { text-align: right; }"));
-      innerLayout->addWidget(button, 0, ((i == 0) ? Qt::AlignLeft : Qt::AlignRight) | Qt::AlignVCenter);
+      optionSelectorLayout->addWidget(button, 0, ((i == 0) ? Qt::AlignLeft : Qt::AlignRight) | Qt::AlignVCenter);
       if (i == 0) {
-        innerLayout->addWidget(&label, 0, Qt::AlignCenter);
+        optionSelectorLayout->addWidget(&label, 0, Qt::AlignCenter);
       }
       button_group->addButton(button, i);
 
@@ -498,14 +503,12 @@ public:
       });
     }
 
-    innerLayout->setAlignment(Qt::AlignLeft);
+    optionSelectorLayout->setAlignment(Qt::AlignLeft);
     if (isInlineLayout) {
       QFrame *container = new QFrame;
-      container->setLayout(innerLayout);
+      container->setLayout(optionSelectorLayout);
       container->setStyleSheet("background-color: #393939; border-radius: 20px;");
       hlayout->addWidget(container);
-    } else {
-      hlayout->addLayout(innerLayout);
     }
   }
 
@@ -539,8 +542,8 @@ protected:
     int w = 0;
     int h = 150;
 
-    for (int i = 0; i < innerLayout->count(); ++i) {
-      QWidget *widget = qobject_cast<QWidget *>(innerLayout->itemAt(i)->widget());
+    for (int i = 0; i < optionSelectorLayout->count(); ++i) {
+      QWidget *widget = qobject_cast<QWidget *>(optionSelectorLayout->itemAt(i)->widget());
       if (widget) {
         w += widget->width();
       }

--- a/selfdrive/ui/sunnypilot/qt/widgets/controls.h
+++ b/selfdrive/ui/sunnypilot/qt/widgets/controls.h
@@ -448,7 +448,7 @@ public:
     )";
 
     label.setStyleSheet(label_enabled_style);
-    label.setFixedWidth(350);
+    label.setFixedWidth(inline_layout ? 350 : 300);
     label.setAlignment(Qt::AlignCenter);
 
     const std::vector<QString> button_texts{"－", "＋"};
@@ -540,7 +540,7 @@ protected:
       if (widget) {
         w += widget->width();
       }
-      }
+    }
 
     // Draw the rectangle
 #ifdef __APPLE__

--- a/selfdrive/ui/sunnypilot/qt/widgets/controls.h
+++ b/selfdrive/ui/sunnypilot/qt/widgets/controls.h
@@ -425,9 +425,10 @@ private:
     int max_value;
   };
   
-  QString getParamValue() {
-    auto param_value = QString::fromStdString(params.get(key));
-    return valueMap != nullptr ? valueMap->key(param_value) : param_value;
+  int getParamValue() {
+    const auto param_value = QString::fromStdString(params.get(key));
+    const auto result = valueMap != nullptr ? valueMap->key(param_value) : param_value;
+    return result.toInt();
   }
 
   // Although the method is not static, and thus has access to the value property, I prefer to be explicit about the value.
@@ -465,7 +466,7 @@ public:
     const std::vector<QString> button_texts{"－", "＋"};
 
     key = param.toStdString();
-    value = getParamValue().toInt();
+    value = getParamValue();
 
     button_group = new QButtonGroup(this);
     button_group->setExclusive(true);
@@ -481,6 +482,7 @@ public:
 
       QObject::connect(button, &QPushButton::clicked, [=]() {
         int change_value = (i == 0) ? -per_value_change : per_value_change;
+        value = getParamValue(); // in case it changed externally, we need to get the latest value.
         value += change_value;
         value = std::clamp(value, range.min_value, range.max_value);
         setParamValue(value);

--- a/selfdrive/ui/sunnypilot/qt/widgets/controls.h
+++ b/selfdrive/ui/sunnypilot/qt/widgets/controls.h
@@ -96,9 +96,8 @@ class AbstractControlSP_SELECTOR : public AbstractControlSP {
   Q_OBJECT
 
 protected:
-  AbstractControlSP_SELECTOR(const QString &title, const QString &desc = "", const QString &icon = "", QWidget *parent = nullptr, const bool inline_layout = false);
+  AbstractControlSP_SELECTOR(const QString &title, const QString &desc = "", const QString &icon = "", QWidget *parent = nullptr);
   void hideEvent(QHideEvent *e) override;
-  bool isInlineLayout;
 
 private:
   QSpacerItem *spacingItem = nullptr;
@@ -418,6 +417,7 @@ class OptionControlSP : public AbstractControlSP_SELECTOR {
   Q_OBJECT
 
 private:
+  bool isInlineLayout;
   QHBoxLayout *optionSelectorLayout = isInlineLayout ? new QHBoxLayout() : hlayout;
   
   struct MinMaxValue {
@@ -439,7 +439,7 @@ private:
 
 public:
   OptionControlSP(const QString &param, const QString &title, const QString &desc, const QString &icon,
-                  const MinMaxValue &range, const int per_value_change = 1, const bool inline_layout = false, const QMap<QString, QString> *valMap = nullptr) : valueMap(valMap), _title(title), AbstractControlSP_SELECTOR(title, desc, icon, nullptr, inline_layout) {
+                  const MinMaxValue &range, const int per_value_change = 1, const bool inline_layout = false, const QMap<QString, QString> *valMap = nullptr) : AbstractControlSP_SELECTOR(title, desc, icon, nullptr), _title(title), valueMap(valMap), isInlineLayout(inline_layout) {
     const QString style = R"(
       QPushButton {
         border-radius: 20px;
@@ -462,6 +462,10 @@ public:
     if (inline_layout) {
       optionSelectorLayout->setMargin(0);
       optionSelectorLayout->setSpacing(0);
+      if (!title.isEmpty()) {
+        main_layout->removeWidget(title_label);
+        hlayout->addWidget(title_label, 1);
+      }
     }
 
     label.setStyleSheet(label_enabled_style);

--- a/selfdrive/ui/sunnypilot/qt/widgets/controls.h
+++ b/selfdrive/ui/sunnypilot/qt/widgets/controls.h
@@ -96,11 +96,10 @@ class AbstractControlSP_SELECTOR : public AbstractControlSP {
   Q_OBJECT
 
 protected:
+  QSpacerItem *spacingItem = new QSpacerItem(44, 44, QSizePolicy::Minimum, QSizePolicy::Fixed);
   AbstractControlSP_SELECTOR(const QString &title, const QString &desc = "", const QString &icon = "", QWidget *parent = nullptr);
   void hideEvent(QHideEvent *e) override;
 
-private:
-  QSpacerItem *spacingItem = nullptr;
 };
 
 // widget to display a value
@@ -465,6 +464,10 @@ public:
       if (!title.isEmpty()) {
         main_layout->removeWidget(title_label);
         hlayout->addWidget(title_label, 1);
+      }
+      if (spacingItem != nullptr && main_layout->indexOf(spacingItem) != -1) {
+        main_layout->removeItem(spacingItem);
+        spacingItem = nullptr;
       }
     }
 


### PR DESCRIPTION
Splitting Widget changes from [Device: Max Time Offroad #796](https://github.com/sunnypilot/sunnypilot/pull/796)

This introduces 2 widget changes:

- Support an inline single-row layout for AbstractControlSP_SELECTOR to avoid wasting screen real-estate when not needed for smaller widgets like "Auto Lane Change" & "Max Time Offroad".
- Support for setting the actual value in params from OptionControlsSP instead of an index.

## Summary by Sourcery

Enhance the AbstractControlSP_SELECTOR and OptionControlSP widgets to support more flexible UI layouts and parameter handling

New Features:
- Implement flexible layout mode for smaller widgets like Auto Lane Change and Max Time Offroad
- Add capability to set actual parameter values directly from OptionControlsSP

Enhancements:
- Introduce an inline single-row layout option for widgets to optimize screen real-estate
- Add support for direct parameter value mapping instead of using index-based selection