### PR TITLE
Hyundai CAN: re-enable auto-enable radar tracks

### DIFF
--- a/common/params_keys.h
+++ b/common/params_keys.h
@@ -165,10 +165,6 @@ inline static std::unordered_map<std::string, uint32_t> keys = {
 
     // sunnypilot car specific params
     {"HyundaiLongitudinalTuning", PERSISTENT},
-    {"HyundaiRadarTracks", PERSISTENT},
-    {"HyundaiRadarTracksConfirmed", PERSISTENT},
-    {"HyundaiRadarTracksPersistent", PERSISTENT},
-    {"HyundaiRadarTracksToggle", PERSISTENT},
 
     {"DynamicExperimentalControl", PERSISTENT},
 };

--- a/selfdrive/car/card.py
+++ b/selfdrive/car/card.py
@@ -108,7 +108,7 @@ class Car:
       fixed_fingerprint = json.loads(self.params.get("CarPlatformBundle", encoding='utf-8') or "{}").get("platform", None)
 
       self.CI = get_car(*self.can_callbacks, obd_callback(self.params), alpha_long_allowed, num_pandas, cached_params, fixed_fingerprint)
-      sunnypilot_interfaces.setup_interfaces(self.CI, self.params, *self.can_callbacks)
+      sunnypilot_interfaces.setup_interfaces(self.CI, self.params)
       self.RI = interfaces[self.CI.CP.carFingerprint].RadarInterface(self.CI.CP, self.CI.CP_SP)
       self.CP = self.CI.CP
       self.CP_SP = self.CI.CP_SP

--- a/selfdrive/car/card.py
+++ b/selfdrive/car/card.py
@@ -108,7 +108,7 @@ class Car:
       fixed_fingerprint = json.loads(self.params.get("CarPlatformBundle", encoding='utf-8') or "{}").get("platform", None)
 
       self.CI = get_car(*self.can_callbacks, obd_callback(self.params), alpha_long_allowed, num_pandas, cached_params, fixed_fingerprint)
-      sunnypilot_interfaces.setup_interfaces(self.CI, self.params)
+      sunnypilot_interfaces.setup_interfaces(self.CI, self.params, *self.can_callbacks)
       self.RI = interfaces[self.CI.CP.carFingerprint].RadarInterface(self.CI.CP, self.CI.CP_SP)
       self.CP = self.CI.CP
       self.CP_SP = self.CI.CP_SP
@@ -274,7 +274,6 @@ class Car:
       # Initialize CarInterface, once controls are ready
       # TODO: this can make us miss at least a few cycles when doing an ECU knockout
       self.CI.init(self.CP, self.CP_SP, *self.can_callbacks)
-      sunnypilot_interfaces.init_interfaces(self.CP, self.CP_SP, self.params, *self.can_callbacks)
       # signal pandad to switch to car safety mode
       self.params.put_bool_nonblocking("ControlsReady", True)
 

--- a/selfdrive/selfdrived/selfdrived.py
+++ b/selfdrive/selfdrived/selfdrived.py
@@ -545,7 +545,6 @@ class SelfdriveD(CruiseHelper):
       self.personality = self.read_personality_param()
 
       self.mads.read_params()
-      self.car_events_sp.read_params()
       time.sleep(0.1)
 
   def run(self):

--- a/selfdrive/ui/qt/offroad/developer_panel.cc
+++ b/selfdrive/ui/qt/offroad/developer_panel.cc
@@ -45,18 +45,6 @@ DeveloperPanel::DeveloperPanel(SettingsWindow *parent) : ListWidget(parent) {
   });
   addItem(experimentalLongitudinalToggle);
 
-  // TODO-SP: Move to Vehicles panel when ported back
-  hyundaiRadarTracksToggle = new ParamControl(
-    "HyundaiRadarTracksToggle",
-    tr("Hyundai: Enable Radar Tracks"),
-    tr("Enable this to attempt to enable radar tracks for Hyundai, Kia, and Genesis models equipped with the supported Mando SCC radar. "
-       "This allows sunnypilot to use radar data for improved lead tracking and overall longitudinal performance."), "");
-  hyundaiRadarTracksToggle->setConfirmation(true, false);
-  QObject::connect(hyundaiRadarTracksToggle, &ParamControl::toggleFlipped, [=](bool state) {
-    updateToggles(offroad);
-  });
-  addItem(hyundaiRadarTracksToggle);
-
   enableGithubRunner = new ParamControl("EnableGithubRunner", tr("Enable GitHub runner service"), tr("Enables or disables the github runner service."), "");
   addItem(enableGithubRunner);
 
@@ -96,9 +84,6 @@ void DeveloperPanel::updateToggles(bool _offroad) {
     capnp::FlatArrayMessageReader cmsg(aligned_buf.align(cp_bytes.data(), cp_bytes.size()));
     cereal::CarParams::Reader CP = cmsg.getRoot<cereal::CarParams>();
 
-    auto hyundai = CP.getBrand() == "hyundai";
-    auto hyundai_mando_radar = hyundai && (CP.getFlags() & 4096);
-
     if (!CP.getAlphaLongitudinalAvailable() || is_release) {
       params.remove("AlphaLongitudinalEnabled");
       experimentalLongitudinalToggle->setEnabled(false);
@@ -112,11 +97,9 @@ void DeveloperPanel::updateToggles(bool _offroad) {
     experimentalLongitudinalToggle->setVisible(CP.getAlphaLongitudinalAvailable() && !is_release);
 
     longManeuverToggle->setEnabled(hasLongitudinalControl(CP) && _offroad);
-    hyundaiRadarTracksToggle->setVisible(hyundai_mando_radar && hasLongitudinalControl(CP));
   } else {
     longManeuverToggle->setEnabled(false);
     experimentalLongitudinalToggle->setVisible(false);
-    hyundaiRadarTracksToggle->setVisible(false);
   }
   experimentalLongitudinalToggle->refresh();
 

--- a/selfdrive/ui/qt/offroad/developer_panel.h
+++ b/selfdrive/ui/qt/offroad/developer_panel.h
@@ -19,7 +19,6 @@ private:
   ButtonControl* errorLogBtn;
   ParamControl* longManeuverToggle;
   ParamControl* experimentalLongitudinalToggle;
-  ParamControl* hyundaiRadarTracksToggle;
   ParamControl* enableGithubRunner;
   bool is_release;
   bool offroad = false;

--- a/sunnypilot/selfdrive/car/car_specific.py
+++ b/sunnypilot/selfdrive/car/car_specific.py
@@ -23,12 +23,6 @@ class CarSpecificEventsSP:
     self.params = params
 
     self.low_speed_alert = False
-    self.hyundai_radar_tracks = self.params.get_bool("HyundaiRadarTracks")
-    self.hyundai_radar_tracks_confirmed = self.params.get_bool("HyundaiRadarTracksConfirmed")
-
-  def read_params(self):
-    self.hyundai_radar_tracks = self.params.get_bool("HyundaiRadarTracks")
-    self.hyundai_radar_tracks_confirmed = self.params.get_bool("HyundaiRadarTracksConfirmed")
 
   def update(self, CS: structs.CarState, events: Events):
     events_sp = EventsSP()
@@ -47,9 +41,5 @@ class CarSpecificEventsSP:
           self.low_speed_alert = True
       if self.low_speed_alert:
         events.add(EventName.belowSteerSpeed)
-
-    if self.CP.brand == 'hyundai':
-      if self.hyundai_radar_tracks and not self.hyundai_radar_tracks_confirmed:
-        events_sp.add(EventNameSP.hyundaiRadarTracksConfirmed)
 
     return events_sp

--- a/sunnypilot/selfdrive/car/interfaces.py
+++ b/sunnypilot/selfdrive/car/interfaces.py
@@ -8,8 +8,6 @@ See the LICENSE.md file in the root directory for more details.
 from opendbc.car import structs
 from opendbc.car.can_definitions import CanRecvCallable, CanSendCallable
 from opendbc.car.interfaces import CarInterfaceBase
-from opendbc.car.hyundai.values import HyundaiFlags
-from opendbc.sunnypilot.car.hyundai.enable_radar_tracks import enable_radar_tracks as hyundai_enable_radar_tracks
 from opendbc.sunnypilot.car.hyundai.longitudinal.helpers import LongitudinalTuningType
 from opendbc.sunnypilot.car.hyundai.values import HyundaiFlagsSP
 from openpilot.common.params import Params
@@ -63,17 +61,9 @@ def _initialize_neural_network_lateral_control(CI: CarInterfaceBase, CP: structs
   CP_SP.neuralNetworkLateralControl.fuzzyFingerprint = not exact_match
 
 
-def _initialize_radar_tracks(CP: structs.CarParams, can_recv: CanRecvCallable = None, can_send: CanSendCallable = None) -> None:
-  if CP.brand == 'hyundai':
-    if CP.flags & HyundaiFlags.MANDO_RADAR and CP.radarUnavailable:
-      tracks_enabled = hyundai_enable_radar_tracks(can_recv, can_send, bus=0, addr=0x7d0)
-      CP.radarUnavailable = not tracks_enabled
-
-
 def setup_interfaces(CI: CarInterfaceBase, params: Params = None, can_recv: CanRecvCallable = None, can_send: CanSendCallable = None) -> None:
   CP = CI.CP
   CP_SP = CI.CP_SP
 
   _initialize_custom_longitudinal_tuning(CI, CP, CP_SP, params)
   _initialize_neural_network_lateral_control(CI, CP, CP_SP, params)
-  _initialize_radar_tracks(CP, can_recv, can_send)

--- a/sunnypilot/selfdrive/car/interfaces.py
+++ b/sunnypilot/selfdrive/car/interfaces.py
@@ -6,7 +6,6 @@ See the LICENSE.md file in the root directory for more details.
 """
 
 from opendbc.car import structs
-from opendbc.car.can_definitions import CanRecvCallable, CanSendCallable
 from opendbc.car.interfaces import CarInterfaceBase
 from opendbc.sunnypilot.car.hyundai.longitudinal.helpers import LongitudinalTuningType
 from opendbc.sunnypilot.car.hyundai.values import HyundaiFlagsSP

--- a/sunnypilot/selfdrive/car/interfaces.py
+++ b/sunnypilot/selfdrive/car/interfaces.py
@@ -5,12 +5,10 @@ This file is part of sunnypilot and is licensed under the MIT License.
 See the LICENSE.md file in the root directory for more details.
 """
 
-from opendbc.car import Bus, structs
+from opendbc.car import structs
 from opendbc.car.can_definitions import CanRecvCallable, CanSendCallable
-from opendbc.car.car_helpers import can_fingerprint
 from opendbc.car.interfaces import CarInterfaceBase
-from opendbc.car.hyundai.radar_interface import RADAR_START_ADDR
-from opendbc.car.hyundai.values import HyundaiFlags, DBC as HYUNDAI_DBC
+from opendbc.car.hyundai.values import HyundaiFlags
 from opendbc.sunnypilot.car.hyundai.enable_radar_tracks import enable_radar_tracks as hyundai_enable_radar_tracks
 from opendbc.sunnypilot.car.hyundai.longitudinal.helpers import LongitudinalTuningType
 from opendbc.sunnypilot.car.hyundai.values import HyundaiFlagsSP

--- a/sunnypilot/selfdrive/car/interfaces.py
+++ b/sunnypilot/selfdrive/car/interfaces.py
@@ -61,7 +61,7 @@ def _initialize_neural_network_lateral_control(CI: CarInterfaceBase, CP: structs
   CP_SP.neuralNetworkLateralControl.fuzzyFingerprint = not exact_match
 
 
-def setup_interfaces(CI: CarInterfaceBase, params: Params = None, can_recv: CanRecvCallable = None, can_send: CanSendCallable = None) -> None:
+def setup_interfaces(CI: CarInterfaceBase, params: Params = None) -> None:
   CP = CI.CP
   CP_SP = CI.CP_SP
 

--- a/sunnypilot/selfdrive/selfdrived/events.py
+++ b/sunnypilot/selfdrive/selfdrived/events.py
@@ -122,10 +122,6 @@ EVENTS_SP: dict[int, dict[str, Alert | AlertCallbackType]] = {
     ET.NO_ENTRY: NoEntryAlert("Controls Mismatch: Lateral"),
   },
 
-  EventNameSP.hyundaiRadarTracksConfirmed: {
-    ET.PERMANENT: NormalPermanentAlert("Radar tracks available. Restart the car to initialize")
-  },
-
   EventNameSP.experimentalModeSwitched: {
     ET.WARNING: NormalPermanentAlert("Experimental Mode Switched", duration=1.5)
   },


### PR DESCRIPTION
## Summary by Sourcery

Enable automatic activation of Mando radar tracks for Hyundai vehicles during interface setup and remove legacy manual toggles, parameters, and UI controls associated with radar track configuration.

New Features:
- Automatically detect and enable Hyundai radar tracks using hyundai_enable_radar_tracks during interface initialization.

Enhancements:
- Simplify setup_interfaces by passing CAN callbacks directly to radar track initialization.
- Remove legacy parameter handling, CarParams flags, and event generation for manual radar track confirmation.

Chores:
- Remove HyundaiRadarTracks-related keys from params_keys and delete unused developer panel controls.
- Eliminate deprecated _enable_radar_tracks and init_interfaces functions and associated code.

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->