### PR TITLE
ci: update auto pr review config and split turst fork pr

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -1,6 +1,10 @@
-CI / testing:
+ci:
   - changed-files:
     - any-glob-to-all-files: "{.github/**,**/test_*,Jenkinsfile}"
+
+chore:
+  - changed-files:
+      - any-glob-to-all-files: "{.github/**}"
 
 car:
   - changed-files:

--- a/.github/workflows/auto_pr_review.yaml
+++ b/.github/workflows/auto_pr_review.yaml
@@ -28,25 +28,63 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        target: /^(?!master$).*/
-        exclude: /commaai:.*/
+        target: /^(?!master-new$).*/
+        exclude: /sunnypilot:.*/
         change-to: ${{ github.base_ref }}
         already-exists-action: close_this
-        already-exists-comment: "Your PR should be made against the `master` branch"
+        already-exists-comment: "Your PR should be made against the `master-new` branch"
 
-    # Welcome comment
-    - name: "First timers PR"
-      uses: actions/first-interaction@v1
-      if: github.event.pull_request.head.repo.full_name != 'sunnypilot/sunnypilot'
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        pr-message: |
-            <!-- _(run_id **${{ github.run_id }}**)_ -->
-            Thanks for contributing to openpilot! In order for us to review your PR as quickly as possible, check the following:
-            * Convert your PR to a draft unless it's ready to review
-            * Read the [contributing docs](https://github.com/sunnypilot/sunnypilot/blob/master/docs/CONTRIBUTING.md)
-            * Before marking as "ready for review", ensure:
-              * the goal is clearly stated in the description
-              * all the tests are passing
-              * the change is [something we merge](https://github.com/sunnypilot/sunnypilot/blob/master/docs/CONTRIBUTING.md#what-gets-merged)
-              * include a route or your device' dongle ID if relevant
+  update-pr-labels:
+    name: Update fork's PR Labels
+    runs-on: ubuntu-latest
+    if: (github.event.pull_request.head.repo.fork && (contains('pull_request', github.event_name) && github.event.action == 'synchronize'))
+    env: 
+      PR_LABEL: 'dev-c3'
+      TRUST_FORK_PR_LABEL: 'trust-fork-pr'
+    steps:
+      - name: Check if PR has dev-c3 label
+        id: check-labels
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber
+            });
+            
+            const hasDevC3Label = labels.some(label => label.name === process.env.PR_LABEL);
+            const hasTrustLabel = labels.some(label => label.name === process.env.TRUST_FORK_PR_LABEL);
+            
+            console.log(`PR #${prNumber} has ${process.env.PR_LABEL} label: ${hasDevC3Label}`);
+            console.log(`PR #${prNumber} has ${process.env.TRUST_FORK_PR_LABEL} label: ${hasTrustLabel}`);
+            
+            core.setOutput('has-dev-c3', hasDevC3Label ? 'true' : 'false');
+            core.setOutput('has-trust', hasTrustLabel ? 'true' : 'false');
+      
+      - name: Remove trust-fork-pr label if present
+        if: steps.check-labels.outputs.has-dev-c3 == 'true' && steps.check-labels.outputs.has-trust == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              name: process.env.TRUST_FORK_PR_LABEL
+            });
+            
+            console.log(`Removed '${process.env.TRUST_FORK_PR_LABEL}' label from PR #${prNumber} as it received new commits`);
+            
+            // Add a comment to the PR
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: `The \`${process.env.TRUST_FORK_PR_LABEL}\` label has been automatically removed because new commits were pushed to this PR. This PR will need to be re-reviewed before the label can be applied again.`
+            });

--- a/.github/workflows/auto_pr_review.yaml
+++ b/.github/workflows/auto_pr_review.yaml
@@ -1,6 +1,6 @@
-name: "PR review 2.0"
+name: "PR review"
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize, edited]
 
 jobs:

--- a/.github/workflows/auto_pr_review_2.yaml
+++ b/.github/workflows/auto_pr_review_2.yaml
@@ -2,7 +2,6 @@ name: "PR review 2.0"
 on:
   pull_request:
     types: [opened, reopened, synchronize, edited]
-  push:
 
 jobs:
   labeler:

--- a/.github/workflows/auto_pr_review_2.yaml
+++ b/.github/workflows/auto_pr_review_2.yaml
@@ -1,7 +1,8 @@
-name: "PR review"
+name: "PR review 2.0"
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, synchronize, edited]
+  push:
 
 jobs:
   labeler:

--- a/.github/workflows/auto_pr_review_2.yaml
+++ b/.github/workflows/auto_pr_review_2.yaml
@@ -9,6 +9,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      issues: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/sunnypilot-master-dev-c3-prep.yaml
+++ b/.github/workflows/sunnypilot-master-dev-c3-prep.yaml
@@ -4,7 +4,6 @@ env:
   DEFAULT_SOURCE_BRANCH: "master-new"
   DEFAULT_TARGET_BRANCH: "master-dev-c3-new"
   PR_LABEL: "dev-c3"
-  TRUST_FORK_PR_LABEL: "trust-fork-pr"
   LFS_URL: 'https://gitlab.com/sunnypilot/public/sunnypilot-new-lfs.git/info/lfs'
   LFS_PUSH_URL: 'ssh://git@gitlab.com/sunnypilot/public/sunnypilot-new-lfs.git'
 
@@ -35,61 +34,9 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
   
-run-name: ${{ github.event.pull_request.head.repo.fork && (contains('pull_request', github.event_name) && github.event.action == 'synchronize') && format('{0} - {1}', github.workflow, github.event.action) || format('{0} - {1}', github.workflow, github.event_name) }}
+run-name: ${{ contains('pull_request', github.event_name) && github.event.action == 'synchronize' && format('{0} - {1}', github.workflow, github.event.action) || format('{0} - {1}', github.workflow, github.event_name) }}
 
 jobs:
-  manage-pr-labels:
-    name: Remove trust-fork-pr label if present
-    runs-on: ubuntu-latest
-    if: (github.event.pull_request.head.repo.fork && (contains('pull_request', github.event_name) && github.event.action == 'synchronize'))
-    steps:
-      - name: Check if PR has dev-c3 label
-        id: check-labels
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const prNumber = context.payload.pull_request.number;
-            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber
-            });
-            
-            const hasDevC3Label = labels.some(label => label.name === process.env.PR_LABEL);
-            const hasTrustLabel = labels.some(label => label.name === process.env.TRUST_FORK_PR_LABEL);
-            
-            console.log(`PR #${prNumber} has ${process.env.PR_LABEL} label: ${hasDevC3Label}`);
-            console.log(`PR #${prNumber} has ${process.env.TRUST_FORK_PR_LABEL} label: ${hasTrustLabel}`);
-            
-            core.setOutput('has-dev-c3', hasDevC3Label ? 'true' : 'false');
-            core.setOutput('has-trust', hasTrustLabel ? 'true' : 'false');
-
-      - name: Remove trust-fork-pr label if present
-        if: steps.check-labels.outputs.has-dev-c3 == 'true' && steps.check-labels.outputs.has-trust == 'true'
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const prNumber = context.payload.pull_request.number;
-            
-            await github.rest.issues.removeLabel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              name: process.env.TRUST_FORK_PR_LABEL
-            });
-            
-            console.log(`Removed '${process.env.TRUST_FORK_PR_LABEL}' label from PR #${prNumber} as it received new commits`);
-            
-            // Add a comment to the PR
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              body: `The \`${process.env.TRUST_FORK_PR_LABEL}\` label has been automatically removed because new commits were pushed to this PR. This PR will need to be re-reviewed before the label can be applied again.`
-            });
-
   reset-and-squash:
     runs-on: ubuntu-latest
     if: (


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Update GitHub Actions workflows to improve PR label management and CI configuration for fork PRs

CI:
- Modify auto PR review workflow to handle fork PRs more dynamically
- Update label management for PRs, including automatic removal of 'trust-fork-pr' label when new commits are pushed
- Adjust labeler configuration to better categorize CI and chore-related changes

Chores:
- Refactor GitHub workflow configurations to streamline PR processing and label management