### PR TITLE
NNLC: decreased low-speed factor

### DIFF
--- a/selfdrive/controls/lib/latcontrol_torque.py
+++ b/selfdrive/controls/lib/latcontrol_torque.py
@@ -80,7 +80,8 @@ class LatControlTorque(LatControl):
       # Lateral acceleration torque controller extension updates
       # Overrides stock ff and pid_log.error
       ff, pid_log = self.extension.update(CS, VM, params, ff, pid_log, setpoint, measurement, calibrated_pose, roll_compensation,
-                                          desired_lateral_accel, actual_lateral_accel, lateral_accel_deadzone, gravity_adjusted_lateral_accel)
+                                          desired_lateral_accel, actual_lateral_accel, lateral_accel_deadzone, gravity_adjusted_lateral_accel,
+                                          desired_curvature, actual_curvature)
 
       freeze_integrator = steer_limited_by_controls or CS.steeringPressed or CS.vEgo < 5
       output_torque = self.pid.update(pid_log.error,

--- a/sunnypilot/selfdrive/controls/lib/latcontrol_torque_ext.py
+++ b/sunnypilot/selfdrive/controls/lib/latcontrol_torque_ext.py
@@ -13,7 +13,8 @@ class LatControlTorqueExt(NeuralNetworkLateralControl):
     super().__init__(lac_torque, CP, CP_SP)
 
   def update(self, CS, VM, params, ff, pid_log, setpoint, measurement, calibrated_pose, roll_compensation,
-             desired_lateral_accel, actual_lateral_accel, lateral_accel_deadzone, gravity_adjusted_lateral_accel):
+             desired_lateral_accel, actual_lateral_accel, lateral_accel_deadzone, gravity_adjusted_lateral_accel,
+             desired_curvature, actual_curvature):
     self._ff = ff
     self._pid_log = pid_log
     self._setpoint = setpoint
@@ -21,6 +22,8 @@ class LatControlTorqueExt(NeuralNetworkLateralControl):
     self._lateral_accel_deadzone = lateral_accel_deadzone
     self._desired_lateral_accel = desired_lateral_accel
     self._actual_lateral_accel = actual_lateral_accel
+    self._desired_curvature = desired_curvature
+    self._actual_curvature = actual_curvature
 
     self.update_calculations(CS, VM, desired_lateral_accel)
     self.update_neural_network_feedforward(CS, params, calibrated_pose)

--- a/sunnypilot/selfdrive/controls/lib/latcontrol_torque_ext_base.py
+++ b/sunnypilot/selfdrive/controls/lib/latcontrol_torque_ext_base.py
@@ -62,6 +62,8 @@ class LatControlTorqueExtBase:
     self._lateral_accel_deadzone = 0.0
     self._desired_lateral_accel = 0.0
     self._actual_lateral_accel = 0.0
+    self._desired_curvature = 0.0
+    self._actual_curvature = 0.0
 
     # twilsonco's Lateral Neural Network Feedforward
     # Instantaneous lateral jerk changes very rapidly, making it not useful on its own,

--- a/sunnypilot/selfdrive/controls/lib/nnlc/nnlc.py
+++ b/sunnypilot/selfdrive/controls/lib/nnlc/nnlc.py
@@ -25,6 +25,8 @@ from openpilot.sunnypilot.selfdrive.controls.lib.nnlc.model import NNTorqueModel
 def roll_pitch_adjust(roll, pitch):
   return roll * math.cos(pitch)
 
+LOW_SPEED_X = [0, 10, 20, 30]
+LOW_SPEED_Y = [12, 3, 1, 0]
 
 class NeuralNetworkLateralControl(LatControlTorqueExtBase):
   def __init__(self, lac_torque, CP, CP_SP):
@@ -58,6 +60,10 @@ class NeuralNetworkLateralControl(LatControlTorqueExtBase):
   def update_neural_network_feedforward(self, CS, params, calibrated_pose) -> None:
     if not self.enabled or not self.model_valid or not self.has_nn_model:
       return
+
+    low_speed_factor = np.interp(CS.vEgo, LOW_SPEED_X, LOW_SPEED_Y)**2
+    self._setpoint = self._desired_lateral_accel + low_speed_factor * self._desired_curvature
+    self._measurement = self._actual_lateral_accel + low_speed_factor * self._actual_curvature
 
     # update past data
     roll = params.roll


### PR DESCRIPTION
The NNLC reimplementation was missing a few things from the old SP implementation. One of them was a [decreased low-speed factor for NNLC](https://github.com/sunnypilot/sunnypilot/blob/1820d16e96c9ad2ee7ad980e0d6a557c2fdfae39/selfdrive/controls/lib/latcontrol_torque.py#L29). 

The way I addressed that here results in redundantly calculating the setpoint and measurement, but it's a small amount to recalculate, and this way it doesn't touch the torque controller code, which is a priority of the NNLC reimplementation in the `-new` branches.

I'm PR-ing this to staging-c3-new instead of dev-c3-new becuase I need people to test it before the PR is marked as ready, and I wasn't sure whether dev-c3-new can be expected to have issues or not, since it's under such active development

## Summary by Sourcery

Implement a low-speed factor adjustment for Neural Network Lateral Control (NNLC) to improve lateral control at low speeds

New Features:
- Introduce low-speed scaling mechanism using predefined speed and factor arrays to modify lateral control behavior

Enhancements:
- Add a low-speed interpolation factor to adjust lateral acceleration and curvature calculations in the NNLC implementation