### PR TITLE
sunnypilot modeld_v2: no action head refactor for gen13

### DIFF
--- a/sunnypilot/modeld_v2/modeld.py
+++ b/sunnypilot/modeld_v2/modeld.py
@@ -332,7 +332,7 @@ def main(demo=False):
       'traffic_convention': traffic_convention,
     }
 
-    if "lateral_control_params" in model.numpy_inputs.keys() and model.no_action_head:
+    if "lateral_control_params" in model.numpy_inputs.keys() and not model.no_action_head:
       inputs['lateral_control_params'] = np.array([v_ego, lat_delay], dtype=np.float32)
 
     mt1 = time.perf_counter()

--- a/sunnypilot/models/helpers.py
+++ b/sunnypilot/models/helpers.py
@@ -19,7 +19,7 @@ from openpilot.system.hardware.hw import Paths
 from pathlib import Path
 
 # see the README.md for more details on the model selector versioning
-CURRENT_SELECTOR_VERSION = 9
+CURRENT_SELECTOR_VERSION = 10
 REQUIRED_MIN_SELECTOR_VERSION = 9
 
 USE_ONNX = os.getenv('USE_ONNX', PC)


### PR DESCRIPTION
https://github.com/commaai/openpilot/pull/36000/files

## Summary by Sourcery

Introduce a no_action_head flag for gen13+ models to disable action head buffer initialization and inputs, and bump the model selector version.

Enhancements:
- Add no_action_head property to detect generation 13+ and refactor modeld to skip action head buffer setup and input mapping accordingly

Build:
- Increment CURRENT_SELECTOR_VERSION to 10