### PR TITLE
car: use vEgoCluster pre-hysteresis for longitudinal planner

### DIFF
--- a/cereal/custom.capnp
+++ b/cereal/custom.capnp
@@ -224,6 +224,7 @@ struct BackupManagerSP @0xf98d843bfd7004a3 {
 }
 
 struct CarStateSP @0xb86e6369214c01c8 {
+  vEgoCluster @0 :Float32;    # best estimate of speed shown on car's instrument cluster
 }
 
 struct LiveMapDataSP @0xf416ec09499d9d19 {

--- a/selfdrive/controls/lib/longitudinal_planner.py
+++ b/selfdrive/controls/lib/longitudinal_planner.py
@@ -103,7 +103,7 @@ class LongitudinalPlanner(LongitudinalPlannerSP):
     else:
       accel_coast = ACCEL_MAX
 
-    v_ego = sm['carState'].vEgo
+    v_ego = sm['carStateSP'].vEgoCluster
     v_cruise_kph = min(sm['carState'].vCruise, V_CRUISE_MAX)
     v_cruise = v_cruise_kph * CV.KPH_TO_MS
     v_cruise_initialized = sm['carState'].vCruise != V_CRUISE_UNSET

--- a/selfdrive/controls/plannerd.py
+++ b/selfdrive/controls/plannerd.py
@@ -19,7 +19,8 @@ def main():
   ldw = LaneDepartureWarning()
   longitudinal_planner = LongitudinalPlanner(CP)
   pm = messaging.PubMaster(['longitudinalPlan', 'driverAssistance', 'longitudinalPlanSP'])
-  sm = messaging.SubMaster(['carControl', 'carState', 'controlsState', 'liveParameters', 'radarState', 'modelV2', 'selfdriveState'],
+  sm = messaging.SubMaster(['carControl', 'carState', 'controlsState', 'liveParameters', 'radarState', 'modelV2', 'selfdriveState',
+                            'carStateSP'],
                            poll='modelV2')
 
   while True:


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Switch the longitudinal planner to use the pre-hysteresis cluster speed estimate (vEgoCluster) instead of the post-hysteresis vehicle speed (vEgo).

Enhancements:
- Add vEgoCluster field to CarStateSP schema in cereal for the raw cluster speed.
- Subscribe to the carStateSP message in plannerd to receive vEgoCluster.
- Update LongitudinalPlanner to read ego speed from sm['carStateSP'].vEgoCluster instead of sm['carState'].vEgo.