### PR TITLE
MADS: prep for refactor

### DIFF
--- a/sunnypilot/mads/mads.py
+++ b/sunnypilot/mads/mads.py
@@ -26,7 +26,6 @@ IGNORED_SAFETY_MODES = (SafetyModel.silent, SafetyModel.noOutput)
 class ModularAssistiveDrivingSystem:
   def __init__(self, selfdrive):
     self.CP = selfdrive.CP
-    self.CS_prev = selfdrive.CS_prev
     self.params = selfdrive.params
 
     self.enabled = False

--- a/sunnypilot/mads/mads.py
+++ b/sunnypilot/mads/mads.py
@@ -55,7 +55,7 @@ class ModularAssistiveDrivingSystem:
     self.unified_engagement_mode = self.params.get_bool("MadsUnifiedEngagementMode")
 
   def pedal_pressed_non_gas_pressed(self, CS: structs.CarState) -> bool:
-    if self.events.has(EventName.pedalPressed) and not (CS.gasPressed and not self.CS_prev.gasPressed and self.disengage_on_accelerator):
+    if self.events.has(EventName.pedalPressed) and not (CS.gasPressed and not self.selfdrive.CS_prev.gasPressed and self.disengage_on_accelerator):
       return True
 
     return False
@@ -82,38 +82,38 @@ class ModularAssistiveDrivingSystem:
 
     return False
 
+  def transition_paused_state(self):
+    if self.state_machine.state != State.paused:
+      self.events_sp.add(EventNameSP.silentLkasDisable)
+
+  def replace_event(self, old_event: int, new_event: int):
+    self.events.remove(old_event)
+    self.events_sp.add(new_event)
+
   def update_events(self, CS: structs.CarState):
-    def transition_paused_state():
-      if self.state_machine.state != State.paused:
-        self.events_sp.add(EventNameSP.silentLkasDisable)
-
-    def replace_event(old_event: int, new_event: int):
-      self.events.remove(old_event)
-      self.events_sp.add(new_event)
-
     if not self.selfdrive.enabled and self.enabled:
       if self.events.has(EventName.doorOpen):
-        replace_event(EventName.doorOpen, EventNameSP.silentDoorOpen)
-        transition_paused_state()
+        self.replace_event(EventName.doorOpen, EventNameSP.silentDoorOpen)
+        self.transition_paused_state()
       if self.events.has(EventName.seatbeltNotLatched):
-        replace_event(EventName.seatbeltNotLatched, EventNameSP.silentSeatbeltNotLatched)
-        transition_paused_state()
+        self.replace_event(EventName.seatbeltNotLatched, EventNameSP.silentSeatbeltNotLatched)
+        self.transition_paused_state()
       if self.events.has(EventName.wrongGear) and (CS.vEgo < 2.5 or CS.gearShifter == GearShifter.reverse):
-        replace_event(EventName.wrongGear, EventNameSP.silentWrongGear)
-        transition_paused_state()
+        self.replace_event(EventName.wrongGear, EventNameSP.silentWrongGear)
+        self.transition_paused_state()
       if self.events.has(EventName.reverseGear):
-        replace_event(EventName.reverseGear, EventNameSP.silentReverseGear)
-        transition_paused_state()
+        self.replace_event(EventName.reverseGear, EventNameSP.silentReverseGear)
+        self.transition_paused_state()
       if self.events.has(EventName.brakeHold):
-        replace_event(EventName.brakeHold, EventNameSP.silentBrakeHold)
-        transition_paused_state()
+        self.replace_event(EventName.brakeHold, EventNameSP.silentBrakeHold)
+        self.transition_paused_state()
       if self.events.has(EventName.parkBrake):
-        replace_event(EventName.parkBrake, EventNameSP.silentParkBrake)
-        transition_paused_state()
+        self.replace_event(EventName.parkBrake, EventNameSP.silentParkBrake)
+        self.transition_paused_state()
 
       if self.pause_lateral_on_brake_toggle:
         if self.pedal_pressed_non_gas_pressed(CS):
-          transition_paused_state()
+          self.transition_paused_state()
 
       self.events.remove(EventName.preEnableStandstill)
       self.events.remove(EventName.belowEngageSpeed)
@@ -127,7 +127,7 @@ class ModularAssistiveDrivingSystem:
         self.events.remove(EventName.buttonEnable)
     else:
       if self.main_enabled_toggle:
-        if CS.cruiseState.available and not self.CS_prev.cruiseState.available:
+        if CS.cruiseState.available and not self.selfdrive.CS_prev.cruiseState.available:
           self.events_sp.add(EventNameSP.lkasEnable)
 
     for be in CS.buttonEvents:
@@ -145,7 +145,7 @@ class ModularAssistiveDrivingSystem:
 
     if not CS.cruiseState.available:
       self.events.remove(EventName.buttonEnable)
-      if self.CS_prev.cruiseState.available:
+      if self.selfdrive.CS_prev.cruiseState.available:
         self.events_sp.add(EventNameSP.lkasDisable)
 
     if self.should_silent_lkas_enable(CS):
@@ -158,7 +158,7 @@ class ModularAssistiveDrivingSystem:
     self.events.remove(EventName.wrongCruiseMode)
     if any(be.type in SET_SPEED_BUTTONS for be in CS.buttonEvents):
       if self.events.has(EventName.wrongCarMode):
-        replace_event(EventName.wrongCarMode, EventNameSP.wrongCarModeAlertOnly)
+        self.replace_event(EventName.wrongCarMode, EventNameSP.wrongCarModeAlertOnly)
     else:
       self.events.remove(EventName.wrongCarMode)
 


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Prepare mads.Mads class for upcoming refactor by extracting helper functions and correcting state references in event handling

Bug Fixes:
- Fix comparisons against previous car state by referencing self.selfdrive.CS_prev instead of self.CS_prev

Enhancements:
- Extract transition_paused_state and replace_event from update_events into standalone methods
- Update calls to helper functions within event update logic to use self.method syntax instead of nested functions