### PR TITLE
UI: Custom Interactivity Timeout

### DIFF
--- a/common/params_keys.h
+++ b/common/params_keys.h
@@ -136,6 +136,7 @@ inline static std::unordered_map<std::string, uint32_t> keys = {
     {"CustomAccShortPressIncrement", PERSISTENT | BACKUP},
     {"DeviceBootMode", PERSISTENT | BACKUP},
     {"EnableGithubRunner", PERSISTENT | BACKUP},
+    {"InteractivityTimeout", PERSISTENT | BACKUP},
     {"MaxTimeOffroad", PERSISTENT | BACKUP},
     {"Brightness", PERSISTENT | BACKUP},
     {"ModelRunnerTypeCache", CLEAR_ON_ONROAD_TRANSITION},

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/device_panel.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/device_panel.cc
@@ -87,6 +87,17 @@ DevicePanelSP::DevicePanelSP(SettingsWindowSP *parent) : DevicePanel(parent) {
     params.put("DeviceBootMode", QString::number(index).toStdString());
     updateState();
   });
+
+  interactivityTimeout =  new OptionControlSP("InteractivityTimeout", tr("Interactivity Timeout"),
+                                     tr("Apply a custom timeout for settings UI."
+                                        "\nThis is the time after which settings UI closes automatically if user is not interacting with the screen."),
+                                     "", {0, 120}, 10, true, nullptr, false);
+
+  connect(interactivityTimeout, &OptionControlSP::updateLabels, [=]() {
+    updateState();
+  });
+
+  addItem(interactivityTimeout);
   
   // Brightness
   brightness = new Brightness();
@@ -198,4 +209,11 @@ void DevicePanelSP::updateState() {
     currStatus = DeviceSleepModeStatus::OFFROAD;
   }
   toggleDeviceBootMode->setDescription(deviceSleepModeDescription(currStatus));
+
+  QString timeoutValue = QString::fromStdString(params.get("InteractivityTimeout"));
+  if (timeoutValue == "0") {
+    interactivityTimeout->setLabel("DEFAULT");
+  } else {
+    interactivityTimeout->setLabel(timeoutValue + "s");
+  }
 }

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/device_panel.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/device_panel.h
@@ -33,6 +33,7 @@ private:
   MaxTimeOffroad *maxTimeOffroad;
   ButtonParamControlSP *toggleDeviceBootMode;
   Brightness *brightness;
+  OptionControlSP *interactivityTimeout;
 
   const QString alwaysOffroadStyle = R"(
     PushButtonSP {

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -164,8 +164,9 @@ void Device::setAwake(bool on) {
 }
 
 void Device::resetInteractiveTimeout(int timeout) {
+  int customTimeout = QString::fromStdString(Params().get("InteractivityTimeout")).toInt();
   if (timeout == -1) {
-    timeout = (ignition_on ? 10 : 30);
+    timeout = customTimeout == 0 ? (ignition_on ? 10 : 30) : customTimeout;
   }
   interactive_timeout = timeout * UI_FREQ;
 }

--- a/system/manager/manager.py
+++ b/system/manager/manager.py
@@ -56,6 +56,7 @@ def manager_init() -> None:
     ("DeviceBootMode", "0"),
     ("DynamicExperimentalControl", "0"),
     ("HyundaiLongitudinalTuning", "0"),
+    ("InteractivityTimeout", "0"),
     ("LagdToggle", "1"),
     ("LagdToggledelay", "0.2"),
     ("Mads", "1"),


### PR DESCRIPTION
Fixes #1029

## Summary by Sourcery

Add a configurable InteractivityTimeout option to the offroad settings panel, store it as a persistent parameter, and apply it in the UI’s resetInteractiveTimeout logic to override the default auto-close delay.

New Features:
- Introduce a custom interactivity timeout setting to automatically close the settings UI after inactivity
- Persist the new InteractivityTimeout parameter in device configuration and initialize it in system manager

Enhancements:
- Display the InteractivityTimeout label as “DEFAULT” when set to zero or as “<value>s” otherwise