### PR TITLE
NNLC: use `safe_exp` to prevent overflow in `sigmoid`

### DIFF
--- a/sunnypilot/selfdrive/controls/lib/nnlc/model.py
+++ b/sunnypilot/selfdrive/controls/lib/nnlc/model.py
@@ -7,6 +7,8 @@ See the LICENSE.md file in the root directory for more details.
 from json import load
 import numpy as np
 
+from openpilot.selfdrive.modeld.parse_model_outputs import safe_exp
+
 # dict used to rename activation functions whose names aren't valid python identifiers
 ACTIVATION_FUNCTION_NAMES = {'σ': 'sigmoid'}
 
@@ -40,7 +42,7 @@ class NNTorqueModel:
   # These are called by name using the keys in the model json file
   @staticmethod
   def sigmoid(x):
-    return 1 / (1 + np.exp(-x))
+    return 1 / (1 + safe_exp(-x))
 
   @staticmethod
   def identity(x):

--- a/sunnypilot/selfdrive/controls/lib/nnlc/tests/test_nnlc.py
+++ b/sunnypilot/selfdrive/controls/lib/nnlc/tests/test_nnlc.py
@@ -1,6 +1,7 @@
+import numpy as np
 from parameterized import parameterized
 
-from cereal import car, log
+from cereal import car, log, messaging
 from opendbc.car.car_helpers import interfaces
 from opendbc.car.honda.values import CAR as HONDA
 from opendbc.car.hyundai.values import CAR as HYUNDAI
@@ -12,6 +13,25 @@ from openpilot.selfdrive.controls.lib.latcontrol_torque import LatControlTorque
 from openpilot.selfdrive.locationd.helpers import Pose
 from openpilot.common.mock.generators import generate_livePose
 from openpilot.sunnypilot.selfdrive.car import interfaces as sunnypilot_interfaces
+from openpilot.system.manager.process_config import managed_processes
+from openpilot.selfdrive.modeld.constants import ModelConstants
+
+
+def generate_modelV2():
+  model = messaging.new_message('modelV2')
+  position = log.XYZTData.new_message()
+  speed = 30
+  position.x = [float(x) for x in (speed + 0.5) * np.array(ModelConstants.T_IDXS)]
+  model.modelV2.position = position
+  velocity = log.XYZTData.new_message()
+  velocity.x = [float(x) for x in (speed + 0.5) * np.ones_like(ModelConstants.T_IDXS)]
+  velocity.x[0] = float(speed)  # always start at current speed
+  model.modelV2.velocity = velocity
+  acceleration = log.XYZTData.new_message()
+  acceleration.x = [float(x) for x in np.zeros_like(ModelConstants.T_IDXS)]
+  model.modelV2.acceleration = acceleration
+
+  return model
 
 
 class TestNeuralNetworkLateralControl:
@@ -20,6 +40,9 @@ class TestNeuralNetworkLateralControl:
   def test_saturation(self, car_name):
     params = Params()
     params.put_bool("NeuralNetworkLateralControl", True)
+
+    sm = messaging.SubMaster(['modelV2'])
+    managed_processes['modeld'].start()
 
     CarInterface = interfaces[car_name]
     CP = CarInterface.get_non_essential_params(car_name)
@@ -42,15 +65,20 @@ class TestNeuralNetworkLateralControl:
     lp = generate_livePose()
     pose = Pose.from_live_pose(lp.livePose)
 
+    mdl = sm['modelV2']
+
     # Saturate for curvature limited and controller limited
     for _ in range(1000):
+      controller.extension.update_model_v2(mdl)
       _, _, lac_log = controller.update(True, CS, VM, params, False, 0, pose, True)
     assert lac_log.saturated
 
     for _ in range(1000):
+      controller.extension.update_model_v2(mdl)
       _, _, lac_log = controller.update(True, CS, VM, params, False, 0, pose, False)
     assert not lac_log.saturated
 
     for _ in range(1000):
+      controller.extension.update_model_v2(mdl)
       _, _, lac_log = controller.update(True, CS, VM, params, False, 1, pose, False)
     assert lac_log.saturated

--- a/sunnypilot/selfdrive/controls/lib/nnlc/tests/test_nnlc.py
+++ b/sunnypilot/selfdrive/controls/lib/nnlc/tests/test_nnlc.py
@@ -23,12 +23,18 @@ def generate_modelV2():
   speed = 30
   position.x = [float(x) for x in (speed + 0.5) * np.array(ModelConstants.T_IDXS)]
   model.modelV2.position = position
+  orientation = log.XYZTData.new_message()
+  curvature = 0.05
+  orientation.x = [float(curvature) for _ in ModelConstants.T_IDXS]
+  orientation.y = [0.0 for _ in ModelConstants.T_IDXS]
+  model.modelV2.orientation = orientation
   velocity = log.XYZTData.new_message()
   velocity.x = [float(x) for x in (speed + 0.5) * np.ones_like(ModelConstants.T_IDXS)]
   velocity.x[0] = float(speed)  # always start at current speed
   model.modelV2.velocity = velocity
   acceleration = log.XYZTData.new_message()
   acceleration.x = [float(x) for x in np.zeros_like(ModelConstants.T_IDXS)]
+  acceleration.y = [float(y) for y in np.zeros_like(ModelConstants.T_IDXS)]
   model.modelV2.acceleration = acceleration
 
   return model
@@ -40,9 +46,6 @@ class TestNeuralNetworkLateralControl:
   def test_saturation(self, car_name):
     params = Params()
     params.put_bool("NeuralNetworkLateralControl", True)
-
-    sm = messaging.SubMaster(['modelV2'])
-    managed_processes['modeld'].start()
 
     CarInterface = interfaces[car_name]
     CP = CarInterface.get_non_essential_params(car_name)
@@ -65,20 +68,23 @@ class TestNeuralNetworkLateralControl:
     lp = generate_livePose()
     pose = Pose.from_live_pose(lp.livePose)
 
-    mdl = sm['modelV2']
+    mdl = generate_modelV2()
+    sm = {'modelV2': mdl.modelV2}
+    model_v2 = sm['modelV2']
+    controller.extension.model_v2 = model_v2
 
     # Saturate for curvature limited and controller limited
     for _ in range(1000):
-      controller.extension.update_model_v2(mdl)
+      controller.extension.update_model_v2(model_v2)
       _, _, lac_log = controller.update(True, CS, VM, params, False, 0, pose, True)
     assert lac_log.saturated
 
     for _ in range(1000):
-      controller.extension.update_model_v2(mdl)
+      controller.extension.update_model_v2(model_v2)
       _, _, lac_log = controller.update(True, CS, VM, params, False, 0, pose, False)
     assert not lac_log.saturated
 
     for _ in range(1000):
-      controller.extension.update_model_v2(mdl)
+      controller.extension.update_model_v2(model_v2)
       _, _, lac_log = controller.update(True, CS, VM, params, False, 1, pose, False)
     assert lac_log.saturated

--- a/sunnypilot/selfdrive/controls/lib/nnlc/tests/test_nnlc.py
+++ b/sunnypilot/selfdrive/controls/lib/nnlc/tests/test_nnlc.py
@@ -13,7 +13,6 @@ from openpilot.selfdrive.controls.lib.latcontrol_torque import LatControlTorque
 from openpilot.selfdrive.locationd.helpers import Pose
 from openpilot.common.mock.generators import generate_livePose
 from openpilot.sunnypilot.selfdrive.car import interfaces as sunnypilot_interfaces
-from openpilot.system.manager.process_config import managed_processes
 from openpilot.selfdrive.modeld.constants import ModelConstants
 
 


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Enhance Neural Network Lateral Control (NNLC) testing by introducing mock modelV2 data for sanity checks

Bug Fixes:
- Replace potentially unsafe numpy exponential function with safe_exp in sigmoid activation

Enhancements:
- Add a mock modelV2 data generator for testing NNLC controller's behavior
- Modify NNLC model to use safe exponential function for sigmoid activation

Tests:
- Implement mock modelV2 data generation for consistent NNLC controller testing
- Add model V2 updates in saturation test scenarios