### PR TITLE
ui: support selected button enabled for `ButtonParamControlSP`

### DIFF
--- a/selfdrive/ui/sunnypilot/qt/widgets/controls.h
+++ b/selfdrive/ui/sunnypilot/qt/widgets/controls.h
@@ -324,10 +324,11 @@ public:
     }
   }
 
-  void setDisabledSelectedButton(std::string val) {
-    int value = atoi(val.c_str());
+  void setEnableSelectedButtons(bool enable, const std::vector<int>& enabled_btns = {}) const {
     for (int i = 0; i < button_group->buttons().size(); i++) {
-      button_group->buttons()[i]->setEnabled(i != value);
+      // Enable the button if its index is in the enabled list
+      bool should_enable = std::find(enabled_btns.begin(), enabled_btns.end(), i) != enabled_btns.end();
+      button_group->buttons()[i]->setEnabled(enable && should_enable);
     }
   }
 


### PR DESCRIPTION
Split from https://github.com/sunnypilot/sunnypilot/pull/938

Replaced setDisabledSelectedButton with setEnableSelectedButtons for improved flexibility. The new implementation allows enabling multiple buttons based on a given list and maintains clarity in handling button states. This enhances functionality and aligns with better code practices.

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Allow toggling multiple selected buttons by index in `ButtonParamControlSP` to enhance flexibility and streamline button control

New Features:
- Support enabling multiple buttons in `ButtonParamControlSP` via `setEnableSelectedButtons`

Enhancements:
- Replace `setDisabledSelectedButton` with `setEnableSelectedButtons` for improved clarity and flexibility in button state management