### PR TITLE
UI: Device & Sunnylink Panels - Standardize push button size & alignment

### DIFF
--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/device_panel.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/device_panel.cc
@@ -31,15 +31,16 @@ DevicePanelSP::DevicePanelSP(SettingsWindowSP *parent) : DevicePanel(parent) {
       continue;
     }
 
-    auto *btn = new PushButtonSP(text, 720, this, param);
+    auto *btn = new PushButtonSP(text, 750, this, param);
     btn->setObjectName(id);
-
-    device_grid_layout->addWidget(btn, row, col);
     buttons[id] = btn;
 
-    col++;
-    if (col > 1) {
-      col = 0;
+    if (col==0) {
+      device_grid_layout->addWidget(btn, row, col, Qt::AlignLeft);
+      col++;
+    } else {
+      device_grid_layout->addWidget(btn, row, col, Qt::AlignRight);
+      col=0;
       row++;
     }
   }
@@ -79,14 +80,14 @@ DevicePanelSP::DevicePanelSP(SettingsWindowSP *parent) : DevicePanel(parent) {
   // offroad mode and power buttons
 
   QHBoxLayout *power_layout = new QHBoxLayout();
-  power_layout->setSpacing(5);
+  power_layout->setSpacing(25);
 
-  PushButtonSP *rebootBtn = new PushButtonSP(tr("Reboot"), 720, this);
+  PushButtonSP *rebootBtn = new PushButtonSP(tr("Reboot"), 750, this);
   rebootBtn->setStyleSheet(rebootButtonStyle);
   power_layout->addWidget(rebootBtn);
   QObject::connect(rebootBtn, &PushButtonSP::clicked, this, &DevicePanelSP::reboot);
 
-  PushButtonSP *poweroffBtn = new PushButtonSP(tr("Power Off"), 720, this);
+  PushButtonSP *poweroffBtn = new PushButtonSP(tr("Power Off"), 750, this);
   poweroffBtn->setStyleSheet(powerOffButtonStyle);
   power_layout->addWidget(poweroffBtn);
   QObject::connect(poweroffBtn, &PushButtonSP::clicked, this, &DevicePanelSP::poweroff);
@@ -100,7 +101,7 @@ DevicePanelSP::DevicePanelSP(SettingsWindowSP *parent) : DevicePanel(parent) {
   QObject::connect(offroadBtn, &PushButtonSP::clicked, this, &DevicePanelSP::setOffroadMode);
 
   QVBoxLayout *power_group_layout = new QVBoxLayout();
-  power_group_layout->setSpacing(30);
+  power_group_layout->setSpacing(25);
   power_group_layout->addWidget(offroadBtn, 0, Qt::AlignHCenter);
   power_group_layout->addLayout(power_layout);
 

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/sunnylink_panel.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/sunnylink_panel.cc
@@ -85,7 +85,7 @@ SunnylinkPanel::SunnylinkPanel(QWidget *parent) : QFrame(parent) {
   });
 
   // Backup Settings
-  backupSettings = new PushButtonSP(tr("Backup Settings"), 730, this);
+  backupSettings = new PushButtonSP(tr("Backup Settings"), 750, this);
   backupSettings->setObjectName("backup_btn");
   connect(backupSettings, &QPushButton::clicked, [=]() {
     backupSettings->setEnabled(false);
@@ -96,7 +96,7 @@ SunnylinkPanel::SunnylinkPanel(QWidget *parent) : QFrame(parent) {
   });
 
   // Restore Settings
-  restoreSettings = new PushButtonSP(tr("Restore Settings"), 730, this);
+  restoreSettings = new PushButtonSP(tr("Restore Settings"), 750, this);
   restoreSettings->setObjectName("restore_btn");
   connect(restoreSettings, &QPushButton::clicked, [=]() {
     restoreSettings->setEnabled(false);

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/sunnylink_panel.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/sunnylink_panel.cc
@@ -108,10 +108,9 @@ SunnylinkPanel::SunnylinkPanel(QWidget *parent) : QFrame(parent) {
   // Settings Restore and Settings Backup in the same horizontal space
   auto settings_layout = new QHBoxLayout;
   settings_layout->setContentsMargins(0, 0, 0, 30);
-  settings_layout->addWidget(backupSettings);
+  settings_layout->addWidget(backupSettings, 0, Qt::AlignLeft);
   settings_layout->addSpacing(10);
-  settings_layout->addWidget(restoreSettings);
-  settings_layout->setAlignment(Qt::AlignLeft);
+  settings_layout->addWidget(restoreSettings, 0, Qt::AlignRight);
   list->addItem(settings_layout);
 
   QObject::connect(uiState(), &UIState::offroadTransition, this, &SunnylinkPanel::updatePanel);


### PR DESCRIPTION
Standardize push button size & alignment on Device Panel & Sunnylink Panel. 
This will also allow additional widgets [like Max Offoroad] to align properly in these panels.

## Summary by Sourcery

Standardize push button sizing and alignment across Device and Sunnylink Panels to improve UI consistency and layout

New Features:
- Prepare UI layout for potential future widget additions like Max Offroad

Enhancements:
- Adjust button width from 720 to 750 pixels for consistent sizing
- Improve button alignment using explicit Qt alignment flags
- Modify layout spacing to create more uniform visual presentation