### PR TITLE
ui: fix descriptions visibility on models panel

### DIFF
--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/models_panel.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/models_panel.cc
@@ -366,13 +366,11 @@ void ModelsPanel::updateLabels() {
     desc += "<br><br><b><span style=\"color:#e0e0e0\">" + tr("Current:") + "</span></b> <span style=\"color:#e0e0e0\">" + current + "</span>";
   }
   lagd_toggle_control->setDescription(desc);
-  lagd_toggle_control->showDescription();
 
   delay_control->setVisible(!params.getBool("LagdToggle"));
   if (delay_control->isVisible()) {
     float value = QString::fromStdString(params.get("LagdToggledelay")).toFloat();
     delay_control->setLabel(QString::number(value, 'f', 2) + "s");
-    delay_control->showDescription();
   }
 
   clearModelCacheBtn->setValue(QString::number(calculateCacheSize(), 'f', 2) + " MB");
@@ -424,4 +422,11 @@ double ModelsPanel::calculateCacheSize() {
     return totalSize;
   });
   return static_cast<double>(future_ModelCacheSize) / (1024.0 * 1024.0);
+}
+
+void ModelsPanel::showEvent(QShowEvent *event) {
+  lagd_toggle_control->showDescription();
+  if (delay_control->isVisible()) {
+    delay_control->showDescription();
+  }
 }

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/models_panel.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/models_panel.h
@@ -21,6 +21,7 @@ private:
   QString GetActiveModelName();
   QString GetActiveModelInternalName();
   void updateModelManagerState();
+  void showEvent(QShowEvent *event) override;
 
   bool isDownloading() const {
     if (!model_manager.hasSelectedBundle()) {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Move showDescription calls for lagd_toggle_control and delay_control from updateLabels to a showEvent override to restore visibility of descriptions on panel display