### PR TITLE
sunnylink: fix sunnylink backup restore version parsing

### DIFF
--- a/sunnypilot/sunnylink/backups/manager.py
+++ b/sunnypilot/sunnylink/backups/manager.py
@@ -210,11 +210,19 @@ class BackupManagerSP:
   def _get_current_version(self) -> custom.BackupManagerSP.Version:
     """Gets current sunnypilot version information."""
     version_obj = custom.BackupManagerSP.Version()
-    version_parts = get_version().split('.')
+
+    build = None
+    if (version_split := get_version().split('-')) and len(version_split) > 1:
+      build = int(version_split[1]) if version_split[1].isdigit() else 0
+
+    version_parts = version_split[0].split('.')
+    if build is None:
+      build = int(version_parts[3]) if len(version_parts) > 3 and version_parts[3].isdigit() else 0
+
     version_obj.major = int(version_parts[0]) if len(version_parts) > 0 else 0
     version_obj.minor = int(version_parts[1]) if len(version_parts) > 1 else 0
     version_obj.patch = int(version_parts[2]) if len(version_parts) > 2 else 0
-    version_obj.build = int(version_parts[3]) if len(version_parts) > 3 else 0
+    version_obj.build = build or 0
     version_obj.branch = get_branch()
     return version_obj
 

--- a/sunnypilot/sunnylink/backups/manager.py
+++ b/sunnypilot/sunnylink/backups/manager.py
@@ -210,20 +210,25 @@ class BackupManagerSP:
   def _get_current_version(self) -> custom.BackupManagerSP.Version:
     """Gets current sunnypilot version information."""
     version_obj = custom.BackupManagerSP.Version()
+    version_str = get_version()
 
-    build = None
-    if (version_split := get_version().split('-')) and len(version_split) > 1:
-      build = int(version_split[1]) if version_split[1].isdigit() else 0
+    version_parts = version_str.split('-')  # For when version is like "1.2.3-456"
+    version_nums = version_parts[0].split('.')
 
-    version_parts = version_split[0].split('.')
-    if build is None:
-      build = int(version_parts[3]) if len(version_parts) > 3 and version_parts[3].isdigit() else 0
+    # Extract build number from hyphen format or as 4th version component
+    build = 0
+    if len(version_parts) > 1 and version_parts[1].isdigit():
+      build = int(version_parts[1])
+    elif len(version_nums) > 3 and version_nums[3].isdigit():
+      build = int(version_nums[3])
 
-    version_obj.major = int(version_parts[0]) if len(version_parts) > 0 else 0
-    version_obj.minor = int(version_parts[1]) if len(version_parts) > 1 else 0
-    version_obj.patch = int(version_parts[2]) if len(version_parts) > 2 else 0
-    version_obj.build = build or 0
+    # Set version components with safer defaults
+    version_obj.major = int(version_nums[0]) if len(version_nums) > 0 and version_nums[0].isdigit() else 0
+    version_obj.minor = int(version_nums[1]) if len(version_nums) > 1 and version_nums[1].isdigit() else 0
+    version_obj.patch = int(version_nums[2]) if len(version_nums) > 2 and version_nums[2].isdigit() else 0
+    version_obj.build = build
     version_obj.branch = get_branch()
+
     return version_obj
 
   async def main_thread(self) -> None:


### PR DESCRIPTION
Fixes 

![image](https://github.com/user-attachments/assets/1c0e1bf9-2556-4ee1-8a37-705d60375337)
https://discord.com/channels/880416502577266699/1358308398403424417/1360906248781824010

## Summary by Sourcery

Improve version parsing for sunnylink backup restore functionality to handle more complex version string formats

Bug Fixes:
- Fix version parsing to correctly handle version strings with build numbers in different formats, such as '1.2.3-456' or '1.2.3.456'

Enhancements:
- Add more robust version parsing with safer default handling and digit validation
- Improve version extraction logic to support multiple version string formats