### PR TITLE
car interface: move certain inits to car helpers

### DIFF
--- a/selfdrive/car/card.py
+++ b/selfdrive/car/card.py
@@ -88,6 +88,8 @@ class Car:
 
     self.can_callbacks = can_comm_callbacks(self.can_sock, self.pm.sock['sendcan'])
 
+    init_params_list_sp = sunnypilot_interfaces.get_init_params(self.params)
+
     if CI is None:
       # wait for one pandaState and one CAN packet
       print("Waiting for CAN messages...")
@@ -107,7 +109,8 @@ class Car:
 
       fixed_fingerprint = json.loads(self.params.get("CarPlatformBundle", encoding='utf-8') or "{}").get("platform", None)
 
-      self.CI = get_car(*self.can_callbacks, obd_callback(self.params), alpha_long_allowed, num_pandas, cached_params, fixed_fingerprint)
+      self.CI = get_car(*self.can_callbacks, obd_callback(self.params), alpha_long_allowed, num_pandas, cached_params,
+                        fixed_fingerprint, init_params_list_sp)
       sunnypilot_interfaces.setup_interfaces(self.CI, self.params)
       self.RI = interfaces[self.CI.CP.carFingerprint].RadarInterface(self.CI.CP, self.CI.CP_SP)
       self.CP = self.CI.CP

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/platform_selector.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/platform_selector.cc
@@ -72,7 +72,6 @@ void PlatformSelector::refresh(bool _offroad) {
 
       for (auto it = platforms.constBegin(); it != platforms.constEnd(); ++it) {
         if (it.value()["platform"].toString() == platform) {
-          platform = it.key();
           brand = it.value()["brand"].toString();
           break;
         }

--- a/sunnypilot/selfdrive/car/interfaces.py
+++ b/sunnypilot/selfdrive/car/interfaces.py
@@ -56,7 +56,7 @@ def setup_interfaces(CI: CarInterfaceBase, params: Params = None) -> None:
 
 def _enable_radar_tracks(CP: structs.CarParams, CP_SP: structs.CarParamsSP, can_recv: CanRecvCallable,
                          params: Params) -> None:
-  if CP.brand == 'hyundai':
+  if CP.brand != 'hyundai':
     if CP_SP.flags & HyundaiFlagsSP.ENABLE_RADAR_TRACKS:
       can_recv()
       _, fingerprint = can_fingerprint(can_recv)

--- a/sunnypilot/selfdrive/car/interfaces.py
+++ b/sunnypilot/selfdrive/car/interfaces.py
@@ -10,8 +10,7 @@ from opendbc.car.can_definitions import CanRecvCallable, CanSendCallable
 from opendbc.car.car_helpers import can_fingerprint
 from opendbc.car.interfaces import CarInterfaceBase
 from opendbc.car.hyundai.radar_interface import RADAR_START_ADDR
-from opendbc.car.hyundai.values import HyundaiFlags, DBC as HYUNDAI_DBC
-from opendbc.sunnypilot.car.hyundai.longitudinal.helpers import LongitudinalTuningType
+from opendbc.car.hyundai.values import DBC as HYUNDAI_DBC
 from opendbc.sunnypilot.car.hyundai.values import HyundaiFlagsSP
 from openpilot.common.params import Params
 from openpilot.common.swaglog import cloudlog
@@ -25,21 +24,6 @@ def log_fingerprint(CP: structs.CarParams) -> None:
     sentry.capture_fingerprint_mock()
   else:
     sentry.capture_fingerprint(CP.carFingerprint, CP.brand)
-
-def _initialize_custom_longitudinal_tuning(CI: CarInterfaceBase, CP: structs.CarParams, CP_SP: structs.CarParamsSP,
-                                           params: Params = None) -> None:
-  if params is None:
-    params = Params()
-
-  # Hyundai Custom Longitudinal Tuning
-  if CP.brand == 'hyundai':
-    hyundai_longitudinal_tuning = int(params.get("HyundaiLongitudinalTuning", encoding="utf8") or 0)
-    if hyundai_longitudinal_tuning == LongitudinalTuningType.DYNAMIC:
-      CP_SP.flags |= HyundaiFlagsSP.LONG_TUNING_DYNAMIC.value
-    if hyundai_longitudinal_tuning == LongitudinalTuningType.PREDICTIVE:
-      CP_SP.flags |= HyundaiFlagsSP.LONG_TUNING_PREDICTIVE.value
-
-  CP_SP = CI.get_longitudinal_tuning_sp(CP, CP_SP)
 
 
 def _initialize_neural_network_lateral_control(CI: CarInterfaceBase, CP: structs.CarParams, CP_SP: structs.CarParamsSP,
@@ -63,31 +47,15 @@ def _initialize_neural_network_lateral_control(CI: CarInterfaceBase, CP: structs
   CP_SP.neuralNetworkLateralControl.fuzzyFingerprint = not exact_match
 
 
-def _initialize_radar_tracks(CP: structs.CarParams, CP_SP: structs.CarParamsSP, params: Params = None) -> None:
-  if params is None:
-    params = Params()
-
-  if CP.brand == 'hyundai':
-    if CP.flags & HyundaiFlags.MANDO_RADAR and CP.radarUnavailable:
-      # Having this automatic without a toggle causes a weird process replay diff because
-      # somehow it sees fewer logs than intended
-      if params.get_bool("HyundaiRadarTracksToggle"):
-        CP_SP.flags |= HyundaiFlagsSP.ENABLE_RADAR_TRACKS.value
-        if params.get_bool("HyundaiRadarTracks"):
-          CP.radarUnavailable = False
-
-
 def setup_interfaces(CI: CarInterfaceBase, params: Params = None) -> None:
   CP = CI.CP
   CP_SP = CI.CP_SP
 
-  _initialize_custom_longitudinal_tuning(CI, CP, CP_SP, params)
   _initialize_neural_network_lateral_control(CI, CP, CP_SP, params)
-  _initialize_radar_tracks(CP, CP_SP, params)
 
 
 def _enable_radar_tracks(CP: structs.CarParams, CP_SP: structs.CarParamsSP, can_recv: CanRecvCallable,
-                        params: Params) -> None:
+                         params: Params) -> None:
   if CP.brand == 'hyundai':
     if CP_SP.flags & HyundaiFlagsSP.ENABLE_RADAR_TRACKS:
       can_recv()
@@ -107,3 +75,13 @@ def _enable_radar_tracks(CP: structs.CarParams, CP_SP: structs.CarParamsSP, can_
 def init_interfaces(CP: structs.CarParams, CP_SP: structs.CarParamsSP, params: Params,
                                 can_recv: CanRecvCallable, can_send: CanSendCallable):
   _enable_radar_tracks(CP, CP_SP, can_recv, params)
+
+
+def get_init_params(params) -> list[dict[str, str]]:
+  keys: list = [
+    "HyundaiLongitudinalTuning",
+    "HyundaiRadarTracks",
+    "HyundaiRadarTracksToggle",
+  ]
+
+  return [{k: params.get(k, encoding='utf8') or "0"} for k in keys]


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Centralize Hyundai-specific parameter initialization by extracting custom tuning and radar track settings into a standalone helper and passing them into the car instantiation process.

Enhancements:
- Remove inline Hyundai longitudinal tuning and radar track setup from the car interface module
- Introduce get_init_params helper to collect Hyundai init parameters from Params
- Update Card initialization to use get_init_params and supply init parameters to get_car