### PR TITLE
fix: correctly establish NAT forwarding fw rule for tethering

### DIFF
--- a/selfdrive/ui/qt/network/wifi_manager.cc
+++ b/selfdrive/ui/qt/network/wifi_manager.cc
@@ -490,6 +490,12 @@ void WifiManager::tetheringActivated(QDBusPendingCallWatcher *call) {
       qWarning() << "net.ipv4.ip_forward = 0";
       std::system("sudo sysctl net.ipv4.ip_forward=0");
     });
+  } else {
+    // nmcli can't set up NAT forwarding due to missing nf_tables kernel module, so we do it manually
+    QTimer::singleShot(5000, this, [=] {
+      qWarning() << "Setting up NAT forwarding for tethering";
+      std::system("sudo iptables-legacy -t nat -A POSTROUTING -s 192.168.43.0/24 -o wwan0 -j MASQUERADE");
+    });
   }
   call->deleteLater();
   tethering_on = true;


### PR DESCRIPTION
**Description**

Enabling the hotspot/tethering mode currently doesn't allow clients to actually tether off the Comma's SIM card connection; prior to 0.9.8 it did.

Upstream bug: https://github.com/commaai/openpilot/issues/34969
Discussion in SP discord: https://discord.com/channels/880416502577266699/1377315397564633169/1384735498379067454

This PR is a quick fix to restore functionality to pre-0.9.8 behaviour. Personally, I think that this should be fixed upstream, e.g. (adding the appropriate kernel modules, and adding it via nmcli instead), but that is a much more involved fix and I don't want to let perfect be the enemy of good - this works well for now, doesn't affect anything else, and is very easily removed once a better fix is in place.

**Verification**

Hotspot wasn't working for me; I cherry picked this commit to my own fork and have been running it for the past week and can confirm that hotspot is fixed for me. 

Credit to @cloudrainstar for the actual fix, I'm just the one raising it.