### PR TITLE
ui: sunnylink panel title & message

### DIFF
--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/sunnylink_panel.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/sunnylink_panel.cc
@@ -34,6 +34,27 @@ SunnylinkPanel::SunnylinkPanel(QWidget *parent) : QFrame(parent) {
   vlayout->setContentsMargins(50, 20, 50, 20);
 
   auto *list = new ListWidget(this, false);
+
+  QVBoxLayout *titleLayout = new QVBoxLayout;
+  QLabel *title = new QLabel(tr("🚀 sunnylink 🚀"));
+  title->setStyleSheet("font-size: 90px; font-weight: 500; font-family: 'Noto Color Emoji';");
+  titleLayout->addWidget(title, 0, Qt::AlignCenter);
+
+  QLabel *sunnylinkDesc = new QLabel("<div align='center'><font color='green'>"+
+    tr("For secure backup, restore, and remote configuration")+ "</font></div>");
+
+  QLabel *sponsorMsg = new QLabel("<div align='center'><font color='orange'>"+
+    tr("Sponsorship isn't required for basic backup/restore") + "<br>" +
+       tr("Click the sponsor button for more details")+ "</font></div>");
+
+  sunnylinkDesc->setStyleSheet("font-size: 40px; font-weight: 100; font-family: 'Noto';");
+  sponsorMsg->setStyleSheet("font-size: 35px; font-weight: 100; font-family: 'Noto';");
+
+  titleLayout->addWidget(sunnylinkDesc, 0, Qt::AlignCenter);
+  titleLayout->addWidget(sponsorMsg, 0, Qt::AlignCenter);
+
+  list->addItem(titleLayout);
+
   QString sunnylinkEnabledBtnDesc = tr("This is the master switch, it will allow you to cutoff any sunnylink requests should you want to do that.");
   sunnylinkEnabledBtn = new ParamControl(
     "SunnylinkEnabled",


### PR DESCRIPTION
## Summary by Sourcery

Add a styled title and informational messages to the sunnylink settings panel.

Enhancements:
- Introduce a centered '🚀 sunnylink 🚀' header with large emoji font
- Add descriptive text about secure backup/restore and sponsorship details below the title