### PR TITLE
Toyota: Flip ACC Increments

### DIFF
--- a/common/params_keys.h
+++ b/common/params_keys.h
@@ -136,6 +136,7 @@ inline static std::unordered_map<std::string, uint32_t> keys = {
     {"CustomAccShortPressIncrement", PERSISTENT | BACKUP},
     {"DeviceBootMode", PERSISTENT | BACKUP},
     {"EnableGithubRunner", PERSISTENT | BACKUP},
+    {"FlipAccIncrements", PERSISTENT | BACKUP},
     {"MaxTimeOffroad", PERSISTENT | BACKUP},
     {"Brightness", PERSISTENT | BACKUP},
     {"ModelRunnerTypeCache", CLEAR_ON_ONROAD_TRANSITION},

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/toyota_settings.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/toyota_settings.cc
@@ -8,6 +8,13 @@
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/toyota_settings.h"
 
 ToyotaSettings::ToyotaSettings(QWidget *parent) : BrandSettingsInterface(parent) {
+  toyotaFlipACC = new ParamControlSP(
+    "FlipAccIncrements",
+    tr("Flip ACC Increments"),
+    tr("Enabling this flips the Short & Long press ACC increments."),
+    "",
+    this);
+  list->addItem(toyotaFlipACC);
 }
 
 void ToyotaSettings::updateSettings() {

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/toyota_settings.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/toyota_settings.h
@@ -23,4 +23,5 @@ public:
 
 private:
   bool offroad = false;
+  ParamControlSP *toyotaFlipACC;
 };

--- a/sunnypilot/selfdrive/controls/lib/param_store.py
+++ b/sunnypilot/selfdrive/controls/lib/param_store.py
@@ -20,6 +20,11 @@ class ParamStore:
     universal_params: list[str] = []
     brand_params: list[str] = []
 
+    if CP.brand == "toyota":
+      brand_params.extend([
+        "FlipAccIncrements",
+      ])
+
     self.keys = universal_params + brand_params
     self.values = {}
 


### PR DESCRIPTION


## Summary by Sourcery

Add a new FlipAccIncrements setting to allow flipping of short and long press ACC increments on Toyota vehicles

New Features:
- Introduce `FlipAccIncrements` as a persistent parameter and register it in common keys
- Register `FlipAccIncrements` for Toyota in the parameter store
- Add a toggle in the Toyota settings UI to enable or disable the ACC increment flip