### PR TITLE
Reapply "MADS: wrongCarMode alert only with selfdrive enable (#931)"

### DIFF
--- a/sunnypilot/mads/mads.py
+++ b/sunnypilot/mads/mads.py
@@ -81,13 +81,6 @@ class ModularAssistiveDrivingSystem:
 
     return False
 
-  def get_wrong_car_mode(self, alert_only: bool) -> None:
-    if alert_only:
-      if self.events.has(EventName.wrongCarMode):
-        self.replace_event(EventName.wrongCarMode, EventNameSP.wrongCarModeAlertOnly)
-    else:
-      self.events.remove(EventName.wrongCarMode)
-
   def transition_paused_state(self):
     if self.state_machine.state != State.paused:
       self.events_sp.add(EventNameSP.silentLkasDisable)
@@ -128,12 +121,11 @@ class ModularAssistiveDrivingSystem:
       self.events.remove(EventName.manualRestart)
 
     selfdrive_enable_events = self.events.has(EventName.pcmEnable) or self.events.has(EventName.buttonEnable)
-    set_speed_btns_enable = any(be.type in SET_SPEED_BUTTONS for be in CS.buttonEvents)
-
-    # wrongCarMode alert only or actively block control
-    self.get_wrong_car_mode(selfdrive_enable_events or set_speed_btns_enable)
 
     if selfdrive_enable_events:
+      if self.pedal_pressed_non_gas_pressed(CS):
+        self.events_sp.add(EventNameSP.pedalPressedAlertOnly)
+
       if self.block_unified_engagement_mode():
         self.events.remove(EventName.pcmEnable)
         self.events.remove(EventName.buttonEnable)
@@ -168,6 +160,11 @@ class ModularAssistiveDrivingSystem:
     self.events.remove(EventName.buttonCancel)
     self.events.remove(EventName.pedalPressed)
     self.events.remove(EventName.wrongCruiseMode)
+    if any(be.type in SET_SPEED_BUTTONS for be in CS.buttonEvents):
+      if self.events.has(EventName.wrongCarMode):
+        self.replace_event(EventName.wrongCarMode, EventNameSP.wrongCarModeAlertOnly)
+    else:
+      self.events.remove(EventName.wrongCarMode)
 
   def update(self, CS: structs.CarState):
     if not self.enabled_toggle:

--- a/sunnypilot/mads/mads.py
+++ b/sunnypilot/mads/mads.py
@@ -81,6 +81,13 @@ class ModularAssistiveDrivingSystem:
 
     return False
 
+  def get_wrong_car_mode(self, alert_only: bool) -> None:
+    if alert_only:
+      if self.events.has(EventName.wrongCarMode):
+        self.replace_event(EventName.wrongCarMode, EventNameSP.wrongCarModeAlertOnly)
+    else:
+      self.events.remove(EventName.wrongCarMode)
+
   def transition_paused_state(self):
     if self.state_machine.state != State.paused:
       self.events_sp.add(EventNameSP.silentLkasDisable)
@@ -121,6 +128,10 @@ class ModularAssistiveDrivingSystem:
       self.events.remove(EventName.manualRestart)
 
     selfdrive_enable_events = self.events.has(EventName.pcmEnable) or self.events.has(EventName.buttonEnable)
+    set_speed_btns_enable = any(be.type in SET_SPEED_BUTTONS for be in CS.buttonEvents)
+
+    # wrongCarMode alert only or actively block control
+    self.get_wrong_car_mode(selfdrive_enable_events or set_speed_btns_enable)
 
     if selfdrive_enable_events:
       if self.pedal_pressed_non_gas_pressed(CS):
@@ -160,11 +171,6 @@ class ModularAssistiveDrivingSystem:
     self.events.remove(EventName.buttonCancel)
     self.events.remove(EventName.pedalPressed)
     self.events.remove(EventName.wrongCruiseMode)
-    if any(be.type in SET_SPEED_BUTTONS for be in CS.buttonEvents):
-      if self.events.has(EventName.wrongCarMode):
-        self.replace_event(EventName.wrongCarMode, EventNameSP.wrongCarModeAlertOnly)
-    else:
-      self.events.remove(EventName.wrongCarMode)
 
   def update(self, CS: structs.CarState):
     if not self.enabled_toggle:


### PR DESCRIPTION
This reverts commit https://github.com/sunnypilot/sunnypilot/commit/c9487597e4ae4aa10a7111d963c5933d472bc88e.

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Bug Fixes:
- Restore the pedalPressedAlertOnly event trigger during selfdrive when a non-gas pedal press is detected