### PR TITLE
mapd: suppress output

### DIFF
--- a/system/manager/process_config.py
+++ b/system/manager/process_config.py
@@ -165,7 +165,7 @@ procs += [
   PythonProcess("backup_manager", "sunnypilot.sunnylink.backups.manager", and_(only_offroad, sunnylink_ready_shim)),
 
   # mapd
-  NativeProcess("mapd", Paths.mapd_root(), [MAPD_PATH], mapd_ready),
+  NativeProcess("mapd", Paths.mapd_root(), ["bash", "-c", f"{MAPD_PATH} > /dev/null 2>&1"], mapd_ready),
   PythonProcess("mapd_manager", "sunnypilot.mapd.mapd_manager", always_run),
 ]
 


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Silence mapd stdout and stderr by launching it through a bash command with output redirection