### PR TITLE
Toyota: Invert ACC Controls

### DIFF
--- a/common/params_keys.h
+++ b/common/params_keys.h
@@ -129,6 +129,7 @@ inline static std::unordered_map<std::string, uint32_t> keys = {
     {"CarParamsSPPersistent", PERSISTENT},
     {"CarPlatformBundle", PERSISTENT},
     {"EnableGithubRunner", PERSISTENT | BACKUP},
+    {"FlipAccIncrements", PERSISTENT | BACKUP},
     {"MaxTimeOffroad", PERSISTENT | BACKUP},
     {"ModelRunnerTypeCache", CLEAR_ON_ONROAD_TRANSITION},
     {"OffroadMode", CLEAR_ON_MANAGER_START},

--- a/selfdrive/ui/sunnypilot/SConscript
+++ b/selfdrive/ui/sunnypilot/SConscript
@@ -21,6 +21,7 @@ qt_src = [
   "sunnypilot/qt/offroad/offroad_home.cc",
   "sunnypilot/qt/offroad/settings/device_panel.cc",
   "sunnypilot/qt/offroad/settings/lateral_panel.cc",
+  "sunnypilot/qt/offroad/settings/longitudinal_panel.cc",
   "sunnypilot/qt/offroad/settings/max_time_offroad.cc",
   "sunnypilot/qt/offroad/settings/settings.cc",
   "sunnypilot/qt/offroad/settings/software_panel.cc",

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/longitudinal_panel.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/longitudinal_panel.cc
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+ *
+ * This file is part of sunnypilot and is licensed under the MIT License.
+ * See the LICENSE.md file in the root directory for more details.
+ */
+
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/longitudinal_panel.h"
+
+LongitudinalPanel::LongitudinalPanel(QWidget *parent) : QWidget(parent) {
+}

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/longitudinal_panel.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/longitudinal_panel.cc
@@ -6,6 +6,31 @@
  */
 
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/longitudinal_panel.h"
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/platform_selector.h"
 
 LongitudinalPanel::LongitudinalPanel(QWidget *parent) : QWidget(parent) {
+  main_layout = new QStackedLayout(this);
+  ListWidget *list = new ListWidget(this, false);
+
+  toyotaFlipACC = new ParamControlSP(
+    "FlipAccIncrements",
+    tr("Flip ACC Controls"),
+    tr("Enable this to flip Short & Long press ACC increments."),
+    "",
+    this);
+  list->addItem(toyotaFlipACC);
+  main_layout->addWidget(list);
+  updateState();
+}
+
+void LongitudinalPanel::showEvent(QShowEvent *event) {
+  updateState();
+}
+
+void LongitudinalPanel::updateState() {
+  if (!isVisible()) {
+    return;
+  }
+
+  toyotaFlipACC->setVisible(PlatformSelector::getPlatformBundle("brand").toString() == "toyota");
 }

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/longitudinal_panel.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/longitudinal_panel.h
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+ *
+ * This file is part of sunnypilot and is licensed under the MIT License.
+ * See the LICENSE.md file in the root directory for more details.
+ */
+
+#pragma once
+
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/settings.h"
+
+class LongitudinalPanel : public QWidget {
+  Q_OBJECT
+
+public:
+  explicit LongitudinalPanel(QWidget *parent = nullptr);
+};

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/longitudinal_panel.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/longitudinal_panel.h
@@ -14,4 +14,10 @@ class LongitudinalPanel : public QWidget {
 
 public:
   explicit LongitudinalPanel(QWidget *parent = nullptr);
+  void showEvent(QShowEvent *event) override;
+  void updateState();
+
+private:
+  QStackedLayout* main_layout = nullptr;
+  ParamControlSP *toyotaFlipACC;
 };

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/settings.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/settings.cc
@@ -16,6 +16,7 @@
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/software_panel.h"
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/sunnylink_panel.h"
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/lateral_panel.h"
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/longitudinal_panel.h"
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/trips_panel.h"
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle_panel.h"
 
@@ -79,6 +80,7 @@ SettingsWindowSP::SettingsWindowSP(QWidget *parent) : SettingsWindow(parent) {
     PanelInfo("   " + tr("Toggles"), toggles, "../../sunnypilot/selfdrive/assets/offroad/icon_toggle.png"),
     PanelInfo("   " + tr("Software"), new SoftwarePanelSP(this), "../../sunnypilot/selfdrive/assets/offroad/icon_software.png"),
     PanelInfo("   " + tr("Steering"), new LateralPanel(this), "../../sunnypilot/selfdrive/assets/offroad/icon_lateral.png"),
+    PanelInfo("   " + tr("Driving"), new LongitudinalPanel(this), "../assets/offroad/icon_speed_limit.png"),
     PanelInfo("   " + tr("Trips"), new TripsPanel(this), "../../sunnypilot/selfdrive/assets/offroad/icon_trips.png"),
     PanelInfo("   " + tr("Vehicle"), new VehiclePanel(this), "../../sunnypilot/selfdrive/assets/offroad/icon_vehicle.png"),
     PanelInfo("   " + tr("Firehose"), new FirehosePanel(this), "../../sunnypilot/selfdrive/assets/offroad/icon_firehose.svg"),

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/platform_selector.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/platform_selector.cc
@@ -8,7 +8,6 @@
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/platform_selector.h"
 
 #include <QJsonArray>
-#include <QJsonDocument>
 #include <QJsonObject>
 #include <QMap>
 

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/platform_selector.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/platform_selector.cc
@@ -14,17 +14,6 @@
 
 #include "selfdrive/ui/sunnypilot/qt/util.h"
 
-QVariant PlatformSelector::getPlatformBundle(const QString &key) {
-  QString platform_bundle = QString::fromStdString(params.get("CarPlatformBundle"));
-  if (!platform_bundle.isEmpty()) {
-    QJsonDocument json = QJsonDocument::fromJson(platform_bundle.toUtf8());
-    if (!json.isNull() && json.isObject()) {
-      return json.object().value(key).toVariant();
-    }
-  }
-  return {};
-}
-
 PlatformSelector::PlatformSelector() : ButtonControl(tr("Vehicle"), "", "") {
   platforms = loadPlatformList();
 

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/platform_selector.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/platform_selector.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <QJsonDocument>
+
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/settings.h"
 
 class PlatformSelector : public ButtonControl {
@@ -14,7 +16,16 @@ class PlatformSelector : public ButtonControl {
 
 public:
   PlatformSelector();
-  QVariant getPlatformBundle(const QString &key);
+  static QVariant getPlatformBundle(const QString &key) {
+    QString platform_bundle = QString::fromStdString(Params().get("CarPlatformBundle"));
+    if (!platform_bundle.isEmpty()) {
+      QJsonDocument json = QJsonDocument::fromJson(platform_bundle.toUtf8());
+      if (!json.isNull() && json.isObject()) {
+        return json.object().value(key).toVariant();
+      }
+    }
+    return {};
+}
 
 public slots:
   void refresh(bool _offroad);


### PR DESCRIPTION
- Added Invert ACC Controls - specifically for Toyota
- Made getPlatformBundle in PlatformSelector Static so that it can be used to control visibility of brand/vehicle specific toggles
- Pulled in the new Longitudinal Panel from [ui: add longitudinal settings panel #852]( https://github.com/sunnypilot/sunnypilot/pull/852)

## Summary by Sourcery

Introduce a setting to invert ACC controls for Toyota vehicles and add a new "Driving" settings panel.

New Features:
- Add a "Flip ACC Controls" toggle, visible only for Toyota vehicles, allowing users to swap the behavior of short and long presses on ACC stalks.

Enhancements:
- Add a new "Driving" panel to the main settings navigation.
- Make `PlatformSelector::getPlatformBundle` static to allow checking platform details without class instantiation.

Build:
- Add the new longitudinal panel source file to the UI build process.

Documentation:
- Add the new longitudinal panel source file to the UI build.

Chores:
- Define the `FlipAccIncrements` persistent parameter.