### PR TITLE
ui: Add utility function to check if a brand is in a list

### DIFF
--- a/selfdrive/ui/sunnypilot/qt/util.cc
+++ b/selfdrive/ui/sunnypilot/qt/util.cc
@@ -78,3 +78,7 @@ QMap<QString, QVariantMap> loadPlatformList() {
 
   return _platforms;
 }
+
+bool isBrandInList(const std::string &brand, const std::vector<std::string> &list) {
+  return std::find(list.begin(), list.end(), brand) != list.end();
+}

--- a/selfdrive/ui/sunnypilot/qt/util.h
+++ b/selfdrive/ui/sunnypilot/qt/util.h
@@ -18,3 +18,4 @@ QString getUserAgent(bool sunnylink = false);
 std::optional<QString> getSunnylinkDongleId();
 std::optional<QString> getParamIgnoringDefault(const std::string &param_name, const std::string &default_value);
 QMap<QString, QVariantMap> loadPlatformList();
+bool isBrandInList(const std::string &brand, const std::vector<std::string> &list);


### PR DESCRIPTION
Split from https://github.com/sunnypilot/sunnypilot/pull/938

Introduces `isBrandInList` to simplify checking if a given brand exists within a list of strings. This improves code clarity and avoids repetitive implementations for the same logic.

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

