### PR TITLE
Car interface: pass into setup interfaces on init

### DIFF
--- a/selfdrive/car/card.py
+++ b/selfdrive/car/card.py
@@ -108,7 +108,7 @@ class Car:
       fixed_fingerprint = json.loads(self.params.get("CarPlatformBundle", encoding='utf-8') or "{}").get("platform", None)
 
       self.CI = get_car(*self.can_callbacks, obd_callback(self.params), alpha_long_allowed, num_pandas, cached_params, fixed_fingerprint)
-      sunnypilot_interfaces.setup_interfaces(self.CI.CP, self.CI.CP_SP, self.params)
+      sunnypilot_interfaces.setup_interfaces(self.CI, self.params)
       self.RI = interfaces[self.CI.CP.carFingerprint].RadarInterface(self.CI.CP, self.CI.CP_SP)
       self.CP = self.CI.CP
       self.CP_SP = self.CI.CP_SP

--- a/selfdrive/car/tests/test_car_interfaces.py
+++ b/selfdrive/car/tests/test_car_interfaces.py
@@ -45,7 +45,7 @@ class TestCarInterfaces:
                                          alpha_long=args['alpha_long'], docs=False)
     car_params_sp = CarInterface.get_params_sp(car_params, car_name, args['fingerprints'], args['car_fw'],
                                                alpha_long=args['alpha_long'], docs=False)
-    sunnypilot_interfaces.setup_interfaces(car_params, car_params_sp)
+    sunnypilot_interfaces.setup_interfaces(CarInterface)
     car_params = car_params.as_reader()
     car_interface = CarInterface(car_params, car_params_sp)
     assert car_params

--- a/selfdrive/car/tests/test_car_interfaces.py
+++ b/selfdrive/car/tests/test_car_interfaces.py
@@ -45,9 +45,9 @@ class TestCarInterfaces:
                                          alpha_long=args['alpha_long'], docs=False)
     car_params_sp = CarInterface.get_params_sp(car_params, car_name, args['fingerprints'], args['car_fw'],
                                                alpha_long=args['alpha_long'], docs=False)
-    sunnypilot_interfaces.setup_interfaces(CarInterface)
     car_params = car_params.as_reader()
     car_interface = CarInterface(car_params, car_params_sp)
+    sunnypilot_interfaces.setup_interfaces(car_interface)
     assert car_params
     assert car_params_sp
     assert car_interface

--- a/selfdrive/controls/lib/tests/test_latcontrol.py
+++ b/selfdrive/controls/lib/tests/test_latcontrol.py
@@ -23,7 +23,7 @@ class TestLatControl:
     CP = CarInterface.get_non_essential_params(car_name)
     CP_SP = CarInterface.get_non_essential_params_sp(CP, car_name)
     CI = CarInterface(CP, CP_SP)
-    sunnypilot_interfaces.setup_interfaces(CP, CP_SP)
+    sunnypilot_interfaces.setup_interfaces(CI)
     CP_SP = convert_to_capnp(CP_SP)
     VM = VehicleModel(CP)
 

--- a/sunnypilot/selfdrive/car/interfaces.py
+++ b/sunnypilot/selfdrive/car/interfaces.py
@@ -26,8 +26,8 @@ def log_fingerprint(CP: structs.CarParams) -> None:
     sentry.capture_fingerprint(CP.carFingerprint, CP.brand)
 
 
-def _initialize_neural_network_lateral_control(CP: structs.CarParams, CP_SP: structs.CarParamsSP, params: Params = None,
-                                              enabled: bool = False) -> None:
+def _initialize_neural_network_lateral_control(CI: CarInterfaceBase, CP: structs.CarParams, CP_SP: structs.CarParamsSP,
+                                               params: Params = None, enabled: bool = False) -> None:
   if params is None:
     params = Params()
 
@@ -40,7 +40,7 @@ def _initialize_neural_network_lateral_control(CP: structs.CarParams, CP_SP: str
     enabled = params.get_bool("NeuralNetworkLateralControl")
 
   if enabled:
-    CarInterfaceBase.configure_torque_tune(CP.carFingerprint, CP.lateralTuning)
+    CI.configure_torque_tune(CP.carFingerprint, CP.lateralTuning)
 
   CP_SP.neuralNetworkLateralControl.model.path = nnlc_model_path
   CP_SP.neuralNetworkLateralControl.model.name = nnlc_model_name
@@ -61,8 +61,11 @@ def _initialize_radar_tracks(CP: structs.CarParams, CP_SP: structs.CarParamsSP, 
           CP.radarUnavailable = False
 
 
-def setup_interfaces(CP: structs.CarParams, CP_SP: structs.CarParamsSP, params: Params = None):
-  _initialize_neural_network_lateral_control(CP, CP_SP, params)
+def setup_interfaces(CI: CarInterfaceBase, params: Params = None):
+  CP = CI.CP
+  CP_SP = CI.CP_SP
+
+  _initialize_neural_network_lateral_control(CI, CP, CP_SP, params)
   _initialize_radar_tracks(CP, CP_SP, params)
 
 

--- a/sunnypilot/selfdrive/controls/lib/nnlc/tests/test_fingerprint.py
+++ b/sunnypilot/selfdrive/controls/lib/nnlc/tests/test_fingerprint.py
@@ -24,7 +24,7 @@ class TestNNLCFingerprintBase:
     CP_SP = CarInterface.get_non_essential_params_sp(CP, car_name)
     CI = CarInterface(CP, CP_SP)
 
-    sunnypilot_interfaces.setup_interfaces(CP, CP_SP, Params())
+    sunnypilot_interfaces.setup_interfaces(CI, Params())
 
     return CI
 

--- a/sunnypilot/selfdrive/controls/lib/nnlc/tests/test_load_model.py
+++ b/sunnypilot/selfdrive/controls/lib/nnlc/tests/test_load_model.py
@@ -22,7 +22,7 @@ class TestNNTorqueModel:
     CP_SP = CarInterface.get_non_essential_params_sp(CP, car_name)
     CI = CarInterface(CP, CP_SP)
 
-    sunnypilot_interfaces.setup_interfaces(CP, CP_SP, params)
+    sunnypilot_interfaces.setup_interfaces(CI, params)
 
     CP_SP = convert_to_capnp(CP_SP)
 

--- a/sunnypilot/selfdrive/controls/lib/nnlc/tests/test_nnlc.py
+++ b/sunnypilot/selfdrive/controls/lib/nnlc/tests/test_nnlc.py
@@ -51,7 +51,7 @@ class TestNeuralNetworkLateralControl:
     CP_SP = CarInterface.get_non_essential_params_sp(CP, car_name)
     CI = CarInterface(CP, CP_SP)
 
-    sunnypilot_interfaces.setup_interfaces(CP, CP_SP, params)
+    sunnypilot_interfaces.setup_interfaces(CI, params)
 
     CP_SP = convert_to_capnp(CP_SP)
     VM = VehicleModel(CP)


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Refactor the setup_interfaces function to pass the CarInterface instance instead of separate CarParams and CarParamsSP

Enhancements:
- Modify setup_interfaces to accept CarInterface as the primary parameter instead of separate CarParams objects

Chores:
- Update multiple test files to use the new setup_interfaces signature