### PR TITLE
fix: update LastSunnylinkPingTime parameter type from string to integer

### DIFF
--- a/sunnypilot/sunnylink/api.py
+++ b/sunnypilot/sunnylink/api.py
@@ -90,7 +90,7 @@ class SunnylinkApi(BaseApi):
       sunnylink_dongle_id = UNREGISTERED_SUNNYLINK_DONGLE_ID
       self._status_update("Public key not found, setting dongle ID to unregistered.")
     else:
-      Params().put("LastSunnylinkPingTime", "0")  # Reset the last ping time to 0 if we are trying to register
+      Params().put("LastSunnylinkPingTime", 0)  # Reset the last ping time to 0 if we are trying to register
       with pubkey_path.open() as f1, privkey_path.open() as f2:
         public_key = f1.read()
         private_key = f2.read()
@@ -148,7 +148,7 @@ class SunnylinkApi(BaseApi):
 
     # Set the last ping time to the current time since we were just talking to the API
     last_ping = int(time.monotonic() * 1e9) if successful_registration else start_time
-    Params().put("LastSunnylinkPingTime", str(last_ping))
+    Params().put("LastSunnylinkPingTime", last_ping)
 
     # Disable sunnylink if registration was not successful
     if not successful_registration:


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Store LastSunnylinkPingTime as an integer instead of a string to ensure correct parameter typing.

Bug Fixes:
- Use integer 0 when resetting LastSunnylinkPingTime instead of string "0"
- Pass last_ping as an integer rather than its string representation when updating LastSunnylinkPingTime