### PR TITLE
Hyundai longitudinal: Parse lead info for camera-based SCC platforms

### DIFF
--- a/selfdrive/controls/radard.py
+++ b/selfdrive/controls/radard.py
@@ -188,7 +188,7 @@ def get_lead(v_ego: float, ready: bool, tracks: dict[int, Track], lead_msg: capn
 
 def get_custom_yrel(CP: structs.CarParams, CP_SP: structs.CarParamsSP, lead_dict: dict[str, Any],
                     lead_msg: capnp._DynamicStructReader) -> dict[str, Any]:
-  if CP.brand == "hyundai" and CP_SP.flags & HyundaiFlagsSP.ENHANCED_SCC:
+  if CP.brand == "hyundai" and CP_SP.flags & (HyundaiFlagsSP.ENHANCED_SCC | HyundaiFlagsSP.CAMERA_SCC_LONG_SINGLE_LEAD):
     lead_dict['yRel'] = float(-lead_msg.y[0])
 
   return lead_dict

--- a/selfdrive/controls/radard.py
+++ b/selfdrive/controls/radard.py
@@ -13,6 +13,7 @@ from openpilot.common.swaglog import cloudlog
 from openpilot.common.simple_kalman import KF1D
 
 from opendbc.car import structs
+from opendbc.car.hyundai.values import HyundaiFlags
 from opendbc.sunnypilot.car.hyundai.values import HyundaiFlagsSP
 
 
@@ -188,7 +189,8 @@ def get_lead(v_ego: float, ready: bool, tracks: dict[int, Track], lead_msg: capn
 
 def get_custom_yrel(CP: structs.CarParams, CP_SP: structs.CarParamsSP, lead_dict: dict[str, Any],
                     lead_msg: capnp._DynamicStructReader) -> dict[str, Any]:
-  if CP.brand == "hyundai" and CP_SP.flags & (HyundaiFlagsSP.ENHANCED_SCC | HyundaiFlagsSP.CAMERA_SCC_LONG_SINGLE_LEAD):
+  if CP.brand == "hyundai" and (CP_SP.flags & HyundaiFlagsSP.ENHANCED_SCC or
+                                CP.flags & (HyundaiFlags.CANFD_CAMERA_SCC | HyundaiFlags.CAMERA_SCC)):
     lead_dict['yRel'] = float(-lead_msg.y[0])
 
   return lead_dict

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/device_panel.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/device_panel.cc
@@ -31,15 +31,16 @@ DevicePanelSP::DevicePanelSP(SettingsWindowSP *parent) : DevicePanel(parent) {
       continue;
     }
 
-    auto *btn = new PushButtonSP(text, 720, this, param);
+    auto *btn = new PushButtonSP(text, 750, this, param);
     btn->setObjectName(id);
-
-    device_grid_layout->addWidget(btn, row, col);
     buttons[id] = btn;
 
-    col++;
-    if (col > 1) {
-      col = 0;
+    if (col==0) {
+      device_grid_layout->addWidget(btn, row, col, Qt::AlignLeft);
+      col++;
+    } else {
+      device_grid_layout->addWidget(btn, row, col, Qt::AlignRight);
+      col=0;
       row++;
     }
   }
@@ -79,14 +80,14 @@ DevicePanelSP::DevicePanelSP(SettingsWindowSP *parent) : DevicePanel(parent) {
   // offroad mode and power buttons
 
   QHBoxLayout *power_layout = new QHBoxLayout();
-  power_layout->setSpacing(5);
+  power_layout->setSpacing(25);
 
-  PushButtonSP *rebootBtn = new PushButtonSP(tr("Reboot"), 720, this);
+  PushButtonSP *rebootBtn = new PushButtonSP(tr("Reboot"), 750, this);
   rebootBtn->setStyleSheet(rebootButtonStyle);
   power_layout->addWidget(rebootBtn);
   QObject::connect(rebootBtn, &PushButtonSP::clicked, this, &DevicePanelSP::reboot);
 
-  PushButtonSP *poweroffBtn = new PushButtonSP(tr("Power Off"), 720, this);
+  PushButtonSP *poweroffBtn = new PushButtonSP(tr("Power Off"), 750, this);
   poweroffBtn->setStyleSheet(powerOffButtonStyle);
   power_layout->addWidget(poweroffBtn);
   QObject::connect(poweroffBtn, &PushButtonSP::clicked, this, &DevicePanelSP::poweroff);
@@ -100,7 +101,7 @@ DevicePanelSP::DevicePanelSP(SettingsWindowSP *parent) : DevicePanel(parent) {
   QObject::connect(offroadBtn, &PushButtonSP::clicked, this, &DevicePanelSP::setOffroadMode);
 
   QVBoxLayout *power_group_layout = new QVBoxLayout();
-  power_group_layout->setSpacing(30);
+  power_group_layout->setSpacing(25);
   power_group_layout->addWidget(offroadBtn, 0, Qt::AlignHCenter);
   power_group_layout->addLayout(power_layout);
 

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/sunnylink_panel.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/sunnylink_panel.cc
@@ -85,7 +85,7 @@ SunnylinkPanel::SunnylinkPanel(QWidget *parent) : QFrame(parent) {
   });
 
   // Backup Settings
-  backupSettings = new PushButtonSP(tr("Backup Settings"), 730, this);
+  backupSettings = new PushButtonSP(tr("Backup Settings"), 750, this);
   backupSettings->setObjectName("backup_btn");
   connect(backupSettings, &QPushButton::clicked, [=]() {
     backupSettings->setEnabled(false);
@@ -96,7 +96,7 @@ SunnylinkPanel::SunnylinkPanel(QWidget *parent) : QFrame(parent) {
   });
 
   // Restore Settings
-  restoreSettings = new PushButtonSP(tr("Restore Settings"), 730, this);
+  restoreSettings = new PushButtonSP(tr("Restore Settings"), 750, this);
   restoreSettings->setObjectName("restore_btn");
   connect(restoreSettings, &QPushButton::clicked, [=]() {
     restoreSettings->setEnabled(false);
@@ -108,10 +108,9 @@ SunnylinkPanel::SunnylinkPanel(QWidget *parent) : QFrame(parent) {
   // Settings Restore and Settings Backup in the same horizontal space
   auto settings_layout = new QHBoxLayout;
   settings_layout->setContentsMargins(0, 0, 0, 30);
-  settings_layout->addWidget(backupSettings);
+  settings_layout->addWidget(backupSettings, 0, Qt::AlignLeft);
   settings_layout->addSpacing(10);
-  settings_layout->addWidget(restoreSettings);
-  settings_layout->setAlignment(Qt::AlignLeft);
+  settings_layout->addWidget(restoreSettings, 0, Qt::AlignRight);
   list->addItem(settings_layout);
 
   QObject::connect(uiState(), &UIState::offroadTransition, this, &SunnylinkPanel::updatePanel);


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Enhancements:
- Extend lead information parsing logic to support additional Hyundai camera-based SCC (Smart Cruise Control) platforms