### PR TITLE
MADS: allow transition from Paused to Enabled at all times

### DIFF
--- a/sunnypilot/mads/mads.py
+++ b/sunnypilot/mads/mads.py
@@ -89,11 +89,6 @@ class ModularAssistiveDrivingSystem:
         if CS.brakePressed:
           transition_paused_state()
 
-      if not (self.pause_lateral_on_brake_toggle and CS.brakePressed) and \
-         not self.events_sp.contains_in_list(GEARS_ALLOW_PAUSED_SILENT):
-        if self.state_machine.state == State.paused:
-          self.events_sp.add(EventNameSP.silentLkasEnable)
-
       self.events.remove(EventName.preEnableStandstill)
       self.events.remove(EventName.belowEngageSpeed)
       self.events.remove(EventName.speedTooLow)
@@ -124,6 +119,11 @@ class ModularAssistiveDrivingSystem:
       self.events.remove(EventName.buttonEnable)
       if self.selfdrive.CS_prev.cruiseState.available:
         self.events_sp.add(EventNameSP.lkasDisable)
+
+    if not (self.pause_lateral_on_brake_toggle and CS.brakePressed) and \
+       not self.events_sp.contains_in_list(GEARS_ALLOW_PAUSED_SILENT):
+      if self.state_machine.state == State.paused:
+        self.events_sp.add(EventNameSP.silentLkasEnable)
 
     self.events.remove(EventName.pcmDisable)
     self.events.remove(EventName.buttonCancel)

--- a/sunnypilot/mads/state.py
+++ b/sunnypilot/mads/state.py
@@ -51,7 +51,7 @@ class StateMachine:
     if self.state != State.disabled:
       # user and immediate disable always have priority in a non-disabled state
       if self.check_contains(ET.USER_DISABLE):
-        if self._events_sp.has(EventNameSP.silentLkasDisable) or self._events_sp.has(EventNameSP.silentBrakeHold):
+        if self._events_sp.has(EventNameSP.silentLkasDisable):
           self.state = State.paused
         else:
           self.state = State.disabled

--- a/sunnypilot/mads/tests/test_mads_state_machine.py
+++ b/sunnypilot/mads/tests/test_mads_state_machine.py
@@ -73,7 +73,7 @@ class TestMADSStateMachine:
         self.clear_events()
 
   def test_user_disable_to_paused(self):
-    paused_events = (EventNameSP.silentLkasDisable, EventNameSP.silentBrakeHold)
+    paused_events = (EventNameSP.silentLkasDisable, )
     for state in ALL_STATES:
       for et in MAINTAIN_STATES[state]:
         self.events_sp.add(make_event([et, ET.USER_DISABLE]))

--- a/sunnypilot/selfdrive/selfdrived/events.py
+++ b/sunnypilot/selfdrive/selfdrived/events.py
@@ -64,7 +64,7 @@ EVENTS_SP: dict[int, dict[str, Alert | AlertCallbackType]] = {
   },
 
   EventNameSP.silentBrakeHold: {
-    ET.USER_DISABLE: EngagementAlert(AudibleAlert.none),
+    ET.WARNING: EngagementAlert(AudibleAlert.none),
     ET.NO_ENTRY: NoEntryAlert("Brake Hold Active"),
   },
 


### PR DESCRIPTION
@sourcery-ai

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->