### PR TITLE
ci: refactor PR handling and input parsing for `squash-and-merge`

### DIFF
--- a/.github/workflows/sunnypilot-master-dev-c3-prep.yaml
+++ b/.github/workflows/sunnypilot-master-dev-c3-prep.yaml
@@ -11,12 +11,12 @@ on:
   push:
     branches:
       - master
-      - master-new    
+      - master-new
   pull_request_target:
-    types: [ labeled ]  
-    branches:    
-      - 'master'        
-      - 'master-new'            
+    types: [ labeled ]
+    branches:
+      - 'master'
+      - 'master-new'
   workflow_dispatch:
     inputs:
       source_branch:
@@ -153,6 +153,7 @@ jobs:
               }
             }' -F label="is:pr is:open label:${PR_LABEL} draft:false sort:created-asc")
 
+          PR_LIST=${PR_LIST//\'/}
           echo "PR_LIST=${PR_LIST}" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -162,7 +163,7 @@ jobs:
           cp ${{ github.workspace }}/release/ci/squash_and_merge.py /tmp/squash_and_merge.py && \
           chmod +x /tmp/squash_and_merge.py && \
           python3 ${{ github.workspace }}/release/ci/squash_and_merge_prs.py \
-            --pr-data "${{ steps.get-prs.outputs.PR_LIST }}" \
+            --pr-data '${{ steps.get-prs.outputs.PR_LIST }}' \
             --target-branch ${{ inputs.target_branch || env.DEFAULT_TARGET_BRANCH }} \
             --squash-script-path '/tmp/squash_and_merge.py'
         env:

--- a/.github/workflows/sunnypilot-master-dev-c3-prep.yaml
+++ b/.github/workflows/sunnypilot-master-dev-c3-prep.yaml
@@ -119,7 +119,7 @@ jobs:
         id: get-prs
         run: |
           # Use GitHub API to get PRs with specific label, ordered by creation date
-          gh api graphql -f query='
+          PR_LIST=$(gh api graphql -f query='
             query($label:String!) {
               search(query: $label, type:ISSUE, first:100) {
                 nodes {
@@ -151,19 +151,20 @@ jobs:
                   }
                 }
               }
-            }' -F label="is:pr is:open label:${PR_LABEL} draft:false sort:created-asc" \
-            > ${{ runner.temp }}/pr_list_output.json
+            }' -F label="is:pr is:open label:${PR_LABEL} draft:false sort:created-asc")
 
-          echo "PR list written to ${{ runner.temp }}/pr_list_output.json"
+          PR_LIST=$(echo "$PR_LIST" | base64 | tr -d '\n')
+          echo "PR_LIST=${PR_LIST}" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Process PRs
         run: |
+          PR_DECODED=$(echo "${{ steps.get-prs.outputs.PR_LIST }}" | base64 -d)
           cp ${{ github.workspace }}/release/ci/squash_and_merge.py /tmp/squash_and_merge.py && \
           chmod +x /tmp/squash_and_merge.py && \
           python3 ${{ github.workspace }}/release/ci/squash_and_merge_prs.py \
-            --pr-data "$(cat ${{ runner.temp }}/pr_list_output.json)" \
+            --pr-data "$PR_DECODED" \
             --target-branch ${{ inputs.target_branch || env.DEFAULT_TARGET_BRANCH }} \
             --squash-script-path '/tmp/squash_and_merge.py'
         env:

--- a/.github/workflows/sunnypilot-master-dev-c3-prep.yaml
+++ b/.github/workflows/sunnypilot-master-dev-c3-prep.yaml
@@ -152,9 +152,9 @@ jobs:
                 }
               }
             }' -F label="is:pr is:open label:${PR_LABEL} draft:false sort:created-asc" \
-            > /tmp/pr_list_output.json
+            > ${{ runner.temp }}/pr_list_output.json
 
-          echo "PR list written to /tmp/pr_list_output.json"
+          echo "PR list written to ${{ runner.temp }}/pr_list_output.json"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -163,7 +163,7 @@ jobs:
           cp ${{ github.workspace }}/release/ci/squash_and_merge.py /tmp/squash_and_merge.py && \
           chmod +x /tmp/squash_and_merge.py && \
           python3 ${{ github.workspace }}/release/ci/squash_and_merge_prs.py \
-            --pr-data "$(cat /tmp/pr_list_output.json)" \
+            --pr-data "$(cat ${{ runner.temp }}/pr_list_output.json)" \
             --target-branch ${{ inputs.target_branch || env.DEFAULT_TARGET_BRANCH }} \
             --squash-script-path '/tmp/squash_and_merge.py'
         env:

--- a/.github/workflows/sunnypilot-master-dev-c3-prep.yaml
+++ b/.github/workflows/sunnypilot-master-dev-c3-prep.yaml
@@ -162,7 +162,7 @@ jobs:
           cp ${{ github.workspace }}/release/ci/squash_and_merge.py /tmp/squash_and_merge.py && \
           chmod +x /tmp/squash_and_merge.py && \
           python3 ${{ github.workspace }}/release/ci/squash_and_merge_prs.py \
-            --pr-data ${{ steps.get-prs.outputs.PR_LIST }} \
+            --pr-data "${{ steps.get-prs.outputs.PR_LIST }}" \
             --target-branch ${{ inputs.target_branch || env.DEFAULT_TARGET_BRANCH }} \
             --squash-script-path '/tmp/squash_and_merge.py'
         env:

--- a/.github/workflows/sunnypilot-master-dev-c3-prep.yaml
+++ b/.github/workflows/sunnypilot-master-dev-c3-prep.yaml
@@ -119,7 +119,7 @@ jobs:
         id: get-prs
         run: |
           # Use GitHub API to get PRs with specific label, ordered by creation date
-          PR_LIST=$(gh api graphql -f query='
+          gh api graphql -f query='
             query($label:String!) {
               search(query: $label, type:ISSUE, first:100) {
                 nodes {
@@ -151,9 +151,10 @@ jobs:
                   }
                 }
               }
-            }' -F label="is:pr is:open label:${PR_LABEL} draft:false sort:created-asc")
+            }' -F label="is:pr is:open label:${PR_LABEL} draft:false sort:created-asc" \
+            > /tmp/pr_list_output.json
 
-          echo "PR_LIST=${PR_LIST}" >> $GITHUB_OUTPUT
+          echo "PR list written to /tmp/pr_list_output.json"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -162,7 +163,7 @@ jobs:
           cp ${{ github.workspace }}/release/ci/squash_and_merge.py /tmp/squash_and_merge.py && \
           chmod +x /tmp/squash_and_merge.py && \
           python3 ${{ github.workspace }}/release/ci/squash_and_merge_prs.py \
-            --pr-data '${{ steps.get-prs.outputs.PR_LIST }}' \
+            --pr-data "$(cat /tmp/pr_list_output.json)" \
             --target-branch ${{ inputs.target_branch || env.DEFAULT_TARGET_BRANCH }} \
             --squash-script-path '/tmp/squash_and_merge.py'
         env:

--- a/.github/workflows/sunnypilot-master-dev-c3-prep.yaml
+++ b/.github/workflows/sunnypilot-master-dev-c3-prep.yaml
@@ -11,12 +11,12 @@ on:
   push:
     branches:
       - master
-      - master-new
+      - master-new    
   pull_request_target:
-    types: [ labeled ]
-    branches:
-      - 'master'
-      - 'master-new'
+    types: [ labeled ]  
+    branches:    
+      - 'master'        
+      - 'master-new'            
   workflow_dispatch:
     inputs:
       source_branch:

--- a/.github/workflows/sunnypilot-master-dev-c3-prep.yaml
+++ b/.github/workflows/sunnypilot-master-dev-c3-prep.yaml
@@ -153,18 +153,16 @@ jobs:
               }
             }' -F label="is:pr is:open label:${PR_LABEL} draft:false sort:created-asc")
 
-          PR_LIST=$(echo "$PR_LIST" | base64 | tr -d '\n')
           echo "PR_LIST=${PR_LIST}" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Process PRs
         run: |
-          PR_DECODED=$(echo "${{ steps.get-prs.outputs.PR_LIST }}" | base64 -d)
           cp ${{ github.workspace }}/release/ci/squash_and_merge.py /tmp/squash_and_merge.py && \
           chmod +x /tmp/squash_and_merge.py && \
           python3 ${{ github.workspace }}/release/ci/squash_and_merge_prs.py \
-            --pr-data "$PR_DECODED" \
+            --pr-data ${{ steps.get-prs.outputs.PR_LIST }} \
             --target-branch ${{ inputs.target_branch || env.DEFAULT_TARGET_BRANCH }} \
             --squash-script-path '/tmp/squash_and_merge.py'
         env:


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Refactor PR handling in CI workflow to store PR data in a temp file and streamline passing it to the merge script

CI:
- Write GH API response to /tmp/pr_list_output.json instead of setting a GITHUB_OUTPUT variable
- Add an echo confirmation message after writing the PR list
- Update squash_and_merge_prs.py invocation to read PR data from the file