### PR TITLE
ui: display actual fingerprint name with auto-fingerprint

### DIFF
--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/platform_selector.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/platform_selector.cc
@@ -70,6 +70,14 @@ void PlatformSelector::refresh(bool _offroad) {
 
       platform = QString::fromStdString(CP.getCarFingerprint().cStr());
 
+      for (auto it = platforms.constBegin(); it != platforms.constEnd(); ++it) {
+        if (it.value()["platform"].toString() == platform) {
+          platform = it.key();
+          brand = it.value()["brand"].toString();
+          break;
+        }
+      }
+
       if (platform == "MOCK") {
         platform = unrecognized_str;
       } else {

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/platform_selector.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/platform_selector.cc
@@ -70,14 +70,6 @@ void PlatformSelector::refresh(bool _offroad) {
 
       platform = QString::fromStdString(CP.getCarFingerprint().cStr());
 
-      for (auto it = platforms.constBegin(); it != platforms.constEnd(); ++it) {
-        if (it.value()["platform"].toString() == platform) {
-          platform = it.key();
-          brand = it.value()["brand"].toString();
-          break;
-        }
-      }
-
       if (platform == "MOCK") {
         platform = unrecognized_str;
       } else {

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/platform_selector.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/platform_selector.cc
@@ -70,6 +70,13 @@ void PlatformSelector::refresh(bool _offroad) {
 
       platform = QString::fromStdString(CP.getCarFingerprint().cStr());
 
+      for (auto it = platforms.constBegin(); it != platforms.constEnd(); ++it) {
+        if (it.value()["platform"].toString() == platform) {
+          brand = it.value()["brand"].toString();
+          break;
+        }
+      }
+
       if (platform == "MOCK") {
         platform = unrecognized_str;
       } else {


### PR DESCRIPTION
keep brand from platform package

## Summary by Sourcery

Enhancements:
- Preserve the original platform name when displaying fingerprint information in the UI.