### PR TITLE
Revert "registration required to go onroad"

### DIFF
--- a/system/hardware/hardwared.py
+++ b/system/hardware/hardwared.py
@@ -18,14 +18,13 @@ from openpilot.common.filter_simple import FirstOrderFilter
 from openpilot.common.params import Params
 from openpilot.common.realtime import DT_HW
 from openpilot.selfdrive.selfdrived.alertmanager import set_offroad_alert
-from openpilot.system.hardware import HARDWARE, TICI, AGNOS, PC
+from openpilot.system.hardware import HARDWARE, TICI, AGNOS
 from openpilot.system.loggerd.config import get_available_percent
 from openpilot.system.statsd import statlog
 from openpilot.common.swaglog import cloudlog
 from openpilot.system.hardware.power_monitoring import PowerMonitoring
 from openpilot.system.hardware.fan_controller import TiciFanController
 from openpilot.system.version import terms_version, training_version
-from openpilot.system.athena.registration import UNREGISTERED_DONGLE_ID
 
 ThermalStatus = log.DeviceState.ThermalStatus
 NetworkType = log.DeviceState.NetworkType
@@ -332,12 +331,6 @@ def hardware_thread(end_event, hw_queue) -> None:
     extra_text = f"{offroad_comp_temp:.1f}C"
     show_alert = (not onroad_conditions["device_temp_good"] or not startup_conditions["device_temp_engageable"]) and onroad_conditions["ignition"]
     set_offroad_alert_if_changed("Offroad_TemperatureTooHigh", show_alert, extra_text=extra_text)
-
-    # *** registration check ***
-    if not PC:
-      # we enforce this for our software, but you are welcome
-      # to make a different decision in your software
-      startup_conditions["registered_device"] = PC or (params.get("DongleId") != UNREGISTERED_DONGLE_ID)
 
     # TODO: this should move to TICI.initialize_hardware, but we currently can't import params there
     if TICI and HARDWARE.get_device_type() == "tici":


### PR DESCRIPTION
This reverts commit f4b017a7

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Revert the registration requirement for onroad operation by removing the enforced device registration check in hardwared, renaming the offroad alert to mark unofficial hardware, and cleaning up related imports.

Enhancements:
- Remove enforced registration check in hardware thread to allow onroad operation without a registered dongle
- Rename offroad alert from Offroad_UnregisteredHardware to Offroad_UnofficialHardware
- Remove unused UNREGISTERED_DONGLE_ID import and related parameters