### PR TITLE
Revert "ci: update cereal validation repo reference to sunnypilot"

### DIFF
--- a/.github/workflows/cereal_validation.yaml
+++ b/.github/workflows/cereal_validation.yaml
@@ -59,7 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          repository: 'sunnypilot/sunnypilot'
+          repository: 'commaai/openpilot'
           submodules: true
           ref: "refs/heads/master"
       - uses: ./.github/workflows/setup-with-retry


### PR DESCRIPTION
Reverts sunnypilot/sunnypilot#1108

## Summary by Sourcery

CI:
- Restore the repository reference in .github/workflows/cereal_validation.yaml from sunnypilot/sunnypilot to commaai/openpilot