### PR TITLE
ui: display thousandths place on lagd toggle

### DIFF
--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/models_panel.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/models_panel.cc
@@ -393,7 +393,7 @@ void ModelsPanel::updateLabels() {
         auto liveDelay = event.getLiveDelay();
         float lateralDelay = liveDelay.getLateralDelay();
         desc += QString("<br><br><b><span style=\"color:#e0e0e0\">%1</span></b> <span style=\"color:#e0e0e0\">%2 s</span>")
-                .arg(tr("Live Steer Delay:")).arg(QString::number(lateralDelay, 'f', 2));
+                .arg(tr("Live Steer Delay:")).arg(QString::number(lateralDelay, 'f', 3));
       }
     }
   } else {


### PR DESCRIPTION
Models -> Live delay as of a few weeks ago displayed the estimated live delay to the thousandsth place. That was useful while debugging to be able to see typical variation during a drive like ±0.5 most of which you wouldn't see with the thousandsth digit hidden. You also wouldn't see bigger changes like between 0.300 and 0.309.

(Unfortunately changes this small did actually matter during a drive. [I intend to investigate this further.](https://github.com/sunnypilot/sunnypilot/pull/1027#issuecomment-3047118883))

This change restores visibility. It is only a display change. 

<img width="3757" height="2410" alt="image" src="https://github.com/user-attachments/assets/b2f8fe83-b459-4bdf-8ce0-db1260e1eaab" />

## Summary by Sourcery

Enhancements:
- Show live steer delay with three decimal places instead of two to reveal typical variation