### PR TITLE
update urls untill sunnypilot fork installer is ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Please refer to [Recommended Branches](#-recommended-branches) to find your pref
 |      Branch      |                 Installation URL              |
 |:----------------:|:---------------------------------------------:|
 | `staging-c3-new` | `https://smiskol.com/fork/sp/staging-c3-new`  |
-|   `dev-c3-new`   | `ttps://smiskol.com/fork/sp/dev-c3-new`       |
+|   `dev-c3-new`   | `https://smiskol.com/fork/sp/dev-c3-new`       |
 | `custom-branch`  | `https://install.sunnypilot.ai/{branch_name}` |
 | `release-c3-new` |            **Not yet available**.             |
 

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ Please refer to [Recommended Branches](#-recommended-branches) to find your pref
 
 |      Branch      |                 Installation URL              |
 |:----------------:|:---------------------------------------------:|
-| `staging-c3-new` | `https://staging-c3-new.sunnypilot.ai`        |
-|   `dev-c3-new`   | `https://dev-c3-new.sunnypilot.ai`            |
+| `staging-c3-new` | `https://smiskol.com/fork/sp/staging-c3-new`  |
+|   `dev-c3-new`   | `ttps://smiskol.com/fork/sp/dev-c3-new`       |
 | `custom-branch`  | `https://install.sunnypilot.ai/{branch_name}` |
 | `release-c3-new` |            **Not yet available**.             |
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Update installation URLs for staging and development branches to use temporary hosting domain