### PR TITLE
MADS: Steering Mode on Brake Pedal Press

### DIFF
--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -164,7 +164,7 @@ jobs:
                         QT_QPA_PLATFORM=offscreen ./selfdrive/ui/tests/test_translations && \
                         chmod -R 777 /tmp/comma_download_cache"
     - name: "Upload coverage to Codecov"
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v4
       with:
         name: ${{ github.job }}
       env:
@@ -217,7 +217,7 @@ jobs:
         ${{ env.RUN }} "ONNXCPU=1 $PYTEST selfdrive/test/process_replay/test_regen.py && \
                         chmod -R 777 /tmp/comma_download_cache"
     - name: "Upload coverage to Codecov"
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v4
       with:
         name: ${{ github.job }}
       env:
@@ -253,7 +253,7 @@ jobs:
         NUM_JOBS: 4
         JOB_ID: ${{ matrix.job }}
     - name: "Upload coverage to Codecov"
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v4
       with:
         name: ${{ github.job }}-${{ matrix.job }}
       env:

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -164,7 +164,7 @@ jobs:
                         QT_QPA_PLATFORM=offscreen ./selfdrive/ui/tests/test_translations && \
                         chmod -R 777 /tmp/comma_download_cache"
     - name: "Upload coverage to Codecov"
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         name: ${{ github.job }}
       env:
@@ -217,7 +217,7 @@ jobs:
         ${{ env.RUN }} "ONNXCPU=1 $PYTEST selfdrive/test/process_replay/test_regen.py && \
                         chmod -R 777 /tmp/comma_download_cache"
     - name: "Upload coverage to Codecov"
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         name: ${{ github.job }}
       env:
@@ -253,7 +253,7 @@ jobs:
         NUM_JOBS: 4
         JOB_ID: ${{ matrix.job }}
     - name: "Upload coverage to Codecov"
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         name: ${{ github.job }}-${{ matrix.job }}
       env:

--- a/common/params_keys.h
+++ b/common/params_keys.h
@@ -138,7 +138,7 @@ inline static std::unordered_map<std::string, uint32_t> keys = {
     // MADS params
     {"Mads", PERSISTENT | BACKUP},
     {"MadsMainCruiseAllowed", PERSISTENT | BACKUP},
-    {"MadsPauseLateralOnBrake", PERSISTENT | BACKUP},
+    {"MadsSteeringMode", PERSISTENT | BACKUP},
     {"MadsUnifiedEngagementMode", PERSISTENT | BACKUP},
 
     // Model Manager params

--- a/selfdrive/pandad/pandad.cc
+++ b/selfdrive/pandad/pandad.cc
@@ -41,7 +41,7 @@
 #define CUTOFF_IL 400
 #define SATURATE_IL 1000
 
-#define ALT_EXP_DISENGAGE_LATERAL_ON_BRAKE 2048
+#define ALT_EXP_MADS_DISENGAGE_LATERAL_ON_BRAKE 2048
 
 ExitHandler do_exit;
 
@@ -57,7 +57,7 @@ bool check_all_connected(const std::vector<Panda *> &pandas) {
 
 bool process_mads_heartbeat(SubMaster *sm) {
   const int &alt_exp = (*sm)["carParams"].getCarParams().getAlternativeExperience();
-  const bool disengage_lateral_on_brake = (alt_exp & ALT_EXP_DISENGAGE_LATERAL_ON_BRAKE) != 0;
+  const bool disengage_lateral_on_brake = (alt_exp & ALT_EXP_MADS_DISENGAGE_LATERAL_ON_BRAKE) != 0;
 
   const auto &mads = (*sm)["selfdriveStateSP"].getSelfdriveStateSP().getMads();
   const bool heartbeat_type = disengage_lateral_on_brake ? mads.getActive() : mads.getEnabled();

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/lateral/mads_settings.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/lateral/mads_settings.cc
@@ -39,17 +39,19 @@ MadsSettings::MadsSettings(QWidget *parent) : QWidget(parent) {
     "");
   list->addItem(madsUnifiedEngagementModeToggle);
 
-  // Pause Lateral On Brake
-  std::vector<QString> lateral_on_brake_texts{tr("Remain Active"), tr("Pause Steering")};
-  madsPauseLateralOnBrake = new ButtonParamControl(
-    "MadsPauseLateralOnBrake",
-    tr("Steering Mode After Braking"),
+  // Steering Mode On Brake
+  std::vector<QString> lateral_on_brake_texts{tr("Remain Active"), tr("Pause Steering"), tr("Disengage")};
+  madsSteeringMode = new ButtonParamControl(
+    "MadsSteeringMode",
+    tr("Steering Mode on Brake Pedal"),
     tr("Choose how Automatic Lane Centering (ALC) behaves after the brake pedal is manually pressed in sunnypilot.\n\n"
-       "Remain Active: ALC will remain active even after the brake pedal is pressed.\nPause Steering: ALC will be paused after the brake pedal is manually pressed."),
+       "Remain Active: ALC will remain active even after the brake pedal is pressed.\n"
+       "Pause Steering: ALC will be paused when the brake pedal is manually pressed."),
+       "Disengage: ALC will be disengaged after the brake pedal is pressed.\n"
     "",
     lateral_on_brake_texts,
     500);
-  list->addItem(madsPauseLateralOnBrake);
+  list->addItem(madsSteeringMode);
 
   QObject::connect(uiState(), &UIState::offroadTransition, this, &MadsSettings::updateToggles);
 
@@ -61,7 +63,7 @@ void MadsSettings::showEvent(QShowEvent *event) {
 }
 
 void MadsSettings::updateToggles(bool _offroad) {
-  madsPauseLateralOnBrake->setEnabled(_offroad);
+  madsSteeringMode->setEnabled(_offroad);
 
   offroad = _offroad;
 }

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/lateral/mads_settings.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/lateral/mads_settings.cc
@@ -68,8 +68,8 @@ void MadsSettings::updateToggles(bool _offroad) {
   MadsSteeringMode steering_mode;
   if (mads_steering_mode_param == static_cast<int>(MadsSteeringMode::REMAIN_ACTIVE)) {
     steering_mode = MadsSteeringMode::REMAIN_ACTIVE;
-  } else if (mads_steering_mode_param == static_cast<int>(MadsSteeringMode::PAUSE_STEERING)) {
-    steering_mode = MadsSteeringMode::PAUSE_STEERING;
+  } else if (mads_steering_mode_param == static_cast<int>(MadsSteeringMode::PAUSE)) {
+    steering_mode = MadsSteeringMode::PAUSE;
   } else {
     steering_mode = MadsSteeringMode::DISENGAGE;
   }

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/lateral/mads_settings.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/lateral/mads_settings.cc
@@ -40,18 +40,11 @@ MadsSettings::MadsSettings(QWidget *parent) : QWidget(parent) {
   list->addItem(madsUnifiedEngagementModeToggle);
 
   // Steering Mode On Brake
-  madsSteeringMode = new ButtonParamControl(
-    "MadsSteeringMode",
-    tr("Steering Mode on Brake Pedal"),
-    "",
-    "",
-    madsSteeringModeTexts(),
-    500);
+  madsSteeringMode = new ButtonParamControl("MadsSteeringMode", tr("Steering Mode on Brake Pedal"), "", "", madsSteeringModeTexts(), 500);
   QObject::connect(madsSteeringMode, &ButtonParamControl::buttonToggled, [=] {
     updateToggles(offroad);
   });
   list->addItem(madsSteeringMode);
-  madsSteeringMode->showDescription();
 
   QObject::connect(uiState(), &UIState::offroadTransition, this, &MadsSettings::updateToggles);
 
@@ -65,14 +58,9 @@ void MadsSettings::showEvent(QShowEvent *event) {
 void MadsSettings::updateToggles(bool _offroad) {
   auto mads_steering_mode_param = std::atoi(params.get("MadsSteeringMode").c_str());
 
-  MadsSteeringMode steering_mode;
-  if (mads_steering_mode_param == static_cast<int>(MadsSteeringMode::REMAIN_ACTIVE)) {
-    steering_mode = MadsSteeringMode::REMAIN_ACTIVE;
-  } else if (mads_steering_mode_param == static_cast<int>(MadsSteeringMode::PAUSE)) {
-    steering_mode = MadsSteeringMode::PAUSE;
-  } else {
-    steering_mode = MadsSteeringMode::DISENGAGE;
-  }
+  auto steering_mode = static_cast<MadsSteeringMode>(
+    std::clamp(mads_steering_mode_param, static_cast<int>(MadsSteeringMode::REMAIN_ACTIVE), static_cast<int>(MadsSteeringMode::DISENGAGE))
+  );
 
   madsSteeringMode->setEnabled(_offroad);
   madsSteeringMode->setDescription(madsSteeringModeDescription(steering_mode));

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/lateral/mads_settings.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/lateral/mads_settings.cc
@@ -40,13 +40,12 @@ MadsSettings::MadsSettings(QWidget *parent) : QWidget(parent) {
   list->addItem(madsUnifiedEngagementModeToggle);
 
   // Steering Mode On Brake
-  std::vector<QString> lateral_on_brake_texts{tr("Remain Active"), tr("Pause Steering"), tr("Disengage")};
   madsSteeringMode = new ButtonParamControl(
     "MadsSteeringMode",
     tr("Steering Mode on Brake Pedal"),
     "",
     "",
-    lateral_on_brake_texts,
+    madsSteeringModeTexts(),
     500);
   QObject::connect(madsSteeringMode, &ButtonParamControl::buttonToggled, [=] {
     updateToggles(offroad);
@@ -67,9 +66,9 @@ void MadsSettings::updateToggles(bool _offroad) {
   auto mads_steering_mode_param = std::atoi(params.get("MadsSteeringMode").c_str());
 
   MadsSteeringMode steering_mode;
-  if (mads_steering_mode_param == int(MadsSteeringMode::REMAIN_ACTIVE)) {
+  if (mads_steering_mode_param == static_cast<int>(MadsSteeringMode::REMAIN_ACTIVE)) {
     steering_mode = MadsSteeringMode::REMAIN_ACTIVE;
-  } else if (mads_steering_mode_param == int(MadsSteeringMode::PAUSE_STEERING)) {
+  } else if (mads_steering_mode_param == static_cast<int>(MadsSteeringMode::PAUSE_STEERING)) {
     steering_mode = MadsSteeringMode::PAUSE_STEERING;
   } else {
     steering_mode = MadsSteeringMode::DISENGAGE;

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/lateral/mads_settings.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/lateral/mads_settings.cc
@@ -44,14 +44,15 @@ MadsSettings::MadsSettings(QWidget *parent) : QWidget(parent) {
   madsSteeringMode = new ButtonParamControl(
     "MadsSteeringMode",
     tr("Steering Mode on Brake Pedal"),
-    tr("Choose how Automatic Lane Centering (ALC) behaves after the brake pedal is manually pressed in sunnypilot.\n\n"
-       "Remain Active: ALC will remain active even after the brake pedal is pressed.\n"
-       "Pause Steering: ALC will be paused when the brake pedal is manually pressed."),
-       "Disengage: ALC will be disengaged after the brake pedal is pressed.\n"
+    "",
     "",
     lateral_on_brake_texts,
     500);
+  QObject::connect(madsSteeringMode, &ButtonParamControl::buttonToggled, [=] {
+    updateToggles(offroad);
+  });
   list->addItem(madsSteeringMode);
+  madsSteeringMode->showDescription();
 
   QObject::connect(uiState(), &UIState::offroadTransition, this, &MadsSettings::updateToggles);
 
@@ -63,7 +64,20 @@ void MadsSettings::showEvent(QShowEvent *event) {
 }
 
 void MadsSettings::updateToggles(bool _offroad) {
+  auto mads_steering_mode_param = std::atoi(params.get("MadsSteeringMode").c_str());
+
+  MadsSteeringMode steering_mode;
+  if (mads_steering_mode_param == int(MadsSteeringMode::REMAIN_ACTIVE)) {
+    steering_mode = MadsSteeringMode::REMAIN_ACTIVE;
+  } else if (mads_steering_mode_param == int(MadsSteeringMode::PAUSE_STEERING)) {
+    steering_mode = MadsSteeringMode::PAUSE_STEERING;
+  } else {
+    steering_mode = MadsSteeringMode::DISENGAGE;
+  }
+
   madsSteeringMode->setEnabled(_offroad);
+  madsSteeringMode->setDescription(madsSteeringModeDescription(steering_mode));
+  madsSteeringMode->showDescription();
 
   offroad = _offroad;
 }

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/lateral/mads_settings.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/lateral/mads_settings.h
@@ -32,5 +32,5 @@ private:
 
   ParamControl *madsMainCruiseToggle;
   ParamControl *madsUnifiedEngagementModeToggle;
-  ButtonParamControl *madsPauseLateralOnBrake;
+  ButtonParamControl *madsSteeringMode;
 };

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/lateral/mads_settings.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/lateral/mads_settings.h
@@ -48,9 +48,9 @@ private:
 
   static const std::vector<MadsSteeringModeOption> &madsSteeringModeOptions() {
     static const std::vector<MadsSteeringModeOption> options = {
-      {MadsSteeringMode::REMAIN_ACTIVE,  tr("Remain Active"), tr("Remain Active: ALC will remain active when the brake pedal is pressed.")},
-      {MadsSteeringMode::PAUSE, tr("Pause"),         tr("Pause: ALC will pause steering when the brake pedal is pressed.")},
-      {MadsSteeringMode::DISENGAGE,      tr("Disengage"),     tr("Disengage: ALC will disengage when the brake pedal is pressed.")},
+      {MadsSteeringMode::REMAIN_ACTIVE, tr("Remain Active"), tr("Remain Active: ALC will remain active when the brake pedal is pressed.")},
+      {MadsSteeringMode::PAUSE,         tr("Pause"),         tr("Pause: ALC will pause steering when the brake pedal is pressed.")},
+      {MadsSteeringMode::DISENGAGE,     tr("Disengage"),     tr("Disengage: ALC will disengage when the brake pedal is pressed.")},
     };
     return options;
   }

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/lateral/mads_settings.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/lateral/mads_settings.h
@@ -13,9 +13,15 @@
 #include "selfdrive/ui/sunnypilot/qt/widgets/controls.h"
 
 enum class MadsSteeringMode {
-  REMAIN_ACTIVE,
-  PAUSE_STEERING,
-  DISENGAGE,
+  REMAIN_ACTIVE = 0,
+  PAUSE_STEERING = 1,
+  DISENGAGE = 2,
+};
+
+struct MadsSteeringModeOption {
+  MadsSteeringMode mode;
+  QString display_text;
+  QString description;
 };
 
 class MadsSettings : public QWidget {
@@ -40,23 +46,35 @@ private:
   ParamControl *madsUnifiedEngagementModeToggle;
   ButtonParamControl *madsSteeringMode;
 
-  static QString madsSteeringModeDescription(MadsSteeringMode mode) {
-    QString remain_active_str = tr("Remain Active: ALC will remain active when the brake pedal is pressed.");
-    QString pause_steering_str = tr("Pause Steering: ALC will pause steering when the brake pedal is pressed.");
-    QString disengage_str = tr("Disengage: ALC will disengage when the brake pedal is pressed.");
+  static const std::vector<MadsSteeringModeOption> &madsSteeringModeOptions() {
+    static const std::vector<MadsSteeringModeOption> options = {
+      {MadsSteeringMode::REMAIN_ACTIVE,  tr("Remain Active"), tr("Remain Active: ALC will remain active when the brake pedal is pressed.")},
+      {MadsSteeringMode::PAUSE_STEERING, tr("Pause"),         tr("Pause: ALC will pause steering when the brake pedal is pressed.")},
+      {MadsSteeringMode::DISENGAGE,      tr("Disengage"),     tr("Disengage: ALC will disengage when the brake pedal is pressed.")},
+    };
+    return options;
+  }
 
-    if (mode == MadsSteeringMode::REMAIN_ACTIVE) {
-      remain_active_str = "<font color='white'><b>" + remain_active_str + "</b></font>";
-    } else if (mode == MadsSteeringMode::PAUSE_STEERING) {
-      pause_steering_str = "<font color='white'><b>" + pause_steering_str + "</b></font>";
-    } else if (mode == MadsSteeringMode::DISENGAGE) {
-      disengage_str = "<font color='white'><b>" + disengage_str + "</b></font>";
+  static std::vector<QString> madsSteeringModeTexts() {
+    std::vector<QString> texts;
+    for (const auto& option : madsSteeringModeOptions()) {
+      texts.push_back(option.display_text);
+    }
+    return texts;
+  }
+
+  static QString madsSteeringModeDescription(const MadsSteeringMode mode) {
+    QString base_desc = tr("Choose how Automatic Lane Centering (ALC) behaves after the brake pedal is manually pressed in sunnypilot.");
+    QString result = base_desc + "<br><br>";
+
+    for (const auto& option : madsSteeringModeOptions()) {
+      QString desc = option.description;
+      if (option.mode == mode) {
+        desc = "<font color='white'><b>" + desc + "</b></font>";
+      }
+      result += desc + "<br>";
     }
 
-    return QString("%1<br><br>%2<br>%3<br>%4")
-             .arg(tr("Choose how Automatic Lane Centering (ALC) behaves after the brake pedal is manually pressed in sunnypilot."))
-             .arg(remain_active_str)
-             .arg(pause_steering_str)
-             .arg(disengage_str);
+    return result;
   }
 };

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/lateral/mads_settings.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/lateral/mads_settings.h
@@ -49,7 +49,7 @@ private:
   static const std::vector<MadsSteeringModeOption> &madsSteeringModeOptions() {
     static const std::vector<MadsSteeringModeOption> options = {
       {MadsSteeringMode::REMAIN_ACTIVE, tr("Remain Active"), tr("Remain Active: ALC will remain active when the brake pedal is pressed.")},
-      {MadsSteeringMode::PAUSE,         tr("Pause"),         tr("Pause: ALC will pause steering when the brake pedal is pressed.")},
+      {MadsSteeringMode::PAUSE,         tr("Pause"),         tr("Pause: ALC will pause when the brake pedal is pressed.")},
       {MadsSteeringMode::DISENGAGE,     tr("Disengage"),     tr("Disengage: ALC will disengage when the brake pedal is pressed.")},
     };
     return options;

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/lateral/mads_settings.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/lateral/mads_settings.h
@@ -14,7 +14,7 @@
 
 enum class MadsSteeringMode {
   REMAIN_ACTIVE = 0,
-  PAUSE_STEERING = 1,
+  PAUSE = 1,
   DISENGAGE = 2,
 };
 
@@ -49,7 +49,7 @@ private:
   static const std::vector<MadsSteeringModeOption> &madsSteeringModeOptions() {
     static const std::vector<MadsSteeringModeOption> options = {
       {MadsSteeringMode::REMAIN_ACTIVE,  tr("Remain Active"), tr("Remain Active: ALC will remain active when the brake pedal is pressed.")},
-      {MadsSteeringMode::PAUSE_STEERING, tr("Pause"),         tr("Pause: ALC will pause steering when the brake pedal is pressed.")},
+      {MadsSteeringMode::PAUSE, tr("Pause"),         tr("Pause: ALC will pause steering when the brake pedal is pressed.")},
       {MadsSteeringMode::DISENGAGE,      tr("Disengage"),     tr("Disengage: ALC will disengage when the brake pedal is pressed.")},
     };
     return options;

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/lateral/mads_settings.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/lateral/mads_settings.h
@@ -12,6 +12,12 @@
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/settings.h"
 #include "selfdrive/ui/sunnypilot/qt/widgets/controls.h"
 
+enum class MadsSteeringMode {
+  REMAIN_ACTIVE,
+  PAUSE_STEERING,
+  DISENGAGE,
+};
+
 class MadsSettings : public QWidget {
   Q_OBJECT
 
@@ -33,4 +39,24 @@ private:
   ParamControl *madsMainCruiseToggle;
   ParamControl *madsUnifiedEngagementModeToggle;
   ButtonParamControl *madsSteeringMode;
+
+  static QString madsSteeringModeDescription(MadsSteeringMode mode) {
+    QString remain_active_str = tr("Remain Active: ALC will remain active when the brake pedal is pressed.");
+    QString pause_steering_str = tr("Pause Steering: ALC will pause steering when the brake pedal is pressed.");
+    QString disengage_str = tr("Disengage: ALC will disengage when the brake pedal is pressed.");
+
+    if (mode == MadsSteeringMode::REMAIN_ACTIVE) {
+      remain_active_str = "<font color='white'><b>" + remain_active_str + "</b></font>";
+    } else if (mode == MadsSteeringMode::PAUSE_STEERING) {
+      pause_steering_str = "<font color='white'><b>" + pause_steering_str + "</b></font>";
+    } else if (mode == MadsSteeringMode::DISENGAGE) {
+      disengage_str = "<font color='white'><b>" + disengage_str + "</b></font>";
+    }
+
+    return QString("%1<br><br>%2<br>%3<br>%4")
+             .arg(tr("Choose how Automatic Lane Centering (ALC) behaves after the brake pedal is manually pressed in sunnypilot."))
+             .arg(remain_active_str)
+             .arg(pause_steering_str)
+             .arg(disengage_str);
+  }
 };

--- a/sunnypilot/mads/helpers.py
+++ b/sunnypilot/mads/helpers.py
@@ -11,15 +11,33 @@ from opendbc.safety import ALTERNATIVE_EXPERIENCE
 from opendbc.sunnypilot.car.hyundai.values import HyundaiFlagsSP, HyundaiSafetyFlagsSP
 
 
+class MadsSteeringModeOnBrake:
+  REMAIN_ACTIVE = 0
+  PAUSE = 1
+  DISENGAGE = 2
+
+
+def read_steering_mode_param(CP: structs.CarParams, params: Params):
+  if CP.brand in ("rivian", "tesla"):
+    return MadsSteeringModeOnBrake.DISENGAGE
+
+  try:
+    return int(params.get("MadsSteeringMode"))
+  except (ValueError, TypeError):
+    return MadsSteeringModeOnBrake.REMAIN_ACTIVE
+
+
 def set_alternative_experience(CP: structs.CarParams, params: Params):
   enabled = params.get_bool("Mads")
-  pause_lateral_on_brake = params.get_bool("MadsPauseLateralOnBrake")
+  steering_mode = read_steering_mode_param(CP, params)
 
   if enabled:
     CP.alternativeExperience |= ALTERNATIVE_EXPERIENCE.ENABLE_MADS
 
-    if pause_lateral_on_brake:
-      CP.alternativeExperience |= ALTERNATIVE_EXPERIENCE.DISENGAGE_LATERAL_ON_BRAKE
+    if steering_mode == MadsSteeringModeOnBrake.DISENGAGE:
+      CP.alternativeExperience |= ALTERNATIVE_EXPERIENCE.MADS_DISENGAGE_LATERAL_ON_BRAKE
+    elif steering_mode == MadsSteeringModeOnBrake.PAUSE:
+      CP.alternativeExperience |= ALTERNATIVE_EXPERIENCE.MADS_PAUSE_LATERAL_ON_BRAKE
 
 
 def set_car_specific_params(CP: structs.CarParams, CP_SP: structs.CarParamsSP, params: Params):
@@ -31,12 +49,16 @@ def set_car_specific_params(CP: structs.CarParams, CP_SP: structs.CarParamsSP, p
       CP_SP.flags |= HyundaiFlagsSP.LONGITUDINAL_MAIN_CRUISE_TOGGLEABLE.value
       CP_SP.safetyParam |= HyundaiSafetyFlagsSP.LONG_MAIN_CRUISE_TOGGLEABLE
 
-  # MADS is currently not supported in Tesla due to lack of consistent states to engage controls
-  # TODO-SP: To enable MADS for Tesla, identify consistent signals for MADS toggling
-  if CP.brand == "tesla":
-    params.remove("Mads")
+    # MADS is currently not supported in Tesla due to lack of consistent states to engage controls
+    # TODO-SP: To enable MADS for Tesla, identify consistent signals for MADS toggling
+    if CP.brand == "tesla":
+      params.put("MadsSteeringMode", "2")
+      params.put_bool("MadsUnifiedEngagementMode", True)
+      params.remove("MadsMainCruiseAllowed")
 
-  # MADS is currently not supported in Rivian due to lack of consistent states to engage controls
-  # TODO-SP: To enable MADS for Rivian, identify consistent signals for MADS toggling
-  if CP.brand == "rivian":
-    params.remove("Mads")
+    # MADS is currently not supported in Rivian due to lack of consistent states to engage controls
+    # TODO-SP: To enable MADS for Rivian, identify consistent signals for MADS toggling
+    if CP.brand == "rivian":
+      params.put("MadsSteeringMode", "2")
+      params.put_bool("MadsUnifiedEngagementMode", True)
+      params.remove("MadsMainCruiseAllowed")

--- a/sunnypilot/mads/helpers.py
+++ b/sunnypilot/mads/helpers.py
@@ -17,7 +17,7 @@ class MadsSteeringModeOnBrake:
   DISENGAGE = 2
 
 
-def read_steering_mode_param(CP: structs.CarParams, params: Params):
+def read_steering_mode_param(params: Params):
   try:
     return int(params.get("MadsSteeringMode"))
   except (ValueError, TypeError):
@@ -26,7 +26,7 @@ def read_steering_mode_param(CP: structs.CarParams, params: Params):
 
 def set_alternative_experience(CP: structs.CarParams, params: Params):
   enabled = params.get_bool("Mads")
-  steering_mode = read_steering_mode_param(CP, params)
+  steering_mode = read_steering_mode_param(params)
 
   if enabled:
     CP.alternativeExperience |= ALTERNATIVE_EXPERIENCE.ENABLE_MADS

--- a/sunnypilot/mads/helpers.py
+++ b/sunnypilot/mads/helpers.py
@@ -18,9 +18,6 @@ class MadsSteeringModeOnBrake:
 
 
 def read_steering_mode_param(CP: structs.CarParams, params: Params):
-  if CP.brand in ("rivian", "tesla"):
-    return MadsSteeringModeOnBrake.DISENGAGE
-
   try:
     return int(params.get("MadsSteeringMode"))
   except (ValueError, TypeError):
@@ -49,16 +46,12 @@ def set_car_specific_params(CP: structs.CarParams, CP_SP: structs.CarParamsSP, p
       CP_SP.flags |= HyundaiFlagsSP.LONGITUDINAL_MAIN_CRUISE_TOGGLEABLE.value
       CP_SP.safetyParam |= HyundaiSafetyFlagsSP.LONG_MAIN_CRUISE_TOGGLEABLE
 
-    # MADS is currently not supported in Tesla due to lack of consistent states to engage controls
-    # TODO-SP: To enable MADS for Tesla, identify consistent signals for MADS toggling
-    if CP.brand == "tesla":
-      params.put("MadsSteeringMode", "2")
-      params.put_bool("MadsUnifiedEngagementMode", True)
-      params.remove("MadsMainCruiseAllowed")
+  # MADS is currently not supported in Tesla due to lack of consistent states to engage controls
+  # TODO-SP: To enable MADS for Tesla, identify consistent signals for MADS toggling
+  if CP.brand == "tesla":
+    params.remove("Mads")
 
-    # MADS is currently not supported in Rivian due to lack of consistent states to engage controls
-    # TODO-SP: To enable MADS for Rivian, identify consistent signals for MADS toggling
-    if CP.brand == "rivian":
-      params.put("MadsSteeringMode", "2")
-      params.put_bool("MadsUnifiedEngagementMode", True)
-      params.remove("MadsMainCruiseAllowed")
+  # MADS is currently not supported in Rivian due to lack of consistent states to engage controls
+  # TODO-SP: To enable MADS for Rivian, identify consistent signals for MADS toggling
+  if CP.brand == "rivian":
+    params.remove("Mads")

--- a/sunnypilot/mads/mads.py
+++ b/sunnypilot/mads/mads.py
@@ -135,6 +135,9 @@ class ModularAssistiveDrivingSystem:
     self.get_wrong_car_mode(selfdrive_enable_events or set_speed_btns_enable)
 
     if selfdrive_enable_events:
+      if self.pedal_pressed_non_gas_pressed(CS):
+        self.events_sp.add(EventNameSP.pedalPressedAlertOnly)
+
       if self.block_unified_engagement_mode():
         self.events.remove(EventName.pcmEnable)
         self.events.remove(EventName.buttonEnable)

--- a/sunnypilot/mads/mads.py
+++ b/sunnypilot/mads/mads.py
@@ -166,7 +166,13 @@ class ModularAssistiveDrivingSystem:
 
     if self.steering_mode_on_brake == MadsSteeringModeOnBrake.DISENGAGE:
       if self.pedal_pressed_non_gas_pressed(CS):
-        self.events_sp.add(EventNameSP.lkasDisable)
+        if self.enabled:
+          self.events_sp.add(EventNameSP.lkasDisable)
+        else:
+          # block lkasEnable if being sent, then send pedalPressedAlertOnly event
+          if self.events_sp.contains(EventNameSP.lkasEnable):
+            self.events_sp.remove(EventNameSP.lkasEnable)
+            self.events_sp.add(EventNameSP.pedalPressedAlertOnly)
 
     if self.should_silent_lkas_enable(CS):
       if self.state_machine.state == State.paused:

--- a/sunnypilot/mads/mads.py
+++ b/sunnypilot/mads/mads.py
@@ -31,7 +31,6 @@ class ModularAssistiveDrivingSystem:
     self.active = False
     self.available = False
     self.allow_always = False
-    self.no_main_cruise = False
     self.selfdrive = selfdrive
     self.selfdrive.enabled_prev = False
     self.state_machine = StateMachine(self)
@@ -42,17 +41,14 @@ class ModularAssistiveDrivingSystem:
       if self.selfdrive.CP.flags & (HyundaiFlags.HAS_LDA_BUTTON | HyundaiFlags.CANFD):
         self.allow_always = True
 
-    if self.selfdrive.CP.brand in ("rivian", "tesla"):
-      self.no_main_cruise = True
-
     # read params on init
     self.enabled_toggle = self.params.get_bool("Mads")
-    self.main_enabled_toggle = self.params.get_bool("MadsMainCruiseAllowed") and not self.no_main_cruise
+    self.main_enabled_toggle = self.params.get_bool("MadsMainCruiseAllowed")
     self.steering_mode_on_brake = read_steering_mode_param(self.selfdrive.CP, self.params)
     self.unified_engagement_mode = self.params.get_bool("MadsUnifiedEngagementMode")
 
   def read_params(self):
-    self.main_enabled_toggle = self.params.get_bool("MadsMainCruiseAllowed") and not self.no_main_cruise
+    self.main_enabled_toggle = self.params.get_bool("MadsMainCruiseAllowed")
     self.unified_engagement_mode = self.params.get_bool("MadsUnifiedEngagementMode")
 
   def update_events(self, CS: structs.CarState):

--- a/sunnypilot/mads/mads.py
+++ b/sunnypilot/mads/mads.py
@@ -47,7 +47,7 @@ class ModularAssistiveDrivingSystem:
     # read params on init
     self.enabled_toggle = self.params.get_bool("Mads")
     self.main_enabled_toggle = self.params.get_bool("MadsMainCruiseAllowed")
-    self.steering_mode_on_brake = read_steering_mode_param(self.CP, self.params)
+    self.steering_mode_on_brake = read_steering_mode_param(self.params)
     self.unified_engagement_mode = self.params.get_bool("MadsUnifiedEngagementMode")
 
   def read_params(self):

--- a/sunnypilot/mads/mads.py
+++ b/sunnypilot/mads/mads.py
@@ -47,7 +47,7 @@ class ModularAssistiveDrivingSystem:
     # read params on init
     self.enabled_toggle = self.params.get_bool("Mads")
     self.main_enabled_toggle = self.params.get_bool("MadsMainCruiseAllowed")
-    self.steering_mode_on_brake = read_steering_mode_param(self.selfdrive.CP, self.params)
+    self.steering_mode_on_brake = read_steering_mode_param(self.CP, self.params)
     self.unified_engagement_mode = self.params.get_bool("MadsUnifiedEngagementMode")
 
   def read_params(self):

--- a/system/manager/manager.py
+++ b/system/manager/manager.py
@@ -48,7 +48,7 @@ def manager_init() -> None:
     ("HyundaiLongitudinalTuning", "0"),
     ("Mads", "1"),
     ("MadsMainCruiseAllowed", "1"),
-    ("MadsPauseLateralOnBrake", "0"),
+    ("MadsSteeringMode", "0"),
     ("MadsUnifiedEngagementMode", "1"),
     ("MaxTimeOffroad", "1800"),
     ("ModelManager_LastSyncTime", "0"),


### PR DESCRIPTION
## Summary by Sourcery

Introduce a configurable steering mode for Automatic Lane Centering when the brake pedal is pressed, replacing the previous single boolean option with a three-state setting (remain active, pause, disengage) and updating the UI, parameter handling, and MADS logic accordingly.

New Features:
- Add MADS Steering Mode parameter with options to remain active, pause, or disengage on brake pedal press.

Enhancements:
- Replace the binary pause-on-brake toggle with a multi-option ButtonParamControl in the settings UI, complete with mode-specific descriptions.
- Update helper functions and the MADS state machine to read and act upon the new steering mode instead of the old boolean flag.
- Rename and migrate the internal parameter key from `MadsPauseLateralOnBrake` to `MadsSteeringMode` and adjust related logic in pandad and the manager defaults.

Chores:
- Rename the alternative experience constant to `ALT_EXP_MADS_DISENGAGE_LATERAL_ON_BRAKE`.

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->