### PR TITLE
Revert "ui: model fuzzy search"

### DIFF
--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/models_panel.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/models_panel.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include "selfdrive/ui/sunnypilot/qt/util.h"
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/settings.h"
 
 class ModelsPanel : public QWidget {
@@ -31,7 +30,7 @@ private:
 
   // UI update related methods
   void updateLabels();
-  void handleCurrentModelLblBtnClicked(const QString &query);
+  void handleCurrentModelLblBtnClicked();
   void handleBundleDownloadProgress();
   void showResetParamsDialog();
   cereal::ModelManagerSP::Reader model_manager;


### PR DESCRIPTION
Reverts sunnypilot/sunnypilot#958

## Summary by Sourcery

Revert the fuzzy search feature in the ModelsPanel and restore the original model selection dialog.

Enhancements:
- Remove the search input dialog and related filtering logic from model selection.
- Simplify model display names by removing internal name concatenation.

Chores:
- Update handleCurrentModelLblBtnClicked signature to no longer accept a query parameter.
- Reconnect the selection button directly to the updated handler method.