### PR TITLE
bugfix: fix fetching params for sunnylink and backup

### DIFF
--- a/sunnypilot/sunnylink/athena/sunnylinkd.py
+++ b/sunnypilot/sunnylink/athena/sunnylinkd.py
@@ -169,11 +169,20 @@ def getParamsAllKeys() -> list[str]:
   return keys
 
 
+def as_bytes(value):
+  if isinstance(value, bytes):
+    return value
+  elif isinstance(value, str):
+    return value.encode('utf-8')
+  else:
+    return str(value).encode('utf-8')
+
+
 @dispatcher.add_method
 def getParams(params_keys: list[str], compression: bool = False) -> str | dict[str, str]:
   try:
     params = Params()
-    params_dict: dict[str, bytes] = {key: params.get(key) or b'' for key in params_keys}
+    params_dict: dict[str, bytes] = {key: as_bytes(params.get(key)) or b'' for key in params_keys}
 
     # Compress the values before encoding to base64 as output from params.get is bytes and same for compression
     if compression:

--- a/sunnypilot/sunnylink/athena/sunnylinkd.py
+++ b/sunnypilot/sunnylink/athena/sunnylinkd.py
@@ -169,20 +169,11 @@ def getParamsAllKeys() -> list[str]:
   return keys
 
 
-def as_bytes(value):
-  if isinstance(value, bytes):
-    return value
-  elif isinstance(value, str):
-    return value.encode('utf-8')
-  else:
-    return str(value).encode('utf-8')
-
-
 @dispatcher.add_method
 def getParams(params_keys: list[str], compression: bool = False) -> str | dict[str, str]:
   try:
     params = Params()
-    params_dict: dict[str, bytes] = {key: as_bytes(params.get(key)) or b'' for key in params_keys}
+    params_dict: dict[str, bytes] = {key: params.get(key) or b'' for key in params_keys}
 
     # Compress the values before encoding to base64 as output from params.get is bytes and same for compression
     if compression:

--- a/sunnypilot/sunnylink/athena/sunnylinkd.py
+++ b/sunnypilot/sunnylink/athena/sunnylinkd.py
@@ -12,7 +12,7 @@ import time
 
 from jsonrpc import dispatcher
 from functools import partial
-from openpilot.common.params import Params, ParamKeyType
+from openpilot.common.params import Params
 from openpilot.common.realtime import set_core_affinity
 from openpilot.common.swaglog import cloudlog
 from openpilot.system.athena.athenad import ws_send, jsonrpc_handler, \

--- a/sunnypilot/sunnylink/athena/sunnylinkd.py
+++ b/sunnypilot/sunnylink/athena/sunnylinkd.py
@@ -194,7 +194,8 @@ def getParams(params_keys: list[str], compression: bool = False) -> str | dict[s
         "is_compressed": compression
       } for key in param_keys_validated
     ]}
-
+    
+    # TODO-SP: Make the server support the entire dict so we can return more metadata
     # Last step is to encode the values to base64 and decode to utf-8 for JSON serialization
     return {param.get('key'): base64.b64encode(param.get('value')).decode('utf-8') for param in params_dict.get("params")}
 

--- a/sunnypilot/sunnylink/athena/sunnylinkd.py
+++ b/sunnypilot/sunnylink/athena/sunnylinkd.py
@@ -185,7 +185,7 @@ def getParams(params_keys: list[str], compression: bool = False) -> str | dict[s
 
   try:
     param_keys_validated = [key for key in params_keys if key in getParamsAllKeys()]
-    params_dict: dict[str, list[dict[str, str]]] = {"params": [
+    params_dict = {"params": [
       {
         "key": key,
         "value": base64.b64encode(gzip.compress(get_param_as_byte(key)) if compression else get_param_as_byte(key)).decode('utf-8'),

--- a/sunnypilot/sunnylink/athena/sunnylinkd.py
+++ b/sunnypilot/sunnylink/athena/sunnylinkd.py
@@ -178,7 +178,7 @@ def getParams(params_keys: list[str], compression: bool = False) -> str | dict[s
     param_type = params.get_type(param_name)
 
     if param_type == ParamKeyType.BYTES:
-      return param
+      return bytes(param)
     elif param_type == ParamKeyType.JSON:
       return json.dumps(param).encode('utf-8')
     return str(param).encode('utf-8')
@@ -194,7 +194,7 @@ def getParams(params_keys: list[str], compression: bool = False) -> str | dict[s
       } for key in param_keys_validated
     ]}
 
-    response = {param.get('key'): param.get('value') for param in params_dict.get("params", [])}
+    response = {str(param.get('key')): str(param.get('value')) for param in params_dict.get("params", [])}
     response |= {"params": json.dumps(params_dict.get("params", []))} # Upcoming for settings v1
     return response
 

--- a/sunnypilot/sunnylink/athena/sunnylinkd.py
+++ b/sunnypilot/sunnylink/athena/sunnylinkd.py
@@ -22,7 +22,7 @@ from websocket import (ABNF, WebSocket, WebSocketException, WebSocketTimeoutExce
 
 import cereal.messaging as messaging
 from sunnypilot.sunnylink.api import SunnylinkApi
-from sunnypilot.sunnylink.utils import sunnylink_need_register, sunnylink_ready
+from sunnypilot.sunnylink.utils import sunnylink_need_register, sunnylink_ready, get_param_as_byte
 
 SUNNYLINK_ATHENA_HOST = os.getenv('SUNNYLINK_ATHENA_HOST', 'wss://ws.stg.api.sunnypilot.ai')
 HANDLER_THREADS = int(os.getenv('HANDLER_THREADS', "4"))
@@ -173,15 +173,6 @@ def getParamsAllKeys() -> list[str]:
 @dispatcher.add_method
 def getParams(params_keys: list[str], compression: bool = False) -> str | dict[str, str]:
   params = Params()
-  def get_param_as_byte(param_name: str) -> bytes:
-    param = params.get(param_name)
-    param_type = params.get_type(param_name)
-
-    if param_type == ParamKeyType.BYTES:
-      return bytes(param)
-    elif param_type == ParamKeyType.JSON:
-      return json.dumps(param).encode('utf-8')
-    return str(param).encode('utf-8')
 
   try:
     param_keys_validated = [key for key in params_keys if key in getParamsAllKeys()]

--- a/sunnypilot/sunnylink/athena/sunnylinkd.py
+++ b/sunnypilot/sunnylink/athena/sunnylinkd.py
@@ -10,10 +10,9 @@ import ssl
 import threading
 import time
 
-from common.params_pyx import ParamKeyType
 from jsonrpc import dispatcher
 from functools import partial
-from openpilot.common.params import Params
+from openpilot.common.params import Params, ParamKeyType
 from openpilot.common.realtime import set_core_affinity
 from openpilot.common.swaglog import cloudlog
 from openpilot.system.athena.athenad import ws_send, jsonrpc_handler, \
@@ -194,7 +193,7 @@ def getParams(params_keys: list[str], compression: bool = False) -> str | dict[s
         "is_compressed": compression
       } for key in param_keys_validated
     ]}
-    
+
     # TODO-SP: Make the server support the entire dict so we can return more metadata
     # Last step is to encode the values to base64 and decode to utf-8 for JSON serialization
     return {param.get('key'): base64.b64encode(param.get('value')).decode('utf-8') for param in params_dict.get("params")}

--- a/sunnypilot/sunnylink/athena/sunnylinkd.py
+++ b/sunnypilot/sunnylink/athena/sunnylinkd.py
@@ -185,7 +185,7 @@ def getParams(params_keys: list[str], compression: bool = False) -> str | dict[s
 
   try:
     param_keys_validated = [key for key in params_keys if key in getParamsAllKeys()]
-    params_dict:  dict[str, list[dict[str, str | bool]]] = {"params": [
+    params_dict:  dict[str, list[dict[str, str | bool | int ]]] = {"params": [
       {
         "key": key,
         "value": base64.b64encode(gzip.compress(get_param_as_byte(key)) if compression else get_param_as_byte(key)).decode('utf-8'),

--- a/sunnypilot/sunnylink/athena/sunnylinkd.py
+++ b/sunnypilot/sunnylink/athena/sunnylinkd.py
@@ -188,15 +188,14 @@ def getParams(params_keys: list[str], compression: bool = False) -> str | dict[s
     params_dict: dict[str, list[dict[str, str]]] = {"params": [
       {
         "key": key,
-        "value": gzip.compress(get_param_as_byte(key)) if compression else get_param_as_byte(key),
+        "value": base64.b64encode(gzip.compress(get_param_as_byte(key)) if compression else get_param_as_byte(key)).decode('utf-8'),
         "type": params.get_type(key),
         "is_compressed": compression
       } for key in param_keys_validated
     ]}
 
     # TODO-SP: Make the server support the entire dict so we can return more metadata
-    # Last step is to encode the values to base64 and decode to utf-8 for JSON serialization
-    return {param.get('key'): base64.b64encode(param.get('value')).decode('utf-8') for param in params_dict.get("params")}
+    return {param.get('key'): param.get('value') for param in params_dict.get("params")}
 
   except Exception as e:
     cloudlog.exception("sunnylinkd.getParams.exception", e)

--- a/sunnypilot/sunnylink/backups/manager.py
+++ b/sunnypilot/sunnylink/backups/manager.py
@@ -20,6 +20,7 @@ from openpilot.system.version import get_version
 from cereal import messaging, custom
 from sunnypilot.sunnylink.api import SunnylinkApi
 from sunnypilot.sunnylink.backups.utils import decrypt_compressed_data, encrypt_compress_data, SnakeCaseEncoder
+from sunnypilot.sunnylink.utils import get_param_as_byte
 
 
 class OperationType(Enum):
@@ -74,7 +75,7 @@ class BackupManagerSP:
     config_data = {}
     params_to_backup = [k.decode('utf-8') for k in self.params.all_keys(ParamKeyFlag.BACKUP)]
     for param in params_to_backup:
-      value = str(self.params.get(param)).encode('utf-8')
+      value = get_param_as_byte(param)
       if value is not None:
         config_data[param] = base64.b64encode(value).decode('utf-8')
     return config_data

--- a/sunnypilot/sunnylink/utils.py
+++ b/sunnypilot/sunnylink/utils.py
@@ -1,5 +1,6 @@
+import json
 from sunnypilot.sunnylink.api import SunnylinkApi, UNREGISTERED_SUNNYLINK_DONGLE_ID
-from openpilot.common.params import Params
+from openpilot.common.params import Params, ParamKeyType
 from openpilot.system.version import is_prebuilt
 
 
@@ -55,3 +56,15 @@ def get_api_token():
   sunnylink_api = SunnylinkApi(sunnylink_dongle_id)
   token = sunnylink_api.get_token()
   print(f"API Token: {token}")
+
+
+def get_param_as_byte(param_name: str) -> bytes:
+  params = Params()
+  param = params.get(param_name)
+  param_type = params.get_type(param_name)
+
+  if param_type == ParamKeyType.BYTES:
+    return bytes(param)
+  elif param_type == ParamKeyType.JSON:
+    return json.dumps(param).encode('utf-8')
+  return str(param).encode('utf-8')


### PR DESCRIPTION
## Summary by Sourcery

Improve the getParams method to reliably convert parameter values to bytes based on their type, filter out invalid keys, and apply optional per-parameter compression before base64 encoding.

Bug Fixes:
- Ensure getParams consistently converts returned parameter values to bytes prior to encoding

Enhancements:
- Add get_param_as_byte helper to coerce parameter values to bytes for bytes, JSON, and other types
- Validate requested keys against getParamsAllKeys to exclude unsupported parameters
- Compress each parameter value conditionally when the compression flag is set