### PR TITLE
chore: sync tinygrad

### DIFF
--- a/.github/workflows/build-all-tinygrad-models.yaml
+++ b/.github/workflows/build-all-tinygrad-models.yaml
@@ -127,7 +127,7 @@ jobs:
   retry_failed_models:
     needs: [setup, get_and_build]
     runs-on: ubuntu-latest
-    if: ${{ needs.setup.result != 'failure' && (failure() && !cancelled()) }}
+    if: ${{ needs.setup.result != 'failure' && !cancelled() }}
     outputs:
       retry_matrix: ${{ steps.set-retry-matrix.outputs.retry_matrix }}
     steps:

--- a/sunnypilot/models/fetcher.py
+++ b/sunnypilot/models/fetcher.py
@@ -114,7 +114,7 @@ class ModelCache:
 
 class ModelFetcher:
   """Handles fetching and caching of model data from remote source"""
-  MODEL_URL = "https://docs.sunnypilot.ai/driving_models_v6.json"
+  MODEL_URL = "https://docs.sunnypilot.ai/driving_models_v7.json"
 
   def __init__(self, params: Params):
     self.params = params

--- a/sunnypilot/models/helpers.py
+++ b/sunnypilot/models/helpers.py
@@ -19,8 +19,8 @@ from openpilot.system.hardware.hw import Paths
 from pathlib import Path
 
 # see the README.md for more details on the model selector versioning
-CURRENT_SELECTOR_VERSION = 8
-REQUIRED_MIN_SELECTOR_VERSION = 8
+CURRENT_SELECTOR_VERSION = 9
+REQUIRED_MIN_SELECTOR_VERSION = 9
 
 USE_ONNX = os.getenv('USE_ONNX', PC)
 


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Increment CURRENT_SELECTOR_VERSION and REQUIRED_MIN_SELECTOR_VERSION from 8 to 9 in the model selector helper to maintain sync with tinygrad