### PR TITLE
audio: harden micd/soundd init (explicit ALSA device) + raise deleter free-space thresholds

### DIFF
--- a/system/loggerd/deleter.py
+++ b/system/loggerd/deleter.py
@@ -10,8 +10,8 @@ from openpilot.system.loggerd.config import get_available_bytes, get_available_p
 from openpilot.system.loggerd.uploader import listdir_by_creation
 from openpilot.system.loggerd.xattr_cache import getxattr
 
-MIN_BYTES = 5 * 1024 * 1024 * 1024
-MIN_PERCENT = 10
+MIN_BYTES = 15 * 1024 * 1024 * 1024
+MIN_PERCENT = 30
 
 DELETE_LAST = ['boot', 'crash']
 


### PR DESCRIPTION
### Description
> This PR is for discussion and reference only. I’m not seeking to merge it.

- Harden audio init on tici: after PortAudio re-init, wait for ALSA default devices and open mic/speaker with explicit device indices; keep a generous retry window (60×, 3s).
- Raise loggerd deleter thresholds (≥15 GB or ≥30%) to reduce I/O pressure that seemed to exacerbate audio init races.

What it fixes
- Intermittent audio init failures at boot leading to `micd`/`soundd` exits, `loggerd` qcam frame drops while waiting for audio, and `process_not_running`.

Changes
- micd/soundd: wait up to 30s for valid ALSA defaults; open `InputStream`/`OutputStream` with explicit device index; retries = 60.
- deleter: trigger cleanup below 15 GB or 30% free.

Note on I/O pressure (hypothesis)
- The deleter change is based on my observation: fresh installs (more free space) show fewer errors; nearly-full devices show more. This is a mitigation; the audio init fix stands alone.

Reporter experience
- I ran into “Process not running” almost daily recently; with this change, audio starts reliably and the issue hasn’t reappeared.

Exact error snippets (from my logs)
```text
sounddevice.PortAudioError: Error querying device -1
get_stream failed, trying again
qRoadEncodeData: dropping frame waiting for audio initialization, queue is too large
qRoadEncodeData: dropping frame, queue is too large
process_not_running {'soundd', 'micd'}
process_not_running {'soundd', 'loggerd', 'micd'}
```

[250827.bad.log](https://github.com/user-attachments/files/22037364/250827.bad.log)

## Summary by Sourcery

Improve audio initialization reliability on tici by explicitly waiting for ALSA default devices and extending retry logic, and reduce storage I/O pressure by raising loggerd free-space deletion thresholds.

Enhancements:
- Harden micd and soundd audio initialization by extending retries to 60 attempts, waiting up to 30s for valid ALSA default devices, and opening streams with explicit device indices
- Raise loggerd deleter thresholds from 5 GB/10% to 15 GB/30% free space to reduce I/O pressure