### PR TITLE
ci: add deploy strategy extraction and refactor publish dependencies

### DIFF
--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -203,7 +203,7 @@ jobs:
   
             echo "prebuilt=true" >> $GITHUB_OUTPUT
             echo "environment=dev" >> $GITHUB_OUTPUT
-            echo "auto_deploy=false" >> $GITHUB_OUTPUT
+            echo "auto_deploy=${{ (contains(fromJSON(vars.AUTO_DEPLOY_PREBUILT_BRANCHES), github.head_ref || github.ref_name) || contains(github.event.pull_request.labels.*.name, 'prebuilt')) && 'auto-deploy' || 'feature-branch' }}" >> $GITHUB_OUTPUT
             echo "new_branch=$NEW_BRANCH" >> $GITHUB_OUTPUT
             echo "version=$VERSION" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -46,16 +46,16 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   build:
-    needs: [ validate_tests ]
+    needs: [ validate_tests, prepare_strategy ]
     concurrency:
       group: build-${{ github.head_ref || github.ref_name }}
       cancel-in-progress: false
     runs-on: [self-hosted, tici]
     outputs:
-      new_branch: ${{ steps.set-env.outputs.new_branch }}
-      version: ${{ steps.set-env.outputs.version }}
-      extra_version_identifier: ${{ steps.set-env.outputs.extra_version_identifier }}
-      commit_sha: ${{ steps.set-env.outputs.commit_sha }}
+      new_branch: ${{ needs.prepare_strategy.outputs.new_branch }}
+      version: ${{ needs.prepare_strategy.outputs.version }}
+      extra_version_identifier: ${{ needs.prepare_strategy.outputs.extra_version_identifier }}
+      commit_sha: ${{ github.sha }}
     if: ${{ (always() && !failure() && !cancelled()) && (!contains(github.event_name, 'pull_request') || (github.event.action == 'labeled' && github.event.label.name == 'prebuilt')) }}
     steps:
       - uses: actions/checkout@v4
@@ -77,61 +77,12 @@ jobs:
             scons-${{ runner.os }}-${{ runner.arch }}-${{ env.STAGING_C3_SOURCE_BRANCH }}
             scons-${{ runner.os }}-${{ runner.arch }}
 
-      - name: Set Feature Branch Prebuilt Configuration
-        id: set_feature_configuration
-        if: (
-          !(env.SOURCE_BRANCH == env.DEV_C3_SOURCE_BRANCH) &&
-          !(env.SOURCE_BRANCH == env.STAGING_C3_SOURCE_BRANCH) &&
-          !(startsWith(github.ref, 'refs/tags/'))
-          )
-        run: |
-          echo "NEW_BRANCH=${{ env.SOURCE_BRANCH }}${{ github.event.pull_request.head.repo.fork && '-fork' || '' }}-prebuilt" >> $GITHUB_ENV
-          echo "VERSION=$(date '+%Y.%m.%d')-${{ github.run_number }}" >> $GITHUB_ENV
-
-      - name: Set dev-c3-new prebuilt Configuration
-        id: set_dev_configuration
-        if: (
-          steps.set_feature_configuration.outcome == 'skipped' &&
-          env.SOURCE_BRANCH == env.DEV_C3_SOURCE_BRANCH
-          )
-        run: |
-          echo "NEW_BRANCH=${{ env.DEV_TARGET_BRANCH }}" >> $GITHUB_ENV
-          echo "VERSION=$(date '+%Y.%m.%d')-${{ github.run_number }}" >> $GITHUB_ENV
-          echo "EXTRA_VERSION_IDENTIFIER=${{ github.run_number }}" >> $GITHUB_ENV
-
-      - name: Set staging-c3-new prebuilt Configuration
-        id: set_staging_configuration
-        if: (
-          steps.set_feature_configuration.outcome == 'skipped' &&
-          !contains(github.event_name, 'pull_request') &&
-          steps.set_dev_configuration.outcome == 'skipped' &&
-          (env.SOURCE_BRANCH == env.STAGING_C3_SOURCE_BRANCH)
-          )
-        run: |
-          echo "NEW_BRANCH=${{ env.STAGING_TARGET_BRANCH }}" >> $GITHUB_ENV
-          echo "EXTRA_VERSION_IDENTIFIER=staging" >> $GITHUB_ENV
-          echo "VERSION=$(cat common/version.h | grep COMMA_VERSION | sed -e 's/[^0-9|.]//g')-staging" >> $GITHUB_ENV
-
-      - name: Set release-c3-new prebuilt Configuration
-        id: set_tag_configuration
-        if: (
-          steps.set_feature_configuration.outcome == 'skipped' &&
-          !contains(github.event_name, 'pull_request') &&
-          steps.set_staging_configuration.outcome == 'skipped' &&
-          startsWith(github.ref, 'refs/tags/')
-          )
-        run: |
-          echo "NEW_BRANCH=${{ env.RELEASE_TARGET_BRANCH }}" >> $GITHUB_ENV
-          echo "EXTRA_VERSION_IDENTIFIER=release" >> $GITHUB_ENV
-          echo "VERSION=$(cat common/version.h | grep COMMA_VERSION | sed -e 's/[^0-9|.]//g')-release" >> $GITHUB_ENV
-
       - name: Set environment variables
         id: set-env
         run: |
-          # Write to GITHUB_OUTPUT from environment variables
-          echo "new_branch=$NEW_BRANCH" >> $GITHUB_OUTPUT
-          [[ ! -z "$EXTRA_VERSION_IDENTIFIER" ]] && echo "extra_version_identifier=$EXTRA_VERSION_IDENTIFIER" >> $GITHUB_OUTPUT
-          [[ ! -z "$VERSION" ]] && echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "new_branch=${{ needs.prepare_strategy.outputs.new_branch }}" >> $GITHUB_OUTPUT
+          echo "version=${{ needs.prepare_strategy.outputs.version }}" >> $GITHUB_OUTPUT
+          echo "extra_version_identifier=${{ needs.prepare_strategy.outputs.extra_version_identifier }}" >> $GITHUB_OUTPUT
           echo "commit_sha=${{ github.sha }}" >> $GITHUB_OUTPUT
           
           # Set up common environment
@@ -229,12 +180,13 @@ jobs:
           
   prepare_strategy:
     runs-on: ubuntu-24.04
-    if: ${{ always() && !failure() && !cancelled() }}
     outputs:
       prebuilt: ${{ steps.strategy.outputs.prebuilt }}
       environment: ${{ steps.strategy.outputs.environment }}
       auto_deploy: ${{ steps.strategy.outputs.auto_deploy }}
-    
+      new_branch: ${{ steps.strategy.outputs.new_branch }}
+      extra_version_identifier: ${{ steps.strategy.outputs.extra_version_identifier }}
+      version: ${{ steps.strategy.outputs.version }}
     steps:
       - name: Extract deploy strategy
         id: strategy
@@ -242,20 +194,29 @@ jobs:
           echo '::group::Strategy Extraction'
           BRANCH="${{ github.head_ref || github.ref_name }}"
           echo "Current branch: $BRANCH"
-          
+
           STRATEGY_JSON='${{ vars.DEPLOY_STRATEGY }}'
           CONFIG=$(echo "$STRATEGY_JSON" | jq -r --arg branch "$BRANCH" '
             .configs[] | select(.branch == $branch)
           ')
-          
           echo "Matched config: $CONFIG"
           echo "::endgroup::"
-          
+
           echo "prebuilt=$(echo "$CONFIG" | jq -r '.prebuilt')" >> $GITHUB_OUTPUT
           echo "environment=$(echo "$CONFIG" | jq -r '.environment')" >> $GITHUB_OUTPUT
           echo "auto_deploy=$(echo "$CONFIG" | jq -r '.auto_deploy')" >> $GITHUB_OUTPUT
 
+          if echo "$CONFIG" | jq -e 'has("version_prefix")'; then
+            VERSION="$(echo "$CONFIG" | jq -r '.version_prefix')-$(date '+%Y.%m.%d')-${{ github.run_number }}"
+          else
+            VERSION="$(date '+%Y.%m.%d')-${{ github.run_number }}"
+          fi
 
+          echo "new_branch=$(echo "$CONFIG" | jq -r '.target_branch')" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "extra_version_identifier=$(echo "$CONFIG" | jq -r '.extra_version_identifier // empty')" >> $GITHUB_OUTPUT
+  
+  
   publish:
     concurrency:
       group: publish-${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -226,15 +226,44 @@ jobs:
         if: always()
         run: |
           PYTHONPATH=$PYTHONPATH:${{ github.workspace }}/ ${{ github.workspace }}/scripts/manage-powersave.py --enable
+          
+  prepare_strategy:
+    runs-on: ubuntu-24.04
+    if: ${{ always() && !failure() && !cancelled() }}
+    outputs:
+      prebuilt: ${{ steps.strategy.outputs.prebuilt }}
+      environment: ${{ steps.strategy.outputs.environment }}
+      auto_deploy: ${{ steps.strategy.outputs.auto_deploy }}
+    
+    steps:
+      - name: Extract deploy strategy
+        id: strategy
+        run: |
+          echo '::group::Strategy Extraction'
+          BRANCH="${{ github.head_ref || github.ref_name }}"
+          echo "Current branch: $BRANCH"
+          
+          STRATEGY_JSON='${{ vars.DEPLOY_STRATEGY }}'
+          CONFIG=$(echo "$STRATEGY_JSON" | jq -r --arg branch "$BRANCH" '
+            .configs[] | select(.branch == $branch)
+          ')
+          
+          echo "Matched config: $CONFIG"
+          echo "::endgroup::"
+          
+          echo "prebuilt=$(echo "$CONFIG" | jq -r '.prebuilt')" >> $GITHUB_OUTPUT
+          echo "environment=$(echo "$CONFIG" | jq -r '.environment')" >> $GITHUB_OUTPUT
+          echo "auto_deploy=$(echo "$CONFIG" | jq -r '.auto_deploy')" >> $GITHUB_OUTPUT
+
 
   publish:
     concurrency:
       group: publish-${{ github.head_ref || github.ref_name }}
       cancel-in-progress: true
     if: ${{ (always() && !failure() && !cancelled()) && (!contains(github.event_name, 'pull_request') || (github.event.action == 'labeled' && github.event.label.name == 'prebuilt')) }}
-    needs: [ build ]
+    needs: [ build, prepare_strategy ]
     runs-on: ubuntu-24.04
-    environment: ${{ (contains(fromJSON(vars.AUTO_DEPLOY_PREBUILT_BRANCHES), github.head_ref || github.ref_name) || contains(github.event.pull_request.labels.*.name, 'prebuilt')) && 'auto-deploy' || 'feature-branch' }}
+    environment: ${{ needs.prepare_strategy.outputs.environment }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -177,7 +177,6 @@ jobs:
     outputs:
       prebuilt: ${{ steps.strategy.outputs.prebuilt }}
       environment: ${{ steps.strategy.outputs.environment }}
-      auto_deploy: ${{ steps.strategy.outputs.auto_deploy }}
       new_branch: ${{ steps.strategy.outputs.new_branch }}
       extra_version_identifier: ${{ steps.strategy.outputs.extra_version_identifier }}
       version: ${{ steps.strategy.outputs.version }}
@@ -202,15 +201,13 @@ jobs:
             VERSION="$(date '+%Y.%m.%d')-${{ github.run_number }}"
   
             echo "prebuilt=true" >> $GITHUB_OUTPUT
-            echo "environment=dev" >> $GITHUB_OUTPUT
-            echo "auto_deploy=${{ (contains(fromJSON(vars.AUTO_DEPLOY_PREBUILT_BRANCHES), github.head_ref || github.ref_name) || contains(github.event.pull_request.labels.*.name, 'prebuilt')) && 'auto-deploy' || 'feature-branch' }}" >> $GITHUB_OUTPUT
+            echo "environment=${{ (contains(fromJSON(vars.AUTO_DEPLOY_PREBUILT_BRANCHES), github.head_ref || github.ref_name) || contains(github.event.pull_request.labels.*.name, 'prebuilt')) && 'auto-deploy' || 'feature-branch' }}" >> $GITHUB_OUTPUT
             echo "new_branch=$NEW_BRANCH" >> $GITHUB_OUTPUT
             echo "version=$VERSION" >> $GITHUB_OUTPUT
           else
           echo "Matched config: $CONFIG"
             echo "prebuilt=$(echo "$CONFIG" | jq -r '.prebuilt')" >> $GITHUB_OUTPUT
             echo "environment=$(echo "$CONFIG" | jq -r '.environment')" >> $GITHUB_OUTPUT
-            echo "auto_deploy=$(echo "$CONFIG" | jq -r '.auto_deploy')" >> $GITHUB_OUTPUT
             echo "new_branch=$(echo "$CONFIG" | jq -r '.target_branch')" >> $GITHUB_OUTPUT
             echo "version=$(echo "$CONFIG" | jq -r '.version_prefix // ""')$(date '+%Y.%m.%d')-${{ github.run_number }}" >> $GITHUB_OUTPUT
             echo "extra_version_identifier=$(echo "$CONFIG" | jq -r '.extra_version_identifier // ""')" >> $GITHUB_OUTPUT

--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -9,12 +9,6 @@ env:
   
   # Branch configurations
   STAGING_C3_SOURCE_BRANCH: ${{ vars.STAGING_C3_SOURCE_BRANCH || 'master' }} # vars are set on repo settings.
-  DEV_C3_SOURCE_BRANCH: ${{ vars.DEV_C3_SOURCE_BRANCH || 'master-dev-c3-new' }} # vars are set on repo settings.
-  
-  # Target branch configurations
-  STAGING_TARGET_BRANCH: ${{ vars.STAGING_TARGET_BRANCH || 'staging-c3-new' }} # vars are set on repo settings.
-  DEV_TARGET_BRANCH: ${{ vars.DEV_TARGET_BRANCH || 'dev-c3-new' }} # vars are set on repo settings.
-  RELEASE_TARGET_BRANCH: ${{ vars.RELEASE_TARGET_BRANCH || 'release-c3-new' }} # vars are set on repo settings.
   
   # Runtime configuration
   SOURCE_BRANCH: "${{ github.head_ref || github.ref_name }}"

--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -193,22 +193,28 @@ jobs:
           CONFIG=$(echo "$STRATEGY_JSON" | jq -r --arg branch "$BRANCH" '
             .configs[] | select(.branch == $branch)
           ')
-          echo "Matched config: $CONFIG"
-          echo "::endgroup::"
-
-          echo "prebuilt=$(echo "$CONFIG" | jq -r '.prebuilt')" >> $GITHUB_OUTPUT
-          echo "environment=$(echo "$CONFIG" | jq -r '.environment')" >> $GITHUB_OUTPUT
-          echo "auto_deploy=$(echo "$CONFIG" | jq -r '.auto_deploy')" >> $GITHUB_OUTPUT
-
-          if echo "$CONFIG" | jq -e 'has("version_prefix")'; then
-            VERSION="$(echo "$CONFIG" | jq -r '.version_prefix')-$(date '+%Y.%m.%d')-${{ github.run_number }}"
-          else
+          
+          if [[ -z "$CONFIG" || "$CONFIG" == "null" ]]; then
+            echo "No exact strategy match found. Falling back to feature/fork logic."
+            IS_FORK="${{ github.event.pull_request.head.repo.fork && 'true' || 'false' }}"
+            FORK_SUFFIX=$( [[ "$IS_FORK" == "true" ]] && echo "-fork" || echo "" )
+            NEW_BRANCH="${BRANCH}${FORK_SUFFIX}-prebuilt"
             VERSION="$(date '+%Y.%m.%d')-${{ github.run_number }}"
+  
+            echo "prebuilt=true" >> $GITHUB_OUTPUT
+            echo "environment=dev" >> $GITHUB_OUTPUT
+            echo "auto_deploy=false" >> $GITHUB_OUTPUT
+            echo "new_branch=$NEW_BRANCH" >> $GITHUB_OUTPUT
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+          else
+          echo "Matched config: $CONFIG"
+            echo "prebuilt=$(echo "$CONFIG" | jq -r '.prebuilt')" >> $GITHUB_OUTPUT
+            echo "environment=$(echo "$CONFIG" | jq -r '.environment')" >> $GITHUB_OUTPUT
+            echo "auto_deploy=$(echo "$CONFIG" | jq -r '.auto_deploy')" >> $GITHUB_OUTPUT
+            echo "new_branch=$(echo "$CONFIG" | jq -r '.target_branch')" >> $GITHUB_OUTPUT
+            echo "version=$(echo "$CONFIG" | jq -r '.version_prefix // ""')$(date '+%Y.%m.%d')-${{ github.run_number }}" >> $GITHUB_OUTPUT
+            echo "extra_version_identifier=$(echo "$CONFIG" | jq -r '.extra_version_identifier // ""')" >> $GITHUB_OUTPUT
           fi
-
-          echo "new_branch=$(echo "$CONFIG" | jq -r '.target_branch')" >> $GITHUB_OUTPUT
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "extra_version_identifier=$(echo "$CONFIG" | jq -r '.extra_version_identifier // empty')" >> $GITHUB_OUTPUT
   
   
   publish:


### PR DESCRIPTION
Changes how we do the prebuilt deployments, and makes it more parametrized. On our variables we have `DEPLOY_STRATEGY`

```json
{
    "configs": [
        {
            "branch": "master",
            "prebuilt": "staging-c3-new",
            "environment": "staging"
        }, 
        {
            "branch": "master-dev-c3-new",
            "prebuilt": "dev-c3-new",
            "environment": "dev-c3"
        }
    ]
}
```

whee we set the branch that this config applies to, and the prebuilt it builds, and the environment got GH that it should use. 

When using `staging` environment, it has a delay of 3 days by default before proceeding with the deployment. This is to ensure that the branch has matured enough before rolling out. This allows us to rollback more effectively a change if it introduces changes not spotted during regular testing.

### Where are the variables?

<img width="1183" height="974" alt="image" src="https://github.com/user-attachments/assets/5ddea24a-ed0a-4d59-b08b-bc2e8102075b" />

### Where are the environments?
<img width="1312" height="570" alt="image" src="https://github.com/user-attachments/assets/9a7796ce-70ae-478c-9442-6c905af4d7dc" />

## Summary by Sourcery

Add a strategy extraction step to GitHub Actions that centralizes branch-specific prebuilt deployment settings through a JSON-based `DEPLOY_STRATEGY` variable and refactor existing build and publish jobs to consume these parameters.

Enhancements:
- Add a prepare_strategy job to parse the DEPLOY_STRATEGY variable and compute prebuilt build settings.
- Parameterize branch targets, versioning, and environments based on a JSON config instead of inline shell logic.

CI:
- Refactor GitHub Actions workflow to introduce the prepare_strategy job and adjust job dependencies and outputs accordingly.