### PR TITLE
Revert "ui: display actual fingerprint name with auto-fingerprint"

### DIFF
--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/platform_selector.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/platform_selector.cc
@@ -70,6 +70,14 @@ void PlatformSelector::refresh(bool _offroad) {
 
       platform = QString::fromStdString(CP.getCarFingerprint().cStr());
 
+      for (auto it = platforms.constBegin(); it != platforms.constEnd(); ++it) {
+        if (it.value()["platform"].toString() == platform) {
+          platform = it.key();
+          brand = it.value()["brand"].toString();
+          break;
+        }
+      }
+
       if (platform == "MOCK") {
         platform = unrecognized_str;
       } else {


### PR DESCRIPTION
Reverts sunnypilot/sunnypilot#906

This is causing auto-fingerprint to not show brand-specific settings. Need to reimplement.

## Summary by Sourcery

Reverts a previous change that displayed the actual fingerprint name with auto-fingerprint in the vehicle platform selector UI.