### PR TITLE
Fix "Default" interactivity timeout display

### DIFF
--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/device_panel.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/device_panel.cc
@@ -211,7 +211,7 @@ void DevicePanelSP::updateState() {
   toggleDeviceBootMode->setDescription(deviceSleepModeDescription(currStatus));
 
   QString timeoutValue = QString::fromStdString(params.get("InteractivityTimeout"));
-  if (timeoutValue == "0") {
+  if (timeoutValue == "0" || timeoutValue.isEmpty()) {
     interactivityTimeout->setLabel("Default");
   } else {
     interactivityTimeout->setLabel(timeoutValue + "s");


### PR DESCRIPTION
If param `InteractivityTimeout` does not exist, timeoutValue == "", resulting in the Interactivity Timeout UI displaying "s" by default.

Fix displayed "Default" by checking for "0" or "".

# Before
<img width="2241" height="1453" alt="image" src="https://github.com/user-attachments/assets/d4625bc0-dd19-436f-84ff-6a9300ec73cb" />

# After
<img width="2409" height="1453" alt="image" src="https://github.com/user-attachments/assets/2f09de70-dc27-4440-986e-8906021a6c88" />

## Summary by Sourcery

Bug Fixes:
- Show "Default" label for interactivity timeout when the parameter is empty or "0" instead of displaying "s"