### PR TITLE
bugfix: improve exception handling for sunnylinkd (SUN-89)

### DIFF
--- a/sunnypilot/sunnylink/athena/sunnylinkd.py
+++ b/sunnypilot/sunnylink/athena/sunnylinkd.py
@@ -267,7 +267,7 @@ def main(exit_event: threading.Event = None):
       if isinstance(e, (ConnectionError, TimeoutError, WebSocketException)):
         cloudlog.warning(f"sunnylinkd.main.{type(e).__name__}")
       elif isinstance(e, OSError):
-        name = errno.errorcode.get(e.errno, "UNKNOWN")
+        name = errno.errorcode.get(e.errno or -1, "UNKNOWN")
         msg = f"sunnylinkd.main.OSError.{name} ({e.errno})"
         is_expected_error = e.errno in (errno.ENETDOWN, errno.ENETRESET, errno.ENETUNREACH)
         cloudlog.warning(msg) if is_expected_error else cloudlog.exception(msg)


### PR DESCRIPTION
## Summary by Sourcery

Enhance exception handling in sunnylinkd by differentiating expected errors from unexpected ones and adjusting log levels accordingly

Enhancements:
- Log WebSocketTimeoutException and WebSocketConnectionClosedException as warnings in ws_recv instead of error-level exceptions
- Log ConnectionError and TimeoutError as warnings in ws_queue.resume_queued and reserve exception logging for other errors
- Simplify retry backoff handling whitespace in ws_queue