### PR TITLE
ui: emit panel refresh signal from Platform Selector

### DIFF
--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/platform_selector.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/platform_selector.cc
@@ -62,6 +62,7 @@ void PlatformSelector::refresh(bool _offroad) {
     }
   }
   setEnabled(true);
+  emit refreshPanel();
 
   offroad = _offroad;
 }

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/platform_selector.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/platform_selector.h
@@ -19,6 +19,9 @@ public:
 public slots:
   void refresh(bool _offroad);
 
+signals:
+  void refreshPanel();
+
 private:
   void searchPlatforms(const QString &query);
   void setPlatform(const QString &platform = "");


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Enhancements:
- Added a new signal `refreshPanel()` to the PlatformSelector class to notify when platform selection is refreshed