### PR TITLE
ui: include MADS enabled state to `engaged` check

### DIFF
--- a/selfdrive/ui/sunnypilot/ui.h
+++ b/selfdrive/ui/sunnypilot/ui.h
@@ -20,6 +20,11 @@ class UIStateSP : public UIState {
 public:
   UIStateSP(QObject *parent = 0);
   void updateStatus() override;
+  inline bool engaged() const override {
+    return scene.started && (
+      (*sm)["selfdriveState"].getSelfdriveState().getEnabled() || (*sm)["selfdriveStateSP"].getSelfdriveStateSP().getMads().getEnabled()
+    );
+  }
   void setSunnylinkRoles(const std::vector<RoleModel> &roles);
   void setSunnylinkDeviceUsers(const std::vector<UserModel> &users);
 

--- a/selfdrive/ui/tests/test_ui/run.py
+++ b/selfdrive/ui/tests/test_ui/run.py
@@ -26,7 +26,7 @@ from openpilot.tools.lib.framereader import FrameReader
 from openpilot.tools.lib.route import Route
 from openpilot.tools.lib.cache import DEFAULT_CACHE_DIR
 
-UI_DELAY = 0.1 # may be slower on CI?
+UI_DELAY = 0.5 # may be slower on CI?
 TEST_ROUTE = "a2a0ccea32023010|2023-07-27--13-01-19"
 
 STREAMS: list[tuple[VisionStreamType, CameraConfig, bytes]] = []

--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -72,7 +72,7 @@ class UIState : public QObject {
 public:
   UIState(QObject* parent = 0);
   virtual void updateStatus();
-  inline bool engaged() const {
+  virtual inline bool engaged() const {
     return scene.started && (*sm)["selfdriveState"].getSelfdriveState().getEnabled();
   }
 


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Extend the engaged state check to include the MADS enabled flag and allow UIState subclasses to override the default logic

Enhancements:
- Add override for engaged() in UIStateSP to consider MADS enabled status
- Make the base UIState::engaged() method virtual to support subclass overrides