### PR TITLE
param_store: update list every 3 seconds

### DIFF
--- a/sunnypilot/selfdrive/controls/lib/param_store.py
+++ b/sunnypilot/selfdrive/controls/lib/param_store.py
@@ -24,11 +24,16 @@ class ParamStore:
     self.values = {}
     self.cached_params_list: list[capnp.lib.capnp._DynamicStructBuilder] | None = None
 
+    self.frame = 0
+
   def update(self, params: Params) -> None:
-    old_values = dict(self.values)
-    self.values = {k: params.get(k) or "0" for k in self.keys}
-    if old_values != self.values:
-      self.cached_params_list = None
+    if self.frame % 300 == 0:
+      old_values = dict(self.values)
+      self.values = {k: params.get(k) or "0" for k in self.keys}
+      if old_values != self.values:
+        self.cached_params_list = None
+
+    self.frame += 1
 
   def publish(self) -> list[capnp.lib.capnp._DynamicStructBuilder]:
     if self.cached_params_list is None:


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Reduce overhead in param_store by updating and invalidating the cached parameter list only once every 300 frames.

Enhancements:
- Throttle param_store.update calls to run only every 300 frames (~3 seconds)
- Introduce frame counter to manage update intervals and maintain cached parameter list