### PR TITLE
ci: avoid deadlock on dev-c3 branch build when PR labeled dev-c3

### DIFF
--- a/.github/workflows/sunnypilot-master-dev-c3-prep.yaml
+++ b/.github/workflows/sunnypilot-master-dev-c3-prep.yaml
@@ -85,6 +85,9 @@ jobs:
             });
 
   reset-and-squash:
+    concurrency:
+      group: reset-and-squash
+      cancel-in-progress: ${{ github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
     runs-on: ubuntu-latest
     if: (
             (github.event_name == 'workflow_dispatch')

--- a/.github/workflows/sunnypilot-master-dev-c3-prep.yaml
+++ b/.github/workflows/sunnypilot-master-dev-c3-prep.yaml
@@ -13,7 +13,7 @@ on:
     branches:
       - master
       - master-new    
-  pull_request:
+  pull_request_target:
     types: [ synchronize, labeled ]  
     branches:    
       - 'master'        

--- a/.github/workflows/sunnypilot-master-dev-c3-prep.yaml
+++ b/.github/workflows/sunnypilot-master-dev-c3-prep.yaml
@@ -13,7 +13,7 @@ on:
     branches:
       - master
       - master-new    
-  pull_request_target:
+  pull_request:
     types: [ synchronize, opened, labeled ]  
     branches:    
       - 'master'        

--- a/.github/workflows/sunnypilot-master-dev-c3-prep.yaml
+++ b/.github/workflows/sunnypilot-master-dev-c3-prep.yaml
@@ -14,7 +14,7 @@ on:
       - master
       - master-new    
   pull_request:
-    types: [ synchronize, opened, labeled ]  
+    types: [ synchronize, labeled ]  
     branches:    
       - 'master'        
       - 'master-new'            

--- a/.github/workflows/sunnypilot-master-dev-c3-prep.yaml
+++ b/.github/workflows/sunnypilot-master-dev-c3-prep.yaml
@@ -31,6 +31,10 @@ on:
         default: 'master-dev-c3-new'
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: ${{ github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && true || false }}
+
 jobs:
   manage-pr-labels:
     name: Remove trust-fork-pr label if present
@@ -85,9 +89,6 @@ jobs:
             });
 
   reset-and-squash:
-    concurrency:
-      group: reset-and-squash
-      cancel-in-progress: ${{ github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
     runs-on: ubuntu-latest
     if: (
             (github.event_name == 'workflow_dispatch')

--- a/.github/workflows/sunnypilot-master-dev-c3-prep.yaml
+++ b/.github/workflows/sunnypilot-master-dev-c3-prep.yaml
@@ -13,7 +13,7 @@ on:
     branches:
       - master
       - master-new    
-  pull_request_target:
+  pull_request:
     types: [ synchronize, labeled ]  
     branches:    
       - 'master'        

--- a/.github/workflows/sunnypilot-master-dev-c3-prep.yaml
+++ b/.github/workflows/sunnypilot-master-dev-c3-prep.yaml
@@ -13,7 +13,7 @@ on:
     branches:
       - master
       - master-new    
-  pull_request:
+  pull_request_target:
     types: [ synchronize, labeled ]  
     branches:    
       - 'master'        
@@ -35,13 +35,13 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
   
-run-name: ${{ github.event.pull_request.head.repo.fork && (github.event_name == 'pull_request_target' && github.event.action == 'synchronize') && format('{0} - {1}', github.workflow, github.event.action) || format('{0} - {1}', github.workflow, github.event_name) }}
+run-name: ${{ github.event.pull_request.head.repo.fork && (contains('pull_request', github.event_name) && github.event.action == 'synchronize') && format('{0} - {1}', github.workflow, github.event.action) || format('{0} - {1}', github.workflow, github.event_name) }}
 
 jobs:
   manage-pr-labels:
     name: Remove trust-fork-pr label if present
     runs-on: ubuntu-latest
-    if: (github.event.pull_request.head.repo.fork && (github.event_name == 'pull_request_target' && github.event.action == 'synchronize'))
+    if: (github.event.pull_request.head.repo.fork && (contains('pull_request', github.event_name) && github.event.action == 'synchronize'))
     steps:
       - name: Check if PR has dev-c3 label
         id: check-labels
@@ -95,7 +95,7 @@ jobs:
     if: (
             (github.event_name == 'workflow_dispatch')
             || (github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
-            || (github.event_name == 'pull_request_target' && ((github.event.action == 'labeled' && (github.event.label.name == 'dev-c3' || github.event.label.name == 'trust-fork-pr') && contains(github.event.pull_request.labels.*.name, 'dev-c3'))))
+            || (contains('pull_request', github.event_name) && ((github.event.action == 'labeled' && (github.event.label.name == 'dev-c3' || github.event.label.name == 'trust-fork-pr') && contains(github.event.pull_request.labels.*.name, 'dev-c3'))))
         )
     steps:
       - uses: actions/checkout@v4
@@ -107,7 +107,7 @@ jobs:
         uses: ./.github/workflows/wait-for-action # Path to where you place the action
         if: (
                 (github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
-                || (github.event_name == 'pull_request_target' && ((github.event.action == 'labeled' && (github.event.label.name == 'dev-c3' || github.event.label.name == 'trust-fork-pr') && contains(github.event.pull_request.labels.*.name, 'dev-c3'))))
+                || (contains('pull_request', github.event_name) && ((github.event.action == 'labeled' && (github.event.label.name == 'dev-c3' || github.event.label.name == 'trust-fork-pr') && contains(github.event.pull_request.labels.*.name, 'dev-c3'))))
             )
         with:
           workflow: selfdrive_tests.yaml # The workflow file to monitor

--- a/.github/workflows/sunnypilot-master-dev-c3-prep.yaml
+++ b/.github/workflows/sunnypilot-master-dev-c3-prep.yaml
@@ -34,6 +34,8 @@ on:
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+  
+run-name: ${{ github.event.pull_request.head.repo.fork && (github.event_name == 'pull_request_target' && github.event.action == 'synchronize') && format('{0} - {1}', github.workflow, github.event.action) || format('{0} - {1}', github.workflow, github.event_name) }}
 
 jobs:
   manage-pr-labels:

--- a/.github/workflows/sunnypilot-master-dev-c3-prep.yaml
+++ b/.github/workflows/sunnypilot-master-dev-c3-prep.yaml
@@ -33,7 +33,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}
-  cancel-in-progress: ${{ github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && true || false }}
+  cancel-in-progress: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
 
 jobs:
   manage-pr-labels:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Enhance the PR validation process to check individual check runs for success, excluding the 'reset-and-squash' check, before allowing a merge.