### PR TITLE
ui: brand settings for Vehicle panel

### DIFF
--- a/selfdrive/ui/sunnypilot/SConscript
+++ b/selfdrive/ui/sunnypilot/SConscript
@@ -50,6 +50,7 @@ network_src = [
 ]
 
 vehicle_panel_qt_src = [
+  "sunnypilot/qt/offroad/settings/vehicle/hyundai_settings.cc",
   "sunnypilot/qt/offroad/settings/vehicle/platform_selector.cc",
 ]
 

--- a/selfdrive/ui/sunnypilot/SConscript
+++ b/selfdrive/ui/sunnypilot/SConscript
@@ -61,6 +61,7 @@ brand_settings_qt_src = [
   "sunnypilot/qt/offroad/settings/vehicle/gm_settings.cc",
   "sunnypilot/qt/offroad/settings/vehicle/honda_settings.cc",
   "sunnypilot/qt/offroad/settings/vehicle/hyundai_settings.cc",
+  "sunnypilot/qt/offroad/settings/vehicle/mazda_settings.cc",
 ]
 
 sp_widgets_src = widgets_src + network_src

--- a/selfdrive/ui/sunnypilot/SConscript
+++ b/selfdrive/ui/sunnypilot/SConscript
@@ -62,6 +62,7 @@ brand_settings_qt_src = [
   "sunnypilot/qt/offroad/settings/vehicle/honda_settings.cc",
   "sunnypilot/qt/offroad/settings/vehicle/hyundai_settings.cc",
   "sunnypilot/qt/offroad/settings/vehicle/mazda_settings.cc",
+  "sunnypilot/qt/offroad/settings/vehicle/nissan_settings.cc",
 ]
 
 sp_widgets_src = widgets_src + network_src

--- a/selfdrive/ui/sunnypilot/SConscript
+++ b/selfdrive/ui/sunnypilot/SConscript
@@ -50,12 +50,18 @@ network_src = [
 ]
 
 vehicle_panel_qt_src = [
-  "sunnypilot/qt/offroad/settings/vehicle/hyundai_settings.cc",
+  "sunnypilot/qt/offroad/settings/vehicle/brand_settings_factory.cc",
+  "sunnypilot/qt/offroad/settings/vehicle/brand_settings_interface.cc",
   "sunnypilot/qt/offroad/settings/vehicle/platform_selector.cc",
 ]
 
+brand_settings_qt_src = [
+  "sunnypilot/qt/offroad/settings/vehicle/chrysler_settings.cc",
+  "sunnypilot/qt/offroad/settings/vehicle/hyundai_settings.cc",
+]
+
 sp_widgets_src = widgets_src + network_src
-sp_qt_src = qt_src + lateral_panel_qt_src + vehicle_panel_qt_src
+sp_qt_src = qt_src + lateral_panel_qt_src + vehicle_panel_qt_src + brand_settings_qt_src
 sp_qt_util = qt_util
 
 Export('sp_widgets_src', 'sp_qt_src', "sp_qt_util")

--- a/selfdrive/ui/sunnypilot/SConscript
+++ b/selfdrive/ui/sunnypilot/SConscript
@@ -67,6 +67,7 @@ brand_settings_qt_src = [
   "sunnypilot/qt/offroad/settings/vehicle/subaru_settings.cc",
   "sunnypilot/qt/offroad/settings/vehicle/tesla_settings.cc",
   "sunnypilot/qt/offroad/settings/vehicle/toyota_settings.cc",
+  "sunnypilot/qt/offroad/settings/vehicle/volkswagen_settings.cc",
 ]
 
 sp_widgets_src = widgets_src + network_src

--- a/selfdrive/ui/sunnypilot/SConscript
+++ b/selfdrive/ui/sunnypilot/SConscript
@@ -64,6 +64,7 @@ brand_settings_qt_src = [
   "sunnypilot/qt/offroad/settings/vehicle/mazda_settings.cc",
   "sunnypilot/qt/offroad/settings/vehicle/nissan_settings.cc",
   "sunnypilot/qt/offroad/settings/vehicle/rivian_settings.cc",
+  "sunnypilot/qt/offroad/settings/vehicle/subaru_settings.cc",
 ]
 
 sp_widgets_src = widgets_src + network_src

--- a/selfdrive/ui/sunnypilot/SConscript
+++ b/selfdrive/ui/sunnypilot/SConscript
@@ -63,6 +63,7 @@ brand_settings_qt_src = [
   "sunnypilot/qt/offroad/settings/vehicle/hyundai_settings.cc",
   "sunnypilot/qt/offroad/settings/vehicle/mazda_settings.cc",
   "sunnypilot/qt/offroad/settings/vehicle/nissan_settings.cc",
+  "sunnypilot/qt/offroad/settings/vehicle/rivian_settings.cc",
 ]
 
 sp_widgets_src = widgets_src + network_src

--- a/selfdrive/ui/sunnypilot/SConscript
+++ b/selfdrive/ui/sunnypilot/SConscript
@@ -57,6 +57,9 @@ vehicle_panel_qt_src = [
 
 brand_settings_qt_src = [
   "sunnypilot/qt/offroad/settings/vehicle/chrysler_settings.cc",
+  "sunnypilot/qt/offroad/settings/vehicle/ford_settings.cc",
+  "sunnypilot/qt/offroad/settings/vehicle/gm_settings.cc",
+  "sunnypilot/qt/offroad/settings/vehicle/honda_settings.cc",
   "sunnypilot/qt/offroad/settings/vehicle/hyundai_settings.cc",
 ]
 

--- a/selfdrive/ui/sunnypilot/SConscript
+++ b/selfdrive/ui/sunnypilot/SConscript
@@ -66,6 +66,7 @@ brand_settings_qt_src = [
   "sunnypilot/qt/offroad/settings/vehicle/rivian_settings.cc",
   "sunnypilot/qt/offroad/settings/vehicle/subaru_settings.cc",
   "sunnypilot/qt/offroad/settings/vehicle/tesla_settings.cc",
+  "sunnypilot/qt/offroad/settings/vehicle/toyota_settings.cc",
 ]
 
 sp_widgets_src = widgets_src + network_src

--- a/selfdrive/ui/sunnypilot/SConscript
+++ b/selfdrive/ui/sunnypilot/SConscript
@@ -65,6 +65,7 @@ brand_settings_qt_src = [
   "sunnypilot/qt/offroad/settings/vehicle/nissan_settings.cc",
   "sunnypilot/qt/offroad/settings/vehicle/rivian_settings.cc",
   "sunnypilot/qt/offroad/settings/vehicle/subaru_settings.cc",
+  "sunnypilot/qt/offroad/settings/vehicle/tesla_settings.cc",
 ]
 
 sp_widgets_src = widgets_src + network_src

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brand_settings_factory.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brand_settings_factory.cc
@@ -15,6 +15,7 @@ static const QStringList supportedBrands = {
   "honda",
   "hyundai",
   "mazda",
+  "nissan",
 };
 
 BrandSettingsInterface* BrandSettingsFactory::createBrandSettings(const QString& brand, QWidget* parent) {
@@ -30,6 +31,8 @@ BrandSettingsInterface* BrandSettingsFactory::createBrandSettings(const QString&
     return new HyundaiSettings(parent);
   if (brand == "mazda")
     return new MazdaSettings(parent);
+  if (brand == "nissan")
+    return new NissanSettings(parent);
 
   // Default empty settings if brand not supported
   return nullptr;

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brand_settings_factory.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brand_settings_factory.cc
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+ *
+ * This file is part of sunnypilot and is licensed under the MIT License.
+ * See the LICENSE.md file in the root directory for more details.
+ */
+
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brand_settings_factory.h"
+
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brands.h"
+
+BrandSettingsInterface* BrandSettingsFactory::createBrandSettings(const QString& brand, QWidget* parent) {
+  if (brand == "hyundai") {
+    return new HyundaiSettings(parent);
+  }
+  // Add other brands here
+
+  // Default empty settings if brand not supported
+  return nullptr;
+}
+
+bool BrandSettingsFactory::isBrandSupported(const QString& brand) {
+  static const QStringList supportedBrands = {
+    "chrysler",
+    "hyundai",
+  };
+
+  return supportedBrands.contains(brand);
+}
+
+QStringList BrandSettingsFactory::getSupportedBrands() {
+  static const QStringList supportedBrands = {
+    "hyundai",
+  };
+
+  return supportedBrands;
+}

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brand_settings_factory.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brand_settings_factory.cc
@@ -6,32 +6,35 @@
  */
 
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brand_settings_factory.h"
-
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brands.h"
 
+static const QStringList supportedBrands = {
+  "chrysler",
+  "ford",
+  "gm",
+  "hyundai",
+};
+
 BrandSettingsInterface* BrandSettingsFactory::createBrandSettings(const QString& brand, QWidget* parent) {
-  if (brand == "hyundai") {
+  if (brand == "chrysler")
+    return new ChryslerSettings(parent);
+  if (brand == "ford")
+    return new FordSettings(parent);
+  if (brand == "gm")
+    return new GMSettings(parent);
+  if (brand == "honda")
+    return new HondaSettings(parent);
+  if (brand == "hyundai")
     return new HyundaiSettings(parent);
-  }
-  // Add other brands here
 
   // Default empty settings if brand not supported
   return nullptr;
 }
 
 bool BrandSettingsFactory::isBrandSupported(const QString& brand) {
-  static const QStringList supportedBrands = {
-    "chrysler",
-    "hyundai",
-  };
-
   return supportedBrands.contains(brand);
 }
 
 QStringList BrandSettingsFactory::getSupportedBrands() {
-  static const QStringList supportedBrands = {
-    "hyundai",
-  };
-
   return supportedBrands;
 }

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brand_settings_factory.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brand_settings_factory.cc
@@ -12,7 +12,9 @@ static const QStringList supportedBrands = {
   "chrysler",
   "ford",
   "gm",
+  "honda",
   "hyundai",
+  "mazda",
 };
 
 BrandSettingsInterface* BrandSettingsFactory::createBrandSettings(const QString& brand, QWidget* parent) {
@@ -26,6 +28,8 @@ BrandSettingsInterface* BrandSettingsFactory::createBrandSettings(const QString&
     return new HondaSettings(parent);
   if (brand == "hyundai")
     return new HyundaiSettings(parent);
+  if (brand == "mazda")
+    return new MazdaSettings(parent);
 
   // Default empty settings if brand not supported
   return nullptr;

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brand_settings_factory.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brand_settings_factory.cc
@@ -20,6 +20,7 @@ static const QStringList supportedBrands = {
   "subaru"
   "tesla",
   "toyota",
+  "volkswagen",
 };
 
 BrandSettingsInterface* BrandSettingsFactory::createBrandSettings(const QString& brand, QWidget* parent) {
@@ -45,6 +46,8 @@ BrandSettingsInterface* BrandSettingsFactory::createBrandSettings(const QString&
     return new TeslaSettings(parent);
   if (brand == "toyota")
     return new ToyotaSettings(parent);
+  if (brand == "volkswagen")
+    return new VolkswagenSettings(parent);
 
   // Default empty settings if brand not supported
   return nullptr;

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brand_settings_factory.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brand_settings_factory.cc
@@ -18,6 +18,7 @@ static const QStringList supportedBrands = {
   "nissan",
   "rivian",
   "subaru"
+  "tesla",
 };
 
 BrandSettingsInterface* BrandSettingsFactory::createBrandSettings(const QString& brand, QWidget* parent) {
@@ -39,6 +40,8 @@ BrandSettingsInterface* BrandSettingsFactory::createBrandSettings(const QString&
     return new RivianSettings(parent);
   if (brand == "subaru")
     return new SubaruSettings(parent);
+  if (brand == "tesla")
+    return new TeslaSettings(parent);
 
   // Default empty settings if brand not supported
   return nullptr;

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brand_settings_factory.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brand_settings_factory.cc
@@ -17,6 +17,7 @@ static const QStringList supportedBrands = {
   "mazda",
   "nissan",
   "rivian",
+  "subaru"
 };
 
 BrandSettingsInterface* BrandSettingsFactory::createBrandSettings(const QString& brand, QWidget* parent) {
@@ -36,6 +37,8 @@ BrandSettingsInterface* BrandSettingsFactory::createBrandSettings(const QString&
     return new NissanSettings(parent);
   if (brand == "rivian")
     return new RivianSettings(parent);
+  if (brand == "subaru")
+    return new SubaruSettings(parent);
 
   // Default empty settings if brand not supported
   return nullptr;

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brand_settings_factory.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brand_settings_factory.cc
@@ -19,6 +19,7 @@ static const QStringList supportedBrands = {
   "rivian",
   "subaru"
   "tesla",
+  "toyota",
 };
 
 BrandSettingsInterface* BrandSettingsFactory::createBrandSettings(const QString& brand, QWidget* parent) {
@@ -42,6 +43,8 @@ BrandSettingsInterface* BrandSettingsFactory::createBrandSettings(const QString&
     return new SubaruSettings(parent);
   if (brand == "tesla")
     return new TeslaSettings(parent);
+  if (brand == "toyota")
+    return new ToyotaSettings(parent);
 
   // Default empty settings if brand not supported
   return nullptr;

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brand_settings_factory.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brand_settings_factory.cc
@@ -16,6 +16,7 @@ static const QStringList supportedBrands = {
   "hyundai",
   "mazda",
   "nissan",
+  "rivian",
 };
 
 BrandSettingsInterface* BrandSettingsFactory::createBrandSettings(const QString& brand, QWidget* parent) {
@@ -33,6 +34,8 @@ BrandSettingsInterface* BrandSettingsFactory::createBrandSettings(const QString&
     return new MazdaSettings(parent);
   if (brand == "nissan")
     return new NissanSettings(parent);
+  if (brand == "rivian")
+    return new RivianSettings(parent);
 
   // Default empty settings if brand not supported
   return nullptr;

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brand_settings_factory.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brand_settings_factory.h
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+ *
+ * This file is part of sunnypilot and is licensed under the MIT License.
+ * See the LICENSE.md file in the root directory for more details.
+ */
+
+#pragma once
+
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brand_settings_interface.h"
+
+class BrandSettingsFactory {
+
+public:
+  static BrandSettingsInterface* createBrandSettings(const QString &brand, QWidget *parent = nullptr);
+  static bool isBrandSupported(const QString& brand);
+  static QStringList getSupportedBrands();
+};

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brand_settings_interface.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brand_settings_interface.cc
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+ *
+ * This file is part of sunnypilot and is licensed under the MIT License.
+ * See the LICENSE.md file in the root directory for more details.
+ */
+
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brand_settings_interface.h"

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brand_settings_interface.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brand_settings_interface.h
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+ *
+ * This file is part of sunnypilot and is licensed under the MIT License.
+ * See the LICENSE.md file in the root directory for more details.
+ */
+
+#pragma once
+
+#include <QWidget>
+
+class BrandSettingsInterface : public QWidget {
+  Q_OBJECT
+
+public:
+  explicit BrandSettingsInterface(QWidget *parent = nullptr) : QWidget(parent) {}
+  virtual ~BrandSettingsInterface() = default;
+
+  virtual void updatePanel(bool offroad) = 0;
+  virtual void updateSettings() = 0;
+};

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brands.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brands.h
@@ -13,3 +13,4 @@
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/honda_settings.h"
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/hyundai_settings.h"
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/mazda_settings.h"
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/nissan_settings.h"

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brands.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brands.h
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+ *
+ * This file is part of sunnypilot and is licensed under the MIT License.
+ * See the LICENSE.md file in the root directory for more details.
+ */
+
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/chrysler_settings.h"
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/hyundai_settings.h"

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brands.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brands.h
@@ -18,3 +18,4 @@
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/subaru_settings.h"
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.h"
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/toyota_settings.h"
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/volkswagen_settings.h"

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brands.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brands.h
@@ -16,3 +16,4 @@
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/nissan_settings.h"
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/rivian_settings.h"
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/subaru_settings.h"
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.h"

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brands.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brands.h
@@ -14,3 +14,4 @@
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/hyundai_settings.h"
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/mazda_settings.h"
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/nissan_settings.h"
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/rivian_settings.h"

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brands.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brands.h
@@ -5,5 +5,10 @@
  * See the LICENSE.md file in the root directory for more details.
  */
 
+#pragma once
+
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/chrysler_settings.h"
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/ford_settings.h"
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/gm_settings.h"
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/honda_settings.h"
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/hyundai_settings.h"

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brands.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brands.h
@@ -15,3 +15,4 @@
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/mazda_settings.h"
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/nissan_settings.h"
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/rivian_settings.h"
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/subaru_settings.h"

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brands.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brands.h
@@ -12,3 +12,4 @@
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/gm_settings.h"
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/honda_settings.h"
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/hyundai_settings.h"
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/mazda_settings.h"

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brands.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brands.h
@@ -17,3 +17,4 @@
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/rivian_settings.h"
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/subaru_settings.h"
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.h"
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/toyota_settings.h"

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/chrysler_settings.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/chrysler_settings.cc
@@ -5,11 +5,11 @@
  * See the LICENSE.md file in the root directory for more details.
  */
 
-#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/hyundai_settings.h"
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/chrysler_settings.h"
 
 #include "selfdrive/ui/sunnypilot/qt/widgets/scrollview.h"
 
-HyundaiSettings::HyundaiSettings(QWidget *parent) : BrandSettingsInterface(parent) {
+ChryslerSettings::ChryslerSettings(QWidget *parent) : BrandSettingsInterface(parent) {
   QVBoxLayout *main_layout = new QVBoxLayout(this);
   main_layout->setContentsMargins(0, 0, 0, 0);
 
@@ -18,13 +18,13 @@ HyundaiSettings::HyundaiSettings(QWidget *parent) : BrandSettingsInterface(paren
   main_layout->addWidget(new ScrollViewSP(list, this));
 }
 
-void HyundaiSettings::updatePanel(bool _offroad) {
+void ChryslerSettings::updatePanel(bool _offroad) {
   updateSettings();
 
   offroad = _offroad;
 }
 
-void HyundaiSettings::updateSettings() {
+void ChryslerSettings::updateSettings() {
   if (!isVisible()) {
     return;
   }

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/chrysler_settings.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/chrysler_settings.h
@@ -14,11 +14,11 @@
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/settings.h"
 #include "selfdrive/ui/sunnypilot/qt/widgets/controls.h"
 
-class HyundaiSettings : public BrandSettingsInterface {
+class ChryslerSettings : public BrandSettingsInterface {
   Q_OBJECT
 
 public:
-  explicit HyundaiSettings(QWidget *parent = nullptr);
+  explicit ChryslerSettings(QWidget *parent = nullptr);
   void updatePanel(bool _offroad);
   void updateSettings();
 

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/ford_settings.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/ford_settings.cc
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+ *
+ * This file is part of sunnypilot and is licensed under the MIT License.
+ * See the LICENSE.md file in the root directory for more details.
+ */
+
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/ford_settings.h"
+
+#include "selfdrive/ui/sunnypilot/qt/widgets/scrollview.h"
+
+FordSettings::FordSettings(QWidget *parent) : BrandSettingsInterface(parent) {
+  QVBoxLayout *main_layout = new QVBoxLayout(this);
+  main_layout->setContentsMargins(0, 0, 0, 0);
+
+  ListWidget *list = new ListWidget(this, false);
+
+  main_layout->addWidget(new ScrollViewSP(list, this));
+}
+
+void FordSettings::updatePanel(bool _offroad) {
+  updateSettings();
+
+  offroad = _offroad;
+}
+
+void FordSettings::updateSettings() {
+  if (!isVisible()) {
+    return;
+  }
+}

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/ford_settings.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/ford_settings.h
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+ *
+ * This file is part of sunnypilot and is licensed under the MIT License.
+ * See the LICENSE.md file in the root directory for more details.
+ */
+
+#pragma once
+
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brand_settings_interface.h"
+
+#include "selfdrive/ui/qt/util.h"
+#include "selfdrive/ui/sunnypilot/ui.h"
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/settings.h"
+#include "selfdrive/ui/sunnypilot/qt/widgets/controls.h"
+
+class FordSettings : public BrandSettingsInterface {
+  Q_OBJECT
+
+public:
+  explicit FordSettings(QWidget *parent = nullptr);
+  void updatePanel(bool _offroad);
+  void updateSettings();
+
+private:
+  bool offroad = false;
+};

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/gm_settings.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/gm_settings.cc
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+ *
+ * This file is part of sunnypilot and is licensed under the MIT License.
+ * See the LICENSE.md file in the root directory for more details.
+ */
+
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/gm_settings.h"
+
+#include "selfdrive/ui/sunnypilot/qt/widgets/scrollview.h"
+
+GMSettings::GMSettings(QWidget *parent) : BrandSettingsInterface(parent) {
+  QVBoxLayout *main_layout = new QVBoxLayout(this);
+  main_layout->setContentsMargins(0, 0, 0, 0);
+
+  ListWidget *list = new ListWidget(this, false);
+
+  main_layout->addWidget(new ScrollViewSP(list, this));
+}
+
+void GMSettings::updatePanel(bool _offroad) {
+  updateSettings();
+
+  offroad = _offroad;
+}
+
+void GMSettings::updateSettings() {
+  if (!isVisible()) {
+    return;
+  }
+}

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/gm_settings.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/gm_settings.h
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+ *
+ * This file is part of sunnypilot and is licensed under the MIT License.
+ * See the LICENSE.md file in the root directory for more details.
+ */
+
+#pragma once
+
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brand_settings_interface.h"
+
+#include "selfdrive/ui/qt/util.h"
+#include "selfdrive/ui/sunnypilot/ui.h"
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/settings.h"
+#include "selfdrive/ui/sunnypilot/qt/widgets/controls.h"
+
+class GMSettings : public BrandSettingsInterface {
+  Q_OBJECT
+
+public:
+  explicit GMSettings(QWidget *parent = nullptr);
+  void updatePanel(bool _offroad);
+  void updateSettings();
+
+private:
+  bool offroad = false;
+};

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/honda_settings.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/honda_settings.cc
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+ *
+ * This file is part of sunnypilot and is licensed under the MIT License.
+ * See the LICENSE.md file in the root directory for more details.
+ */
+
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/honda_settings.h"
+
+#include "selfdrive/ui/sunnypilot/qt/widgets/scrollview.h"
+
+HondaSettings::HondaSettings(QWidget *parent) : BrandSettingsInterface(parent) {
+  QVBoxLayout *main_layout = new QVBoxLayout(this);
+  main_layout->setContentsMargins(0, 0, 0, 0);
+
+  ListWidget *list = new ListWidget(this, false);
+
+  main_layout->addWidget(new ScrollViewSP(list, this));
+}
+
+void HondaSettings::updatePanel(bool _offroad) {
+  updateSettings();
+
+  offroad = _offroad;
+}
+
+void HondaSettings::updateSettings() {
+  if (!isVisible()) {
+    return;
+  }
+}

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/honda_settings.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/honda_settings.h
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+ *
+ * This file is part of sunnypilot and is licensed under the MIT License.
+ * See the LICENSE.md file in the root directory for more details.
+ */
+
+#pragma once
+
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brand_settings_interface.h"
+
+#include "selfdrive/ui/qt/util.h"
+#include "selfdrive/ui/sunnypilot/ui.h"
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/settings.h"
+#include "selfdrive/ui/sunnypilot/qt/widgets/controls.h"
+
+class HondaSettings : public BrandSettingsInterface {
+  Q_OBJECT
+
+public:
+  explicit HondaSettings(QWidget *parent = nullptr);
+  void updatePanel(bool _offroad);
+  void updateSettings();
+
+private:
+  bool offroad = false;
+};

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/hyundai_settings.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/hyundai_settings.cc
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+ *
+ * This file is part of sunnypilot and is licensed under the MIT License.
+ * See the LICENSE.md file in the root directory for more details.
+ */
+
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/hyundai_settings.h"
+
+#include "selfdrive/ui/sunnypilot/qt/widgets/scrollview.h"
+
+HyundaiSettings::HyundaiSettings(QWidget *parent) : QWidget(parent) {
+  QVBoxLayout *main_layout = new QVBoxLayout(this);
+  main_layout->setContentsMargins(0, 0, 0, 0);
+
+  ListWidget *list = new ListWidget(this, false);
+
+  main_layout->addWidget(new ScrollViewSP(list, this));
+}
+
+void HyundaiSettings::updatePanel(bool _offroad) {
+  updateSettings();
+
+  offroad = _offroad;
+}
+
+void HyundaiSettings::updateSettings() {
+  if (!isVisible()) {
+    return;
+  }
+}

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/hyundai_settings.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/hyundai_settings.h
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+ *
+ * This file is part of sunnypilot and is licensed under the MIT License.
+ * See the LICENSE.md file in the root directory for more details.
+ */
+
+#pragma once
+
+#include "selfdrive/ui/qt/util.h"
+#include "selfdrive/ui/sunnypilot/ui.h"
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/settings.h"
+#include "selfdrive/ui/sunnypilot/qt/widgets/controls.h"
+
+class HyundaiSettings : public QWidget {
+  Q_OBJECT
+
+public:
+  explicit HyundaiSettings(QWidget *parent = nullptr);
+
+public slots:
+  void updatePanel(bool _offroad);
+  void updateSettings();
+
+private:
+  bool offroad = false;
+};

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/mazda_settings.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/mazda_settings.cc
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+ *
+ * This file is part of sunnypilot and is licensed under the MIT License.
+ * See the LICENSE.md file in the root directory for more details.
+ */
+
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/mazda_settings.h"
+
+#include "selfdrive/ui/sunnypilot/qt/widgets/scrollview.h"
+
+MazdaSettings::MazdaSettings(QWidget *parent) : BrandSettingsInterface(parent) {
+  QVBoxLayout *main_layout = new QVBoxLayout(this);
+  main_layout->setContentsMargins(0, 0, 0, 0);
+
+  ListWidget *list = new ListWidget(this, false);
+
+  main_layout->addWidget(new ScrollViewSP(list, this));
+}
+
+void MazdaSettings::updatePanel(bool _offroad) {
+  updateSettings();
+
+  offroad = _offroad;
+}
+
+void MazdaSettings::updateSettings() {
+  if (!isVisible()) {
+    return;
+  }
+}

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/mazda_settings.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/mazda_settings.h
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+ *
+ * This file is part of sunnypilot and is licensed under the MIT License.
+ * See the LICENSE.md file in the root directory for more details.
+ */
+
+#pragma once
+
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brand_settings_interface.h"
+
+#include "selfdrive/ui/qt/util.h"
+#include "selfdrive/ui/sunnypilot/ui.h"
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/settings.h"
+#include "selfdrive/ui/sunnypilot/qt/widgets/controls.h"
+
+class MazdaSettings : public BrandSettingsInterface {
+  Q_OBJECT
+
+public:
+  explicit MazdaSettings(QWidget *parent = nullptr);
+  void updatePanel(bool _offroad);
+  void updateSettings();
+
+private:
+  bool offroad = false;
+};

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/nissan_settings.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/nissan_settings.cc
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+ *
+ * This file is part of sunnypilot and is licensed under the MIT License.
+ * See the LICENSE.md file in the root directory for more details.
+ */
+
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/nissan_settings.h"
+
+#include "selfdrive/ui/sunnypilot/qt/widgets/scrollview.h"
+
+NissanSettings::NissanSettings(QWidget *parent) : BrandSettingsInterface(parent) {
+  QVBoxLayout *main_layout = new QVBoxLayout(this);
+  main_layout->setContentsMargins(0, 0, 0, 0);
+
+  ListWidget *list = new ListWidget(this, false);
+
+  main_layout->addWidget(new ScrollViewSP(list, this));
+}
+
+void NissanSettings::updatePanel(bool _offroad) {
+  updateSettings();
+
+  offroad = _offroad;
+}
+
+void NissanSettings::updateSettings() {
+  if (!isVisible()) {
+    return;
+  }
+}

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/nissan_settings.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/nissan_settings.h
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+ *
+ * This file is part of sunnypilot and is licensed under the MIT License.
+ * See the LICENSE.md file in the root directory for more details.
+ */
+
+#pragma once
+
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brand_settings_interface.h"
+
+#include "selfdrive/ui/qt/util.h"
+#include "selfdrive/ui/sunnypilot/ui.h"
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/settings.h"
+#include "selfdrive/ui/sunnypilot/qt/widgets/controls.h"
+
+class NissanSettings : public BrandSettingsInterface {
+  Q_OBJECT
+
+public:
+  explicit NissanSettings(QWidget *parent = nullptr);
+  void updatePanel(bool _offroad);
+  void updateSettings();
+
+private:
+  bool offroad = false;
+};

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/platform_selector.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/platform_selector.cc
@@ -48,11 +48,14 @@ PlatformSelector::PlatformSelector() : ButtonControl(tr("Vehicle"), "", "") {
 
 void PlatformSelector::refresh(bool _offroad) {
   QString name = getPlatformBundle("name").toString();
-  if (!name.isEmpty()) {
-    setValue(name);
-    setText(tr("REMOVE"));
+  platform = unrecognized_str;
+  QString platform_color = YELLOW_PLATFORM;
 
+  if (!name.isEmpty()) {
+    platform = name;
+    platform_color = BLUE_PLATFORM;
     brand = getPlatformBundle("brand").toString();
+    setText(tr("REMOVE"));
   } else {
     setText(tr("SEARCH"));
 
@@ -76,13 +79,28 @@ void PlatformSelector::refresh(bool _offroad) {
 
       if (platform == "MOCK") {
         platform = unrecognized_str;
+      } else {
+        platform_color = GREEN_PLATFORM;
       }
     }
-    setValue(platform);
   }
+  setValue(platform, platform_color);
   setEnabled(true);
   emit refreshPanel();
+
   offroad = _offroad;
+
+  FingerprintStatus cur_status;
+  if (platform_color == GREEN_PLATFORM) {
+    cur_status = FingerprintStatus::AUTO_FINGERPRINT;
+  } else if (platform_color == BLUE_PLATFORM) {
+    cur_status = FingerprintStatus::MANUAL_FINGERPRINT;
+  } else {
+    cur_status = FingerprintStatus::UNRECOGNIZED;
+  }
+
+  setDescription(platformDescription(cur_status));
+  showDescription();
 }
 
 void PlatformSelector::setPlatform(const QString &_platform) {

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/platform_selector.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/platform_selector.cc
@@ -51,29 +51,47 @@ void PlatformSelector::refresh(bool _offroad) {
   if (!name.isEmpty()) {
     setValue(name);
     setText(tr("REMOVE"));
+
+    brand = getPlatformBundle("brand").toString();
   } else {
     setText(tr("SEARCH"));
+
+    platform = unrecognized_str;
+    brand = "";
     auto cp_bytes = params.get("CarParamsPersistent");
     if (!cp_bytes.empty()) {
       AlignedBuffer aligned_buf;
       capnp::FlatArrayMessageReader cmsg(aligned_buf.align(cp_bytes.data(), cp_bytes.size()));
       cereal::CarParams::Reader CP = cmsg.getRoot<cereal::CarParams>();
-      setValue(QString::fromStdString(CP.getCarFingerprint().cStr()));
+
+      platform = QString::fromStdString(CP.getCarFingerprint().cStr());
+
+      for (auto it = platforms.constBegin(); it != platforms.constEnd(); ++it) {
+        if (it.value()["platform"].toString() == platform) {
+          platform = it.key();
+          brand = it.value()["brand"].toString();
+          break;
+        }
+      }
+
+      if (platform == "MOCK") {
+        platform = unrecognized_str;
+      }
     }
+    setValue(platform);
   }
   setEnabled(true);
   emit refreshPanel();
-
   offroad = _offroad;
 }
 
-void PlatformSelector::setPlatform(const QString &platform) {
-  QVariantMap platform_data = platforms[platform];
+void PlatformSelector::setPlatform(const QString &_platform) {
+  QVariantMap platform_data = platforms[_platform];
 
   const QString offroad_msg = offroad ? tr("This setting will take effect immediately.") :
                                         tr("This setting will take effect once the device enters offroad state.");
   const QString msg = QString("<b>%1</b><br><br>%2")
-                      .arg(platform, offroad_msg);
+                      .arg(_platform, offroad_msg);
 
   QString content("<body><h2 style=\"text-align: center;\">" + tr("Vehicle Selector") + "</h2><br>"
                   "<p style=\"text-align: center; margin: 0 128px; font-size: 50px;\">" + msg + "</p></body>");
@@ -81,7 +99,7 @@ void PlatformSelector::setPlatform(const QString &platform) {
   if (ConfirmationDialog(content, tr("Confirm"), tr("Cancel"), true, this).exec()) {
     QJsonObject json_bundle;
     json_bundle["platform"] = platform_data["platform"].toString();
-    json_bundle["name"] = platform;
+    json_bundle["name"] = _platform;
     json_bundle["make"] = platform_data["make"].toString();
     json_bundle["brand"] = platform_data["brand"].toString();
     json_bundle["model"] = platform_data["model"].toString();

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/platform_selector.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/platform_selector.cc
@@ -43,6 +43,7 @@ PlatformSelector::PlatformSelector() : ButtonControl(tr("Vehicle"), "", "") {
     }
   });
 
+  main_layout->addStretch(0);
   refresh(offroad);
 }
 

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/platform_selector.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/platform_selector.h
@@ -16,6 +16,9 @@ public:
   PlatformSelector();
   QVariant getPlatformBundle(const QString &key);
 
+  QString platform;
+  QString brand;
+
 public slots:
   void refresh(bool _offroad);
 
@@ -29,4 +32,6 @@ private:
 
   Params params;
   bool offroad;
+
+  QString unrecognized_str = tr("Unrecognized Vehicle");
 };

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/platform_selector.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/platform_selector.h
@@ -9,6 +9,16 @@
 
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/settings.h"
 
+static const QString GREEN_PLATFORM = "#00F100";
+static const QString BLUE_PLATFORM = "#0086E9";
+static const QString YELLOW_PLATFORM = "#FFD500";
+
+enum class FingerprintStatus {
+  AUTO_FINGERPRINT,
+  MANUAL_FINGERPRINT,
+  UNRECOGNIZED,
+};
+
 class PlatformSelector : public ButtonControl {
   Q_OBJECT
 
@@ -34,4 +44,25 @@ private:
   bool offroad;
 
   QString unrecognized_str = tr("Unrecognized Vehicle");
+
+  static QString platformDescription(FingerprintStatus status = FingerprintStatus::UNRECOGNIZED) {
+    QString auto_str = "🟢 - " + tr("Fingerprinted automatically");
+    QString manual_str = "🔵 - " + tr("Manually selected");
+    QString unrecognized_str = "🟡 - " + tr("Not fingerprinted or manually selected");
+
+    if (status == FingerprintStatus::AUTO_FINGERPRINT) {
+      auto_str = "<font color='white'><b>" + auto_str + "</b></font>";
+    } else if (status == FingerprintStatus::MANUAL_FINGERPRINT) {
+      manual_str = "<font color='white'><b>" + manual_str + "</b></font>";
+    } else {
+      unrecognized_str = "<font color='white'><b>" + unrecognized_str + "</b></font>";
+    }
+
+    return QString("%1<br>%2<br><br>%3<br>%4<br>%5")
+             .arg(tr("Select vehicle to force fingerprint manually."))
+             .arg(tr("Colors represent fingerprint status:"))
+             .arg(auto_str)
+             .arg(manual_str)
+             .arg(unrecognized_str);
+  }
 };

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/rivian_settings.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/rivian_settings.cc
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+ *
+ * This file is part of sunnypilot and is licensed under the MIT License.
+ * See the LICENSE.md file in the root directory for more details.
+ */
+
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/rivian_settings.h"
+
+#include "selfdrive/ui/sunnypilot/qt/widgets/scrollview.h"
+
+RivianSettings::RivianSettings(QWidget *parent) : BrandSettingsInterface(parent) {
+  QVBoxLayout *main_layout = new QVBoxLayout(this);
+  main_layout->setContentsMargins(0, 0, 0, 0);
+
+  ListWidget *list = new ListWidget(this, false);
+
+  main_layout->addWidget(new ScrollViewSP(list, this));
+}
+
+void RivianSettings::updatePanel(bool _offroad) {
+  updateSettings();
+
+  offroad = _offroad;
+}
+
+void RivianSettings::updateSettings() {
+  if (!isVisible()) {
+    return;
+  }
+}

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/rivian_settings.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/rivian_settings.h
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+ *
+ * This file is part of sunnypilot and is licensed under the MIT License.
+ * See the LICENSE.md file in the root directory for more details.
+ */
+
+#pragma once
+
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brand_settings_interface.h"
+
+#include "selfdrive/ui/qt/util.h"
+#include "selfdrive/ui/sunnypilot/ui.h"
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/settings.h"
+#include "selfdrive/ui/sunnypilot/qt/widgets/controls.h"
+
+class RivianSettings : public BrandSettingsInterface {
+  Q_OBJECT
+
+public:
+  explicit RivianSettings(QWidget *parent = nullptr);
+  void updatePanel(bool _offroad);
+  void updateSettings();
+
+private:
+  bool offroad = false;
+};

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/subaru_settings.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/subaru_settings.cc
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+ *
+ * This file is part of sunnypilot and is licensed under the MIT License.
+ * See the LICENSE.md file in the root directory for more details.
+ */
+
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/subaru_settings.h"
+
+#include "selfdrive/ui/sunnypilot/qt/widgets/scrollview.h"
+
+SubaruSettings::SubaruSettings(QWidget *parent) : BrandSettingsInterface(parent) {
+  QVBoxLayout *main_layout = new QVBoxLayout(this);
+  main_layout->setContentsMargins(0, 0, 0, 0);
+
+  ListWidget *list = new ListWidget(this, false);
+
+  main_layout->addWidget(new ScrollViewSP(list, this));
+}
+
+void SubaruSettings::updatePanel(bool _offroad) {
+  updateSettings();
+
+  offroad = _offroad;
+}
+
+void SubaruSettings::updateSettings() {
+  if (!isVisible()) {
+    return;
+  }
+}

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/subaru_settings.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/subaru_settings.h
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+ *
+ * This file is part of sunnypilot and is licensed under the MIT License.
+ * See the LICENSE.md file in the root directory for more details.
+ */
+
+#pragma once
+
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brand_settings_interface.h"
+
+#include "selfdrive/ui/qt/util.h"
+#include "selfdrive/ui/sunnypilot/ui.h"
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/settings.h"
+#include "selfdrive/ui/sunnypilot/qt/widgets/controls.h"
+
+class SubaruSettings : public BrandSettingsInterface {
+  Q_OBJECT
+
+public:
+  explicit SubaruSettings(QWidget *parent = nullptr);
+  void updatePanel(bool _offroad);
+  void updateSettings();
+
+private:
+  bool offroad = false;
+};

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.cc
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+ *
+ * This file is part of sunnypilot and is licensed under the MIT License.
+ * See the LICENSE.md file in the root directory for more details.
+ */
+
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.h"
+
+#include "selfdrive/ui/sunnypilot/qt/widgets/scrollview.h"
+
+TeslaSettings::TeslaSettings(QWidget *parent) : BrandSettingsInterface(parent) {
+  QVBoxLayout *main_layout = new QVBoxLayout(this);
+  main_layout->setContentsMargins(0, 0, 0, 0);
+
+  ListWidget *list = new ListWidget(this, false);
+
+  main_layout->addWidget(new ScrollViewSP(list, this));
+}
+
+void TeslaSettings::updatePanel(bool _offroad) {
+  updateSettings();
+
+  offroad = _offroad;
+}
+
+void TeslaSettings::updateSettings() {
+  if (!isVisible()) {
+    return;
+  }
+}

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.h
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+ *
+ * This file is part of sunnypilot and is licensed under the MIT License.
+ * See the LICENSE.md file in the root directory for more details.
+ */
+
+#pragma once
+
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brand_settings_interface.h"
+
+#include "selfdrive/ui/qt/util.h"
+#include "selfdrive/ui/sunnypilot/ui.h"
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/settings.h"
+#include "selfdrive/ui/sunnypilot/qt/widgets/controls.h"
+
+class TeslaSettings : public BrandSettingsInterface {
+  Q_OBJECT
+
+public:
+  explicit TeslaSettings(QWidget *parent = nullptr);
+  void updatePanel(bool _offroad);
+  void updateSettings();
+
+private:
+  bool offroad = false;
+};

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/toyota_settings.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/toyota_settings.cc
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+ *
+ * This file is part of sunnypilot and is licensed under the MIT License.
+ * See the LICENSE.md file in the root directory for more details.
+ */
+
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/toyota_settings.h"
+
+#include "selfdrive/ui/sunnypilot/qt/widgets/scrollview.h"
+
+ToyotaSettings::ToyotaSettings(QWidget *parent) : BrandSettingsInterface(parent) {
+  QVBoxLayout *main_layout = new QVBoxLayout(this);
+  main_layout->setContentsMargins(0, 0, 0, 0);
+
+  ListWidget *list = new ListWidget(this, false);
+
+  main_layout->addWidget(new ScrollViewSP(list, this));
+}
+
+void ToyotaSettings::updatePanel(bool _offroad) {
+  updateSettings();
+
+  offroad = _offroad;
+}
+
+void ToyotaSettings::updateSettings() {
+  if (!isVisible()) {
+    return;
+  }
+}

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/toyota_settings.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/toyota_settings.h
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+ *
+ * This file is part of sunnypilot and is licensed under the MIT License.
+ * See the LICENSE.md file in the root directory for more details.
+ */
+
+#pragma once
+
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brand_settings_interface.h"
+
+#include "selfdrive/ui/qt/util.h"
+#include "selfdrive/ui/sunnypilot/ui.h"
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/settings.h"
+#include "selfdrive/ui/sunnypilot/qt/widgets/controls.h"
+
+class ToyotaSettings : public BrandSettingsInterface {
+  Q_OBJECT
+
+public:
+  explicit ToyotaSettings(QWidget *parent = nullptr);
+  void updatePanel(bool _offroad);
+  void updateSettings();
+
+private:
+  bool offroad = false;
+};

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/volkswagen_settings.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/volkswagen_settings.cc
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+ *
+ * This file is part of sunnypilot and is licensed under the MIT License.
+ * See the LICENSE.md file in the root directory for more details.
+ */
+
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/volkswagen_settings.h"
+
+#include "selfdrive/ui/sunnypilot/qt/widgets/scrollview.h"
+
+VolkswagenSettings::VolkswagenSettings(QWidget *parent) : BrandSettingsInterface(parent) {
+  QVBoxLayout *main_layout = new QVBoxLayout(this);
+  main_layout->setContentsMargins(0, 0, 0, 0);
+
+  ListWidget *list = new ListWidget(this, false);
+
+  main_layout->addWidget(new ScrollViewSP(list, this));
+}
+
+void VolkswagenSettings::updatePanel(bool _offroad) {
+  updateSettings();
+
+  offroad = _offroad;
+}
+
+void VolkswagenSettings::updateSettings() {
+  if (!isVisible()) {
+    return;
+  }
+}

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/volkswagen_settings.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/volkswagen_settings.h
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+ *
+ * This file is part of sunnypilot and is licensed under the MIT License.
+ * See the LICENSE.md file in the root directory for more details.
+ */
+
+#pragma once
+
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brand_settings_interface.h"
+
+#include "selfdrive/ui/qt/util.h"
+#include "selfdrive/ui/sunnypilot/ui.h"
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/settings.h"
+#include "selfdrive/ui/sunnypilot/qt/widgets/controls.h"
+
+class VolkswagenSettings : public BrandSettingsInterface {
+  Q_OBJECT
+
+public:
+  explicit VolkswagenSettings(QWidget *parent = nullptr);
+  void updatePanel(bool _offroad);
+  void updateSettings();
+
+private:
+  bool offroad = false;
+};

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle_panel.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle_panel.cc
@@ -7,6 +7,7 @@
 
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle_panel.h"
 
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/hyundai_settings.h"
 #include "selfdrive/ui/sunnypilot/qt/widgets/scrollview.h"
 
 VehiclePanel::VehiclePanel(QWidget *parent) : QFrame(parent) {
@@ -18,10 +19,15 @@ VehiclePanel::VehiclePanel(QWidget *parent) : QFrame(parent) {
   vlayout->setContentsMargins(50, 20, 50, 20);
 
   platformSelector = new PlatformSelector();
+  QObject::connect(platformSelector, &PlatformSelector::refreshPanel, this, &VehiclePanel::updateBrandSettings);
   list->addItem(platformSelector);
 
   ScrollViewSP *scroller = new ScrollViewSP(list, this);
   vlayout->addWidget(scroller);
+
+  hyundaiSettings = new HyundaiSettings(this);
+  vlayout->addWidget(hyundaiSettings);
+  hyundaiSettings->setVisible(false);
 
   QObject::connect(uiState(), &UIState::offroadTransition, this, &VehiclePanel::updatePanel);
 
@@ -36,5 +42,24 @@ void VehiclePanel::showEvent(QShowEvent *event) {
 void VehiclePanel::updatePanel(bool _offroad) {
   platformSelector->refresh(_offroad);
 
+  updateBrandSettings();
+
   offroad = _offroad;
+}
+
+void VehiclePanel::updateBrandSettings() {
+  if (!isVisible()) {
+    return;
+  }
+
+  resetBrandSettings();
+
+  if (platformSelector->brand == "hyundai") {
+    hyundaiSettings->setVisible(true);
+    hyundaiSettings->updatePanel(offroad);
+  }
+}
+
+void VehiclePanel::resetBrandSettings() {
+  hyundaiSettings->setVisible(false);
 }

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle_panel.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle_panel.h
@@ -9,7 +9,7 @@
 
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/settings.h"
 
-#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/hyundai_settings.h"
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/brand_settings_interface.h"
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/platform_selector.h"
 
 class VehiclePanel : public QFrame {
@@ -23,15 +23,10 @@ public slots:
   void updatePanel(bool _offroad);
 
 private:
-  void resetBrandSettings();
-
   QStackedLayout* main_layout = nullptr;
   QWidget* vehicleScreen = nullptr;
   PlatformSelector* platformSelector = nullptr;
-
-  // brand panels
-  HyundaiSettings* hyundaiSettings = nullptr;
-
+  BrandSettingsInterface* currentBrandSettings = nullptr;
   bool offroad = false;
 
 private slots:

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle_panel.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle_panel.h
@@ -9,6 +9,7 @@
 
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/settings.h"
 
+#include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/hyundai_settings.h"
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/platform_selector.h"
 
 class VehiclePanel : public QFrame {
@@ -22,8 +23,17 @@ public slots:
   void updatePanel(bool _offroad);
 
 private:
+  void resetBrandSettings();
+
   QStackedLayout* main_layout = nullptr;
   QWidget* vehicleScreen = nullptr;
-  PlatformSelector *platformSelector = nullptr;
-  bool offroad;
+  PlatformSelector* platformSelector = nullptr;
+
+  // brand panels
+  HyundaiSettings* hyundaiSettings = nullptr;
+
+  bool offroad = false;
+
+private slots:
+  void updateBrandSettings();
 };


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Implement brand-specific settings for vehicle panel in the UI, allowing dynamic loading of settings based on the selected vehicle brand

New Features:
- Added support for brand-specific settings panels for multiple vehicle manufacturers
- Created a factory mechanism to dynamically load brand-specific settings
- Implemented base infrastructure for brand settings interface

Enhancements:
- Improved vehicle platform selector with more robust platform and brand detection
- Extended vehicle panel to support dynamic brand-specific settings

Build:
- Updated SConscript to include new brand settings source files