### PR TITLE
ui: add expandable row widget

### DIFF
--- a/selfdrive/ui/sunnypilot/SConscript
+++ b/selfdrive/ui/sunnypilot/SConscript
@@ -3,6 +3,7 @@ widgets_src = [
   "sunnypilot/qt/widgets/toggle.cc",
   "sunnypilot/qt/widgets/controls.cc",
   "sunnypilot/qt/widgets/drive_stats.cc",
+  "sunnypilot/qt/widgets/expandable_row.cc",
   "sunnypilot/qt/widgets/prime.cc",
   "sunnypilot/qt/widgets/scrollview.cc",
   "sunnypilot/qt/network/networking.cc",

--- a/selfdrive/ui/sunnypilot/qt/widgets/controls.h
+++ b/selfdrive/ui/sunnypilot/qt/widgets/controls.h
@@ -440,14 +440,15 @@ public:
 class OptionControlSP : public AbstractControlSP_SELECTOR {
   Q_OBJECT
 
-private:
-  bool is_inline_layout;
-  QHBoxLayout *optionSelectorLayout = is_inline_layout ? new QHBoxLayout() : hlayout;
-
+protected:
   struct MinMaxValue {
     int min_value;
     int max_value;
   };
+
+private:
+  bool is_inline_layout;
+  QHBoxLayout *optionSelectorLayout = is_inline_layout ? new QHBoxLayout() : hlayout;
 
   int getParamValue() {
     const auto param_value = QString::fromStdString(params.get(key));

--- a/selfdrive/ui/sunnypilot/qt/widgets/controls.h
+++ b/selfdrive/ui/sunnypilot/qt/widgets/controls.h
@@ -551,6 +551,10 @@ public:
     request_update = _update;
   }
 
+  void setFixedWidth(int width) {
+    label.setFixedWidth(width);
+  }
+
   inline void setLabel(const QString &text) { label.setText(text); }
 
   void setEnabled(bool enabled) {

--- a/selfdrive/ui/sunnypilot/qt/widgets/expandable_row.cc
+++ b/selfdrive/ui/sunnypilot/qt/widgets/expandable_row.cc
@@ -16,7 +16,7 @@ ExpandableToggleRow::ExpandableToggleRow(const QString &param, const QString &ti
   collapsibleWidget = new QFrame(this);
   collapsibleWidget->setContentsMargins(0, 0, 0, 0);
   collapsibleWidget->setVisible(false);
-  QVBoxLayout *collapsible_layout = new QVBoxLayout(this);
+  QVBoxLayout *collapsible_layout = new QVBoxLayout();
   collapsibleWidget->setLayout(collapsible_layout);
 
   list = new ListWidgetSP(this, false);

--- a/selfdrive/ui/sunnypilot/qt/widgets/expandable_row.cc
+++ b/selfdrive/ui/sunnypilot/qt/widgets/expandable_row.cc
@@ -8,7 +8,7 @@
 #include "selfdrive/ui/sunnypilot/qt/widgets/expandable_row.h"
 
 ExpandableToggleRow::ExpandableToggleRow(const QString &param, const QString &title, const QString &desc, const QString &icon, QWidget *parent)
-    : ToggleControlSP(title, desc, icon, false, parent) {
+  : ToggleControlSP(title, desc, icon, false, parent) {
 
   key = param.toStdString();
   QObject::connect(this, &ExpandableToggleRow::toggleFlipped, this, &ExpandableToggleRow::toggleClicked);
@@ -23,7 +23,6 @@ ExpandableToggleRow::ExpandableToggleRow(const QString &param, const QString &ti
 
   main_layout->addWidget(collapsibleWidget);
   collapsible_layout->addWidget(list);
-
 }
 
 void ExpandableToggleRow::toggleClicked(bool state) {

--- a/selfdrive/ui/sunnypilot/qt/widgets/expandable_row.cc
+++ b/selfdrive/ui/sunnypilot/qt/widgets/expandable_row.cc
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+ *
+ * This file is part of sunnypilot and is licensed under the MIT License.
+ * See the LICENSE.md file in the root directory for more details.
+ */
+
+#include "selfdrive/ui/sunnypilot/qt/widgets/expandable_row.h"
+
+ExpandableToggleRow::ExpandableToggleRow(const QString &param, const QString &title, const QString &desc, const QString &icon, QWidget *parent)
+    : ToggleControlSP(title, desc, icon, false, parent) {
+
+  key = param.toStdString();
+  QObject::connect(this, &ExpandableToggleRow::toggleFlipped, this, &ExpandableToggleRow::toggleClicked);
+
+  collapsibleWidget = new QFrame(this);
+  collapsibleWidget->setContentsMargins(0, 0, 0, 0);
+  collapsibleWidget->setVisible(false);
+  QVBoxLayout *collapsible_layout = new QVBoxLayout(this);
+  collapsibleWidget->setLayout(collapsible_layout);
+
+  list = new ListWidgetSP(this, false);
+
+  main_layout->addWidget(collapsibleWidget);
+  collapsible_layout->addWidget(list);
+
+}
+
+void ExpandableToggleRow::toggleClicked(bool state) {
+  params.putBool(key, state);
+  collapsibleWidget->setVisible(state);
+}

--- a/selfdrive/ui/sunnypilot/qt/widgets/expandable_row.h
+++ b/selfdrive/ui/sunnypilot/qt/widgets/expandable_row.h
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+ *
+ * This file is part of sunnypilot and is licensed under the MIT License.
+ * See the LICENSE.md file in the root directory for more details.
+ */
+
+ #pragma once
+
+#include "selfdrive/ui/sunnypilot/qt/widgets/controls.h"
+
+ class ExpandableToggleRow : public ToggleControlSP {
+  Q_OBJECT
+
+public:
+  ExpandableToggleRow(const QString &param, const QString &title, const QString &desc, const QString &icon, QWidget *parent = nullptr);
+
+  void addItem(QWidget *widget) {
+    list->addItem(widget);
+  }
+
+  ListWidgetSP* innerList() {
+    return list;
+  }
+
+  void refresh() {
+    bool state = params.getBool(key);
+    if (state != toggle.on) {
+      toggle.togglePosition();
+    }
+    collapsibleWidget->setVisible(state);
+  }
+
+  bool isToggled() {
+    return params.getBool(key);
+  }
+
+  void showEvent(QShowEvent *event) override {
+    refresh();
+  }
+
+
+private:
+  void toggleClicked(bool state);
+  std::string key;
+  Params params;
+
+  ListWidgetSP *list;
+  QFrame *collapsibleWidget = nullptr;
+};

--- a/selfdrive/ui/sunnypilot/qt/widgets/expandable_row.h
+++ b/selfdrive/ui/sunnypilot/qt/widgets/expandable_row.h
@@ -5,11 +5,11 @@
  * See the LICENSE.md file in the root directory for more details.
  */
 
- #pragma once
+#pragma once
 
 #include "selfdrive/ui/sunnypilot/qt/widgets/controls.h"
 
- class ExpandableToggleRow : public ToggleControlSP {
+class ExpandableToggleRow : public ToggleControlSP {
   Q_OBJECT
 
 public:
@@ -19,7 +19,7 @@ public:
     list->addItem(widget);
   }
 
-  ListWidgetSP* innerList() {
+  ListWidgetSP *innerList() {
     return list;
   }
 
@@ -39,9 +39,9 @@ public:
     refresh();
   }
 
-
 private:
   void toggleClicked(bool state);
+
   std::string key;
   Params params;
 


### PR DESCRIPTION
cleaning up custom-acc-increments PR

## Summary by Sourcery

Add a new expandable row widget to the UI, allowing rows to be expanded or collapsed to show additional content.

New Features:
- Introduce an expandable row widget for the UI.

Enhancements:
- Integrate the new expandable row widget into the build configuration.