### PR TITLE
ci: dynamic submodule check for build_release

### DIFF
--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -77,8 +77,8 @@ jobs:
             fi
           done | tr '\n' ' ')
 
-          echo "Changed submodule paths: $SUBMODULE_PATHS"
           if [ -n "$SUBMODULE_PATHS" ]; then
+            echo "Changed submodule paths: $SUBMODULE_PATHS"
             export SUBMODULE_PATHS="$SUBMODULE_PATHS"
             export CHECK_PR_REFS=true
           fi

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -71,9 +71,11 @@ jobs:
         if [ "${{ github.event_name }}" == "pull_request" ]; then
           git fetch origin master:refs/remotes/origin/master
           SUBMODULE_DIFF=$(git diff origin/master HEAD --submodule=short | grep "^-Subproject\|^+Subproject" | awk '{print $3}' | sort -u)
+          echo "Submodule differences found: $SUBMODULE_DIFF"
           if [ -n "$SUBMODULE_DIFF" ]; then
-            export SUBMODULE_DIFF="$SUBMODULE_DIFF"
-            export CHECK_PR_REFS=true
+            echo "SUBMODULE_DIFF=$SUBMODULE_DIFF" >> $GITHUB_ENV
+            echo "CHECK_PR_REFS=true" >> $GITHUB_ENV
+            echo "Setting environment variables for PR submodule checking"
           fi
         fi
         release/check-submodules.sh

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -67,7 +67,16 @@ jobs:
     - name: Check submodules
       if: github.repository == 'sunnypilot/sunnypilot'
       timeout-minutes: 3
-      run: release/check-submodules.sh
+      run: |
+        if [ "${{ github.event_name }}" == "pull_request" ]; then
+          git fetch origin master:refs/remotes/origin/master
+          SUBMODULE_DIFF=$(git diff origin/master HEAD --submodule=short | grep "^-Subproject\|^+Subproject" | awk '{print $3}' | sort -u)
+          if [ -n "$SUBMODULE_DIFF" ]; then
+            export SUBMODULE_DIFF="$SUBMODULE_DIFF"
+            export CHECK_PR_REFS=true
+          fi
+        fi
+        release/check-submodules.sh
 
   build:
     runs-on: ${{

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -68,24 +68,24 @@ jobs:
       if: github.repository == 'sunnypilot/sunnypilot'
       timeout-minutes: 3
       run: |
-        if [ "${{ github.event_name }}" == "pull_request" ]; then
-           git fetch origin master:refs/remotes/origin/master
+        if [ "${{ github.ref }}" != "refs/heads/master" ]; then
+          git fetch  origin master:refs/remotes/origin/master
 
-           SUBMODULE_PATHS=$(git diff origin/master HEAD --name-only | grep -E '^[^/]+$' | while read path; do
-             if git ls-files --stage "$path" | grep -q "^160000"; then
-               echo "$path"
-             fi
-           done | tr '\n' ' ')
+            SUBMODULE_PATHS=$(git diff origin/master HEAD --name-only | grep -E '^[^/]+$' | while read path; do
+              if git ls-files --stage "$path" | grep -q "^160000"; then
+                echo "$path"
+              fi
+            done | tr '\n' ' ')
 
-           echo "Changed submodule paths: $SUBMODULE_PATHS"
-           if [ -n "$SUBMODULE_PATHS" ]; then
-             # Export variables for the script
-             export SUBMODULE_PATHS="$SUBMODULE_PATHS"
-             export CHECK_PR_REFS=true
-             echo "Setting environment variables for PR submodule checking"
-           fi
-         fi
-         release/check-submodules.sh
+            echo "Changed submodule paths: $SUBMODULE_PATHS"
+            if [ -n "$SUBMODULE_PATHS" ]; then
+              # Export variables for the script
+              export SUBMODULE_PATHS="$SUBMODULE_PATHS"
+              export CHECK_PR_REFS=true
+              echo "Setting environment variables for PR submodule checking"
+            fi
+          fi
+          release/check-submodules.sh
 
   build:
     runs-on: ${{

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -71,21 +71,19 @@ jobs:
         if [ "${{ github.ref }}" != "refs/heads/master" ]; then
           git fetch  origin master:refs/remotes/origin/master
 
-            SUBMODULE_PATHS=$(git diff origin/master HEAD --name-only | grep -E '^[^/]+$' | while read path; do
-              if git ls-files --stage "$path" | grep -q "^160000"; then
-                echo "$path"
-              fi
-            done | tr '\n' ' ')
-
-            echo "Changed submodule paths: $SUBMODULE_PATHS"
-            if [ -n "$SUBMODULE_PATHS" ]; then
-              # Export variables for the script
-              export SUBMODULE_PATHS="$SUBMODULE_PATHS"
-              export CHECK_PR_REFS=true
-              echo "Setting environment variables for PR submodule checking"
+          SUBMODULE_PATHS=$(git diff origin/master HEAD --name-only | grep -E '^[^/]+$' | while read path; do
+            if git ls-files --stage "$path" | grep -q "^160000"; then
+              echo "$path"
             fi
+          done | tr '\n' ' ')
+
+          echo "Changed submodule paths: $SUBMODULE_PATHS"
+          if [ -n "$SUBMODULE_PATHS" ]; then
+            export SUBMODULE_PATHS="$SUBMODULE_PATHS"
+            export CHECK_PR_REFS=true
           fi
-          release/check-submodules.sh
+        fi
+        release/check-submodules.sh
 
   build:
     runs-on: ${{

--- a/.github/workflows/selfdrive_tests.yaml
+++ b/.github/workflows/selfdrive_tests.yaml
@@ -69,16 +69,23 @@ jobs:
       timeout-minutes: 3
       run: |
         if [ "${{ github.event_name }}" == "pull_request" ]; then
-          git fetch origin master:refs/remotes/origin/master
-          SUBMODULE_DIFF=$(git diff origin/master HEAD --submodule=short | grep "^-Subproject\|^+Subproject" | awk '{print $3}' | sort -u)
-          echo "Submodule differences found: $SUBMODULE_DIFF"
-          if [ -n "$SUBMODULE_DIFF" ]; then
-            echo "SUBMODULE_DIFF=$SUBMODULE_DIFF" >> $GITHUB_ENV
-            echo "CHECK_PR_REFS=true" >> $GITHUB_ENV
-            echo "Setting environment variables for PR submodule checking"
-          fi
-        fi
-        release/check-submodules.sh
+           git fetch origin master:refs/remotes/origin/master
+
+           SUBMODULE_PATHS=$(git diff origin/master HEAD --name-only | grep -E '^[^/]+$' | while read path; do
+             if git ls-files --stage "$path" | grep -q "^160000"; then
+               echo "$path"
+             fi
+           done | tr '\n' ' ')
+
+           echo "Changed submodule paths: $SUBMODULE_PATHS"
+           if [ -n "$SUBMODULE_PATHS" ]; then
+             # Export variables for the script
+             export SUBMODULE_PATHS="$SUBMODULE_PATHS"
+             export CHECK_PR_REFS=true
+             echo "Setting environment variables for PR submodule checking"
+           fi
+         fi
+         release/check-submodules.sh
 
   build:
     runs-on: ${{

--- a/release/check-submodules.sh
+++ b/release/check-submodules.sh
@@ -2,8 +2,8 @@
 
 has_submodule_changes() {
   local submodule_path="$1"
-  if [ -n "$SUBMODULE_DIFF" ]; then
-    echo "$SUBMODULE_DIFF" | grep -q "^$submodule_path$"
+  if [ -n "$SUBMODULE_PATHS" ]; then
+    echo "$SUBMODULE_PATHS" | grep -q "$submodule_path"
     return $?
   fi
   return 1

--- a/release/check-submodules.sh
+++ b/release/check-submodules.sh
@@ -22,7 +22,7 @@ while read hash submodule ref; do
   fi
 
   if [ "$CHECK_PR_REFS" = "true" ] && has_submodule_changes "$submodule"; then
-    echo "Checking $submodule (PR mode): verifying hash $hash exists"
+    echo "Checking $submodule (non-master): verifying hash $hash exists"
     git -C $submodule fetch --depth 100 origin
     if git -C $submodule cat-file -e $hash 2>/dev/null; then
       echo "$submodule ok (hash exists)"


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Add dynamic PR submodule detection and conditional hash validation to the submodule check script and GitHub Actions workflow

Enhancements:
- Extend check-submodules.sh to accept a SUBMODULE_PATHS list and verify submodule hashes directly when not on master

CI:
- Compute changed submodule paths in the selfdrive_tests workflow via git diff and set SUBMODULE_PATHS and CHECK_PR_REFS before running the submodule check