### PR TITLE
CI: Update PR list query to exclude draft pull requests

### DIFF
--- a/.github/workflows/sunnypilot-master-dev-c3-prep.yaml
+++ b/.github/workflows/sunnypilot-master-dev-c3-prep.yaml
@@ -195,7 +195,7 @@ jobs:
                   }
                 }
               }
-            }' -F label="is:pr is:open label:${PR_LABEL} sort:created-asc")
+            }' -F label="is:pr is:open label:${PR_LABEL} draft:false sort:created-asc")
 
           echo "PR_LIST=${PR_LIST}" >> $GITHUB_OUTPUT
         env:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Modify GitHub Actions workflow to filter out draft pull requests by adding 'draft:false' to the GitHub CLI query