### PR TITLE
ci: tweaking the deploy with delay process + fixing bugs

### DIFF
--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -235,7 +235,7 @@ jobs:
   
   publish:
     concurrency:
-      # We do a bit of a hack here to avoid cancelling the publishing job if a new commit comes in while we're publishing by adding the sha to the group name.
+      # We do a bit of a hack here to avoid canceling the publishing job if a new commit comes in while we're publishing by adding the sha to the group name.
       # This means that if multiple commits come in while we're publishing, they will be queued up and publish one after the other.
       # Otherwise, if a job is waiting to be published due to environment wait time, it would be canceled by a new commit and restart the wait time.
       group: ${{ needs.prepare_strategy.outputs.publish_concurrency_group }}

--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -180,6 +180,7 @@ jobs:
       new_branch: ${{ steps.strategy.outputs.new_branch }}
       extra_version_identifier: ${{ steps.strategy.outputs.extra_version_identifier }}
       version: ${{ steps.strategy.outputs.version }}
+      cancel_publish_in_progress": ${{ steps.strategy.outputs.cancel_publish_in_progress }}
     steps:
       - name: Extract deploy strategy
         id: strategy
@@ -211,13 +212,14 @@ jobs:
             echo "new_branch=$(echo "$CONFIG" | jq -r '.target_branch')" >> $GITHUB_OUTPUT
             echo "version=$(echo "$CONFIG" | jq -r '.version_prefix // ""')$(date '+%Y.%m.%d')-${{ github.run_number }}" >> $GITHUB_OUTPUT
             echo "extra_version_identifier=$(echo "$CONFIG" | jq -r '.extra_version_identifier // ""')" >> $GITHUB_OUTPUT
+            echo "cancel_publish_in_progress=$(echo "$CONFIG" | jq -r '.cancel_publish_in_progress // true')" >> $GITHUB_OUTPUT
           fi
   
   
   publish:
     concurrency:
       group: publish-${{ github.head_ref || github.ref_name }}
-      cancel-in-progress: ${{ vars.CANCEL_PUBLISH_IN_PROGRESS }}
+      cancel-in-progress: ${{ needs.prepare_strategy.outputs.cancel_publish_in_progress }}
     if: ${{ (always() && !failure() && !cancelled()) && (!contains(github.event_name, 'pull_request') || (github.event.action == 'labeled' && github.event.label.name == 'prebuilt')) }}
     needs: [ build, prepare_strategy ]
     runs-on: ubuntu-24.04

--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -217,7 +217,7 @@ jobs:
   publish:
     concurrency:
       group: publish-${{ github.head_ref || github.ref_name }}
-      cancel-in-progress: true
+      cancel-in-progress: false
     if: ${{ (always() && !failure() && !cancelled()) && (!contains(github.event_name, 'pull_request') || (github.event.action == 'labeled' && github.event.label.name == 'prebuilt')) }}
     needs: [ build, prepare_strategy ]
     runs-on: ubuntu-24.04

--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -217,7 +217,7 @@ jobs:
   publish:
     concurrency:
       group: publish-${{ github.head_ref || github.ref_name }}
-      cancel-in-progress: false
+      cancel-in-progress: ${{ env.CANCEL_PUBLISH_IN_PROGRESS }}
     if: ${{ (always() && !failure() && !cancelled()) && (!contains(github.event_name, 'pull_request') || (github.event.action == 'labeled' && github.event.label.name == 'prebuilt')) }}
     needs: [ build, prepare_strategy ]
     runs-on: ubuntu-24.04

--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -223,7 +223,7 @@ jobs:
     concurrency:
       # We do a bit of a hack here to avoid cancelling the publishing job if a new commit comes in while we're publishing by adding the sha to the group name.
       # This means that if multiple commits come in while we're publishing, they will be queued up and publish one after the other.
-      # Otherwise, if a job is waiting to be published due to environment wait time, it would be canceled by a new commit and restart the wait time. 
+      # Otherwise, if a job is waiting to be published due to environment wait time, it would be canceled by a new commit and restart the wait time.
       group: ${{ needs.prepare_strategy.outputs.publish_concurrency_group }}
       cancel-in-progress: ${{ needs.prepare_strategy.outputs.cancel_publish_in_progress == 'true' }}
     if: ${{ (always() && !failure() && !cancelled()) && (!contains(github.event_name, 'pull_request') || (github.event.action == 'labeled' && github.event.label.name == 'prebuilt')) }}

--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -206,6 +206,8 @@ jobs:
             echo "environment=${{ (contains(fromJSON(vars.AUTO_DEPLOY_PREBUILT_BRANCHES), github.head_ref || github.ref_name) || contains(github.event.pull_request.labels.*.name, 'prebuilt')) && 'auto-deploy' || 'feature-branch' }}" >> $GITHUB_OUTPUT
             echo "new_branch=$NEW_BRANCH" >> $GITHUB_OUTPUT
             echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "cancel_publish_in_progress=true" >> $GITHUB_OUTPUT
+            echo "publish_concurrency_group=publish-${BRANCH}" >> $GITHUB_OUTPUT
           else
           echo "Matched config: $CONFIG"
             echo "prebuilt=$(echo "$CONFIG" | jq -r '.prebuilt')" >> $GITHUB_OUTPUT
@@ -214,7 +216,7 @@ jobs:
             echo "version=$(echo "$CONFIG" | jq -r '.version_prefix // ""')$(date '+%Y.%m.%d')-${{ github.run_number }}" >> $GITHUB_OUTPUT
             echo "extra_version_identifier=$(echo "$CONFIG" | jq -r '.extra_version_identifier // ""')" >> $GITHUB_OUTPUT
             echo "cancel_publish_in_progress=$(echo "$CONFIG" | jq -r '.cancel_publish_in_progress // true')" >> $GITHUB_OUTPUT
-            echo "publish_concurrency_group=publish-${{ github.head_ref || github.ref_name }}${{ needs.prepare_strategy.outputs.cancel_publish_in_progress != 'true' && github.sha || '' }}" >> $GITHUB_OUTPUT 
+            echo "publish_concurrency_group=publish-${BRANCH}${{ needs.prepare_strategy.outputs.cancel_publish_in_progress != 'true' && github.sha }}" >> $GITHUB_OUTPUT 
           fi
   
   
@@ -223,11 +225,10 @@ jobs:
       # We do a bit of a hack here to avoid cancelling the publishing job if a new commit comes in while we're publishing by adding the sha to the group name.
       # This means that if multiple commits come in while we're publishing, they will be queued up and publish one after the other.
       # Otherwise, if a job is waiting to be published due to environment wait time, it would be canceled by a new commit and restart the wait time. 
-      group: publish-${{ github.head_ref || github.ref_name }}${{ needs.prepare_strategy.outputs.cancel_publish_in_progress != 'true' && github.sha || '' }}
+      group: ${{ needs.prepare_strategy.outputs.publish_concurrency_group }}
       cancel-in-progress: ${{ needs.prepare_strategy.outputs.cancel_publish_in_progress == 'true' }}
     if: ${{ (always() && !failure() && !cancelled()) && (!contains(github.event_name, 'pull_request') || (github.event.action == 'labeled' && github.event.label.name == 'prebuilt')) }}
     needs: [ build, prepare_strategy ]
-    name: publish-${{ github.head_ref || github.ref_name }}${{ needs.prepare_strategy.outputs.cancel_publish_in_progress != 'true' && github.sha || '' }}
     runs-on: ubuntu-24.04
     environment: ${{ needs.prepare_strategy.outputs.environment }}
     steps:

--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -221,10 +221,11 @@ jobs:
       # We do a bit of a hack here to avoid cancelling the publishing job if a new commit comes in while we're publishing by adding the sha to the group name.
       # This means that if multiple commits come in while we're publishing, they will be queued up and publish one after the other.
       # Otherwise, if a job is waiting to be published due to environment wait time, it would be canceled by a new commit and restart the wait time. 
-      group: publish-${{ github.head_ref || github.ref_name }}${{ needs.prepare_strategy.outputs.cancel_publish_in_progress != 'true' && github.sha }}
+      group: publish-${{ github.head_ref || github.ref_name }}${{ needs.prepare_strategy.outputs.cancel_publish_in_progress != 'true' && github.sha || '' }}
       cancel-in-progress: ${{ needs.prepare_strategy.outputs.cancel_publish_in_progress == 'true' }}
     if: ${{ (always() && !failure() && !cancelled()) && (!contains(github.event_name, 'pull_request') || (github.event.action == 'labeled' && github.event.label.name == 'prebuilt')) }}
     needs: [ build, prepare_strategy ]
+    name: publish-${{ github.head_ref || github.ref_name }}${{ needs.prepare_strategy.outputs.cancel_publish_in_progress != 'true' && github.sha || '' }}
     runs-on: ubuntu-24.04
     environment: ${{ needs.prepare_strategy.outputs.environment }}
     steps:

--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -28,6 +28,52 @@ on:
         default: false
 
 jobs:
+  prepare_strategy:
+    runs-on: ubuntu-24.04
+    outputs:
+      environment: ${{ steps.strategy.outputs.environment }}
+      new_branch: ${{ steps.strategy.outputs.new_branch }}
+      extra_version_identifier: ${{ steps.strategy.outputs.extra_version_identifier }}
+      version: ${{ steps.strategy.outputs.version }}
+      cancel_publish_in_progress: ${{ steps.strategy.outputs.cancel_publish_in_progress }}
+      publish_concurrency_group: ${{ steps.strategy.outputs.publish_concurrency_group }}
+    steps:
+      - name: Extract deploy strategy
+        id: strategy
+        run: |
+          echo '::group::Strategy Extraction'
+          BRANCH="${{ github.head_ref || github.ref_name }}"
+          echo "Current branch: $BRANCH"
+
+          STRATEGY_JSON='${{ vars.DEPLOY_STRATEGY }}'
+          CONFIG=$(echo "$STRATEGY_JSON" | jq -r --arg branch "$BRANCH" '
+            .configs[] | select(.branch == $branch)
+          ')
+
+          if [[ -z "$CONFIG" || "$CONFIG" == "null" ]]; then
+            echo "No exact strategy match found. Falling back to feature/fork logic."
+            IS_FORK="${{ github.event.pull_request.head.repo.fork && 'true' || 'false' }}"
+            FORK_SUFFIX=$( [[ "$IS_FORK" == "true" ]] && echo "-fork" || echo "" )
+            NEW_BRANCH="${BRANCH}${FORK_SUFFIX}-prebuilt"
+            VERSION="$(date '+%Y.%m.%d')-${{ github.run_number }}"
+
+            echo "environment=${{ (contains(fromJSON(vars.AUTO_DEPLOY_PREBUILT_BRANCHES), github.head_ref || github.ref_name) || contains(github.event.pull_request.labels.*.name, 'prebuilt')) && 'auto-deploy' || 'feature-branch' }}" >> $GITHUB_OUTPUT
+            echo "new_branch=$NEW_BRANCH" >> $GITHUB_OUTPUT
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "cancel_publish_in_progress=true" >> $GITHUB_OUTPUT
+            echo "publish_concurrency_group=publish-${BRANCH}" >> $GITHUB_OUTPUT
+          else
+          echo "Matched config: $CONFIG"
+            echo "environment=$(echo "$CONFIG" | jq -r '.environment')" >> $GITHUB_OUTPUT
+            echo "new_branch=$(echo "$CONFIG" | jq -r '.target_branch')" >> $GITHUB_OUTPUT
+            echo "version=$(echo "$CONFIG" | jq -r '.version_prefix // ""')$(date '+%Y.%m.%d')-${{ github.run_number }}" >> $GITHUB_OUTPUT
+            echo "extra_version_identifier=$(echo "$CONFIG" | jq -r '.extra_version_identifier // ""')" >> $GITHUB_OUTPUT
+            cancel="$(echo "$CONFIG" | jq -r '.cancel_publish_in_progress')";
+            echo "cancel_publish_in_progress=$( [ "$cancel" = "null" ] && echo "true" || echo $cancel)" >> $GITHUB_OUTPUT
+            echo "publish_concurrency_group=publish-${BRANCH}$( [ "$cancel" = "null" ] || [ "$cancel" = "true" ] || echo "${{ github.sha }}" )" >> $GITHUB_OUTPUT 
+          fi
+          cat $GITHUB_OUTPUT
+  
   validate_tests:
     runs-on: ubuntu-24.04
     if: ((github.event_name == 'workflow_dispatch' && inputs.wait_for_tests) || contains(github.event_name, 'pull_request') && (github.event.action == 'labeled' && github.event.label.name == 'prebuilt'))
@@ -176,52 +222,6 @@ jobs:
         if: always()
         run: |
           PYTHONPATH=$PYTHONPATH:${{ github.workspace }}/ ${{ github.workspace }}/scripts/manage-powersave.py --enable
-          
-  prepare_strategy:
-    runs-on: ubuntu-24.04
-    outputs:
-      environment: ${{ steps.strategy.outputs.environment }}
-      new_branch: ${{ steps.strategy.outputs.new_branch }}
-      extra_version_identifier: ${{ steps.strategy.outputs.extra_version_identifier }}
-      version: ${{ steps.strategy.outputs.version }}
-      cancel_publish_in_progress: ${{ steps.strategy.outputs.cancel_publish_in_progress }}
-      publish_concurrency_group: ${{ steps.strategy.outputs.publish_concurrency_group }}
-    steps:
-      - name: Extract deploy strategy
-        id: strategy
-        run: |
-          echo '::group::Strategy Extraction'
-          BRANCH="${{ github.head_ref || github.ref_name }}"
-          echo "Current branch: $BRANCH"
-
-          STRATEGY_JSON='${{ vars.DEPLOY_STRATEGY }}'
-          CONFIG=$(echo "$STRATEGY_JSON" | jq -r --arg branch "$BRANCH" '
-            .configs[] | select(.branch == $branch)
-          ')
-          
-          if [[ -z "$CONFIG" || "$CONFIG" == "null" ]]; then
-            echo "No exact strategy match found. Falling back to feature/fork logic."
-            IS_FORK="${{ github.event.pull_request.head.repo.fork && 'true' || 'false' }}"
-            FORK_SUFFIX=$( [[ "$IS_FORK" == "true" ]] && echo "-fork" || echo "" )
-            NEW_BRANCH="${BRANCH}${FORK_SUFFIX}-prebuilt"
-            VERSION="$(date '+%Y.%m.%d')-${{ github.run_number }}"
-  
-            echo "environment=${{ (contains(fromJSON(vars.AUTO_DEPLOY_PREBUILT_BRANCHES), github.head_ref || github.ref_name) || contains(github.event.pull_request.labels.*.name, 'prebuilt')) && 'auto-deploy' || 'feature-branch' }}" >> $GITHUB_OUTPUT
-            echo "new_branch=$NEW_BRANCH" >> $GITHUB_OUTPUT
-            echo "version=$VERSION" >> $GITHUB_OUTPUT
-            echo "cancel_publish_in_progress=true" >> $GITHUB_OUTPUT
-            echo "publish_concurrency_group=publish-${BRANCH}" >> $GITHUB_OUTPUT
-          else
-          echo "Matched config: $CONFIG"
-            echo "environment=$(echo "$CONFIG" | jq -r '.environment')" >> $GITHUB_OUTPUT
-            echo "new_branch=$(echo "$CONFIG" | jq -r '.target_branch')" >> $GITHUB_OUTPUT
-            echo "version=$(echo "$CONFIG" | jq -r '.version_prefix // ""')$(date '+%Y.%m.%d')-${{ github.run_number }}" >> $GITHUB_OUTPUT
-            echo "extra_version_identifier=$(echo "$CONFIG" | jq -r '.extra_version_identifier // ""')" >> $GITHUB_OUTPUT
-            cancel="$(echo "$CONFIG" | jq -r '.cancel_publish_in_progress')";
-            echo "cancel_publish_in_progress=$( [ "$cancel" = "null" ] && echo "true" || echo $cancel)" >> $GITHUB_OUTPUT
-            echo "publish_concurrency_group=publish-${BRANCH}$( [ "$cancel" = "null" ] || [ "$cancel" = "true" ] || echo "${{ github.sha }}" )" >> $GITHUB_OUTPUT 
-          fi
-          cat $GITHUB_OUTPUT
   
   
   publish:
@@ -278,7 +278,7 @@ jobs:
   notify:
     needs: [ build, publish ]
     runs-on: ubuntu-24.04
-    if: ${{ needs.publish.result != 'cancelled' && !failure() && (!contains(github.event_name, 'pull_request') || (github.event.action == 'labeled' && github.event.label.name == 'prebuilt')) }}
+    if: ${{ needs.publish.result == 'success' && !failure() && (!contains(github.event_name, 'pull_request') || (github.event.action == 'labeled' && github.event.label.name == 'prebuilt')) }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup Alpine Linux environment

--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -218,6 +218,7 @@ jobs:
             echo "cancel_publish_in_progress=$(echo "$CONFIG" | jq -r '.cancel_publish_in_progress // true')" >> $GITHUB_OUTPUT
             echo "publish_concurrency_group=publish-${BRANCH}${{ needs.prepare_strategy.outputs.cancel_publish_in_progress != 'true' && github.sha }}" >> $GITHUB_OUTPUT 
           fi
+          cat $GITHUB_OUTPUT
   
   
   publish:

--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -180,7 +180,7 @@ jobs:
       new_branch: ${{ steps.strategy.outputs.new_branch }}
       extra_version_identifier: ${{ steps.strategy.outputs.extra_version_identifier }}
       version: ${{ steps.strategy.outputs.version }}
-      cancel_publish_in_progress": ${{ steps.strategy.outputs.cancel_publish_in_progress }}
+      cancel_publish_in_progress: ${{ steps.strategy.outputs.cancel_publish_in_progress }}
     steps:
       - name: Extract deploy strategy
         id: strategy

--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -38,6 +38,7 @@ jobs:
       cancel_publish_in_progress: ${{ steps.strategy.outputs.cancel_publish_in_progress }}
       publish_concurrency_group: ${{ steps.strategy.outputs.publish_concurrency_group }}
     steps:
+      - uses: actions/checkout@v4
       - name: Extract deploy strategy
         id: strategy
         run: |

--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -218,7 +218,10 @@ jobs:
   
   publish:
     concurrency:
-      group: publish-${{ github.head_ref || github.ref_name }}
+      # We do a bit of a hack here to avoid cancelling the publish job if a new commit comes in while we're publishing by adding the sha to the group name.
+      # This means that if multiple commits come in while we're publishing, they will be queued up and publish one after the other.
+      # Otherwise, if a job is waiting to be publihshed due to environment wait time, it would be canceled by a new commit and restart the wait time.
+      group: publish-${{ github.head_ref || github.ref_name }}${{ needs.prepare_strategy.outputs.cancel_publish_in_progress != 'true' && github.sha }}
       cancel-in-progress: ${{ needs.prepare_strategy.outputs.cancel_publish_in_progress == 'true' }}
     if: ${{ (always() && !failure() && !cancelled()) && (!contains(github.event_name, 'pull_request') || (github.event.action == 'labeled' && github.event.label.name == 'prebuilt')) }}
     needs: [ build, prepare_strategy ]

--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -97,6 +97,7 @@ jobs:
       extra_version_identifier: ${{ needs.prepare_strategy.outputs.extra_version_identifier }}
       commit_sha: ${{ github.sha }}
     if: ${{
+      always() && !failure() &&
       needs.prepare_strategy.result == 'success' &&
       (needs.validate_tests.result == 'success' || needs.validate_tests.result == 'skipped') &&
       (!contains(github.event_name, 'pull_request') ||

--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -218,9 +218,9 @@ jobs:
   
   publish:
     concurrency:
-      # We do a bit of a hack here to avoid cancelling the publish job if a new commit comes in while we're publishing by adding the sha to the group name.
+      # We do a bit of a hack here to avoid cancelling the publishing job if a new commit comes in while we're publishing by adding the sha to the group name.
       # This means that if multiple commits come in while we're publishing, they will be queued up and publish one after the other.
-      # Otherwise, if a job is waiting to be publihshed due to environment wait time, it would be canceled by a new commit and restart the wait time.
+      # Otherwise, if a job is waiting to be published due to environment wait time, it would be canceled by a new commit and restart the wait time. 
       group: publish-${{ github.head_ref || github.ref_name }}${{ needs.prepare_strategy.outputs.cancel_publish_in_progress != 'true' && github.sha }}
       cancel-in-progress: ${{ needs.prepare_strategy.outputs.cancel_publish_in_progress == 'true' }}
     if: ${{ (always() && !failure() && !cancelled()) && (!contains(github.event_name, 'pull_request') || (github.event.action == 'labeled' && github.event.label.name == 'prebuilt')) }}

--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -64,13 +64,18 @@ jobs:
             echo "publish_concurrency_group=publish-${BRANCH}" >> $GITHUB_OUTPUT
           else
           echo "Matched config: $CONFIG"
-            echo "environment=$(echo "$CONFIG" | jq -r '.environment')" >> $GITHUB_OUTPUT
+            environment=$(echo "$CONFIG" | jq -r '.environment')
+            echo "environment=$environment" >> $GITHUB_OUTPUT
             echo "new_branch=$(echo "$CONFIG" | jq -r '.target_branch')" >> $GITHUB_OUTPUT
-            echo "version=$(echo "$CONFIG" | jq -r '.version_prefix // ""')$(date '+%Y.%m.%d')-${{ github.run_number }}" >> $GITHUB_OUTPUT
             echo "extra_version_identifier=$(echo "$CONFIG" | jq -r '.extra_version_identifier // ""')" >> $GITHUB_OUTPUT
             cancel="$(echo "$CONFIG" | jq -r '.cancel_publish_in_progress')";
             echo "cancel_publish_in_progress=$( [ "$cancel" = "null" ] && echo "true" || echo $cancel)" >> $GITHUB_OUTPUT
-            echo "publish_concurrency_group=publish-${BRANCH}$( [ "$cancel" = "null" ] || [ "$cancel" = "true" ] || echo "${{ github.sha }}" )" >> $GITHUB_OUTPUT 
+            echo "publish_concurrency_group=publish-${BRANCH}$( [ "$cancel" = "null" ] || [ "$cancel" = "true" ] || echo "${{ github.sha }}" )" >> $GITHUB_OUTPUT
+          
+            stable_branch="$(echo "$CONFIG" | jq -r '.stable_branch // false')";
+            stable_version=$(cat common/version.h | grep COMMA_VERSION | sed -e 's/[^0-9|.]//g')-$environment;
+            unstable_version=$(date '+%Y.%m.%d')-${{ github.run_number }};
+            echo "version=$([ "$stable_branch" = "true" ] && echo "$stable_version" || echo "$unstable_version")" >> $GITHUB_OUTPUT
           fi
           cat $GITHUB_OUTPUT
   

--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -68,15 +68,17 @@ jobs:
             environment=$(echo "$CONFIG" | jq -r '.environment')
             echo "environment=$environment" >> $GITHUB_OUTPUT
             echo "new_branch=$(echo "$CONFIG" | jq -r '.target_branch')" >> $GITHUB_OUTPUT
-            echo "extra_version_identifier=$(echo "$CONFIG" | jq -r '.extra_version_identifier // ""')" >> $GITHUB_OUTPUT
             cancel="$(echo "$CONFIG" | jq -r '.cancel_publish_in_progress')";
             echo "cancel_publish_in_progress=$( [ "$cancel" = "null" ] && echo "true" || echo $cancel)" >> $GITHUB_OUTPUT
             echo "publish_concurrency_group=publish-${BRANCH}$( [ "$cancel" = "null" ] || [ "$cancel" = "true" ] || echo "${{ github.sha }}" )" >> $GITHUB_OUTPUT
           
             stable_branch="$(echo "$CONFIG" | jq -r '.stable_branch // false')";
-            stable_version=$(cat common/version.h | grep COMMA_VERSION | sed -e 's/[^0-9|.]//g')-$environment;
+            stable_version=$(cat common/version.h | grep COMMA_VERSION | sed -e 's/[^0-9|.]//g');
             unstable_version=$(date '+%Y.%m.%d')-${{ github.run_number }};
             echo "version=$([ "$stable_branch" = "true" ] && echo "$stable_version" || echo "$unstable_version")" >> $GITHUB_OUTPUT
+            
+            extra_version_identifier=$( [ "$stable_branch" = "true" ] && echo "$environment" || echo "" );
+            echo "extra_version_identifier=$extra_version_identifier" >> $GITHUB_OUTPUT
           fi
           cat $GITHUB_OUTPUT
   

--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -97,7 +97,7 @@ jobs:
       extra_version_identifier: ${{ needs.prepare_strategy.outputs.extra_version_identifier }}
       commit_sha: ${{ github.sha }}
     if: ${{
-      always() && !failure() &&
+      (always() && !cancelled() && !failure()) &&
       needs.prepare_strategy.result == 'success' &&
       (needs.validate_tests.result == 'success' || needs.validate_tests.result == 'skipped') &&
       (!contains(github.event_name, 'pull_request') ||
@@ -232,7 +232,7 @@ jobs:
       # Otherwise, if a job is waiting to be published due to environment wait time, it would be canceled by a new commit and restart the wait time.
       group: ${{ needs.prepare_strategy.outputs.publish_concurrency_group }}
       cancel-in-progress: ${{ needs.prepare_strategy.outputs.cancel_publish_in_progress == 'true' }}
-    if: ${{ needs.build.result == 'success' && needs.prepare_strategy.result == 'success' && (!contains(github.event_name, 'pull_request') || (github.event.action == 'labeled' && github.event.label.name == 'prebuilt')) }}
+    if: ${{ (always() && !cancelled() && !failure()) && needs.build.result == 'success' && needs.prepare_strategy.result == 'success' && (!contains(github.event_name, 'pull_request') || (github.event.action == 'labeled' && github.event.label.name == 'prebuilt')) }}
     needs: [ build, prepare_strategy ]
     runs-on: ubuntu-24.04
     environment: ${{ needs.prepare_strategy.outputs.environment }}
@@ -279,7 +279,7 @@ jobs:
   notify:
     needs: [ build, publish ]
     runs-on: ubuntu-24.04
-    if: ${{ needs.publish.result == 'success' && !failure() && (!contains(github.event_name, 'pull_request') || (github.event.action == 'labeled' && github.event.label.name == 'prebuilt')) }}
+    if: ${{ (always() && !cancelled() && !failure()) && needs.publish.result == 'success' && !failure() && (!contains(github.event_name, 'pull_request') || (github.event.action == 'labeled' && github.event.label.name == 'prebuilt')) }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup Alpine Linux environment

--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -219,7 +219,7 @@ jobs:
   publish:
     concurrency:
       group: publish-${{ github.head_ref || github.ref_name }}
-      cancel-in-progress: ${{ needs.prepare_strategy.outputs.cancel_publish_in_progress }}
+      cancel-in-progress: ${{ needs.prepare_strategy.outputs.cancel_publish_in_progress == 'true' }}
     if: ${{ (always() && !failure() && !cancelled()) && (!contains(github.event_name, 'pull_request') || (github.event.action == 'labeled' && github.event.label.name == 'prebuilt')) }}
     needs: [ build, prepare_strategy ]
     runs-on: ubuntu-24.04

--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -214,6 +214,7 @@ jobs:
             echo "extra_version_identifier=$(echo "$CONFIG" | jq -r '.extra_version_identifier // ""')" >> $GITHUB_OUTPUT
             echo "cancel_publish_in_progress=$(echo "$CONFIG" | jq -r '.cancel_publish_in_progress // true')" >> $GITHUB_OUTPUT
           fi
+          echo publish-${{ github.head_ref || github.ref_name }}${{ needs.prepare_strategy.outputs.cancel_publish_in_progress != 'true' && github.sha || '' }}
   
   
   publish:

--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -77,7 +77,7 @@ jobs:
             unstable_version=$(date '+%Y.%m.%d')-${{ github.run_number }};
             echo "version=$([ "$stable_branch" = "true" ] && echo "$stable_version" || echo "$unstable_version")" >> $GITHUB_OUTPUT
             
-            extra_version_identifier=$( [ "$stable_branch" = "true" ] && echo "$environment" || echo "" );
+            extra_version_identifier=$( [ "$stable_branch" = "true" ] && echo "-${environment}" || echo "" );
             echo "extra_version_identifier=$extra_version_identifier" >> $GITHUB_OUTPUT
           fi
           cat $GITHUB_OUTPUT

--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -175,7 +175,6 @@ jobs:
   prepare_strategy:
     runs-on: ubuntu-24.04
     outputs:
-      prebuilt: ${{ steps.strategy.outputs.prebuilt }}
       environment: ${{ steps.strategy.outputs.environment }}
       new_branch: ${{ steps.strategy.outputs.new_branch }}
       extra_version_identifier: ${{ steps.strategy.outputs.extra_version_identifier }}
@@ -202,7 +201,6 @@ jobs:
             NEW_BRANCH="${BRANCH}${FORK_SUFFIX}-prebuilt"
             VERSION="$(date '+%Y.%m.%d')-${{ github.run_number }}"
   
-            echo "prebuilt=true" >> $GITHUB_OUTPUT
             echo "environment=${{ (contains(fromJSON(vars.AUTO_DEPLOY_PREBUILT_BRANCHES), github.head_ref || github.ref_name) || contains(github.event.pull_request.labels.*.name, 'prebuilt')) && 'auto-deploy' || 'feature-branch' }}" >> $GITHUB_OUTPUT
             echo "new_branch=$NEW_BRANCH" >> $GITHUB_OUTPUT
             echo "version=$VERSION" >> $GITHUB_OUTPUT
@@ -210,7 +208,6 @@ jobs:
             echo "publish_concurrency_group=publish-${BRANCH}" >> $GITHUB_OUTPUT
           else
           echo "Matched config: $CONFIG"
-            echo "prebuilt=$(echo "$CONFIG" | jq -r '.prebuilt')" >> $GITHUB_OUTPUT
             echo "environment=$(echo "$CONFIG" | jq -r '.environment')" >> $GITHUB_OUTPUT
             echo "new_branch=$(echo "$CONFIG" | jq -r '.target_branch')" >> $GITHUB_OUTPUT
             echo "version=$(echo "$CONFIG" | jq -r '.version_prefix // ""')$(date '+%Y.%m.%d')-${{ github.run_number }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -212,8 +212,9 @@ jobs:
             echo "new_branch=$(echo "$CONFIG" | jq -r '.target_branch')" >> $GITHUB_OUTPUT
             echo "version=$(echo "$CONFIG" | jq -r '.version_prefix // ""')$(date '+%Y.%m.%d')-${{ github.run_number }}" >> $GITHUB_OUTPUT
             echo "extra_version_identifier=$(echo "$CONFIG" | jq -r '.extra_version_identifier // ""')" >> $GITHUB_OUTPUT
-            echo "cancel_publish_in_progress=$(echo "$CONFIG" | jq -r '.cancel_publish_in_progress // true')" >> $GITHUB_OUTPUT
-            echo "publish_concurrency_group=publish-${BRANCH}${{ needs.prepare_strategy.outputs.cancel_publish_in_progress != 'true' && github.sha }}" >> $GITHUB_OUTPUT 
+            cancel="$(echo "$CONFIG" | jq -r '.cancel_publish_in_progress')";
+            echo "cancel_publish_in_progress=$( [ "$cancel" = "null" ] && echo "true" || echo $cancel)" >> $GITHUB_OUTPUT
+            echo "publish_concurrency_group=publish-${BRANCH}$( [ "$cancel" = "null" ] || [ "$cancel" = "true" ] || echo "${{ github.sha }}" )" >> $GITHUB_OUTPUT 
           fi
           cat $GITHUB_OUTPUT
   

--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -30,6 +30,7 @@ on:
 jobs:
   prepare_strategy:
     runs-on: ubuntu-24.04
+    if: (!contains(github.event_name, 'pull_request') || (github.event.action == 'labeled' && github.event.label.name == 'prebuilt'))
     outputs:
       environment: ${{ steps.strategy.outputs.environment }}
       new_branch: ${{ steps.strategy.outputs.new_branch }}

--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -50,7 +50,12 @@ jobs:
       version: ${{ needs.prepare_strategy.outputs.version }}
       extra_version_identifier: ${{ needs.prepare_strategy.outputs.extra_version_identifier }}
       commit_sha: ${{ github.sha }}
-    if: ${{ (always() && !failure() && !cancelled()) && (!contains(github.event_name, 'pull_request') || (github.event.action == 'labeled' && github.event.label.name == 'prebuilt')) }}
+    if: ${{
+      needs.prepare_strategy.result == 'success' &&
+      (needs.validate_tests.result == 'success' || needs.validate_tests.result == 'skipped') &&
+      (!contains(github.event_name, 'pull_request') ||
+      (github.event.action == 'labeled' && github.event.label.name == 'prebuilt')) 
+      }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -226,7 +231,7 @@ jobs:
       # Otherwise, if a job is waiting to be published due to environment wait time, it would be canceled by a new commit and restart the wait time.
       group: ${{ needs.prepare_strategy.outputs.publish_concurrency_group }}
       cancel-in-progress: ${{ needs.prepare_strategy.outputs.cancel_publish_in_progress == 'true' }}
-    if: ${{ (always() && !failure() && !cancelled()) && (!contains(github.event_name, 'pull_request') || (github.event.action == 'labeled' && github.event.label.name == 'prebuilt')) }}
+    if: ${{ needs.build.result == 'success' && needs.prepare_strategy.result == 'success' && (!contains(github.event_name, 'pull_request') || (github.event.action == 'labeled' && github.event.label.name == 'prebuilt')) }}
     needs: [ build, prepare_strategy ]
     runs-on: ubuntu-24.04
     environment: ${{ needs.prepare_strategy.outputs.environment }}
@@ -273,7 +278,7 @@ jobs:
   notify:
     needs: [ build, publish ]
     runs-on: ubuntu-24.04
-    if: ${{ (always() && !failure() && !cancelled()) && (!contains(github.event_name, 'pull_request') || (github.event.action == 'labeled' && github.event.label.name == 'prebuilt')) }}
+    if: ${{ needs.publish.result != 'cancelled' && !failure() && (!contains(github.event_name, 'pull_request') || (github.event.action == 'labeled' && github.event.label.name == 'prebuilt')) }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup Alpine Linux environment

--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -217,7 +217,7 @@ jobs:
   publish:
     concurrency:
       group: publish-${{ github.head_ref || github.ref_name }}
-      cancel-in-progress: ${{ env.CANCEL_PUBLISH_IN_PROGRESS }}
+      cancel-in-progress: ${{ vars.CANCEL_PUBLISH_IN_PROGRESS }}
     if: ${{ (always() && !failure() && !cancelled()) && (!contains(github.event_name, 'pull_request') || (github.event.action == 'labeled' && github.event.label.name == 'prebuilt')) }}
     needs: [ build, prepare_strategy ]
     runs-on: ubuntu-24.04

--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -181,6 +181,7 @@ jobs:
       extra_version_identifier: ${{ steps.strategy.outputs.extra_version_identifier }}
       version: ${{ steps.strategy.outputs.version }}
       cancel_publish_in_progress: ${{ steps.strategy.outputs.cancel_publish_in_progress }}
+      publish_concurrency_group: ${{ steps.strategy.outputs.publish_concurrency_group }}
     steps:
       - name: Extract deploy strategy
         id: strategy
@@ -213,8 +214,8 @@ jobs:
             echo "version=$(echo "$CONFIG" | jq -r '.version_prefix // ""')$(date '+%Y.%m.%d')-${{ github.run_number }}" >> $GITHUB_OUTPUT
             echo "extra_version_identifier=$(echo "$CONFIG" | jq -r '.extra_version_identifier // ""')" >> $GITHUB_OUTPUT
             echo "cancel_publish_in_progress=$(echo "$CONFIG" | jq -r '.cancel_publish_in_progress // true')" >> $GITHUB_OUTPUT
+            echo "publish_concurrency_group=publish-${{ github.head_ref || github.ref_name }}${{ needs.prepare_strategy.outputs.cancel_publish_in_progress != 'true' && github.sha || '' }}" >> $GITHUB_OUTPUT 
           fi
-          echo publish-${{ github.head_ref || github.ref_name }}${{ needs.prepare_strategy.outputs.cancel_publish_in_progress != 'true' && github.sha || '' }}
   
   
   publish:


### PR DESCRIPTION
Since we now have the waiting time setup, we no longer need to cancel publish in progress. This allows us for still release to staging things in the order they were merged into master, each merge with it's own waiting time

## Summary by Sourcery

CI:
- Disable cancel-in-progress in the publish concurrency group