### PR TITLE
bugfix: Clamp longitudinal personality to max value

### DIFF
--- a/selfdrive/selfdrived/selfdrived.py
+++ b/selfdrive/selfdrived/selfdrived.py
@@ -130,9 +130,7 @@ class SelfdriveD(CruiseHelper):
     self.logged_comm_issue = None
     self.not_running_prev = None
     self.experimental_mode = False
-    self.personality = self.params.get("LongitudinalPersonality", return_default=True)
-    if self.personality > max(LONGITUDINAL_PERSONALITY_MAP):
-      self.personality = max(LONGITUDINAL_PERSONALITY_MAP)
+    self.personality = min(self.params.get("LongitudinalPersonality", return_default=True), max(LONGITUDINAL_PERSONALITY_MAP))
     self.recalibrating_seen = False
     self.state_machine = StateMachine()
     self.rk = Ratekeeper(100, print_delay_threshold=None)

--- a/selfdrive/selfdrived/selfdrived.py
+++ b/selfdrive/selfdrived/selfdrived.py
@@ -131,6 +131,8 @@ class SelfdriveD(CruiseHelper):
     self.not_running_prev = None
     self.experimental_mode = False
     self.personality = self.params.get("LongitudinalPersonality", return_default=True)
+    if self.personality > max(LONGITUDINAL_PERSONALITY_MAP):
+      self.personality = max(LONGITUDINAL_PERSONALITY_MAP)
     self.recalibrating_seen = False
     self.state_machine = StateMachine()
     self.rk = Ratekeeper(100, print_delay_threshold=None)


### PR DESCRIPTION
fix for https://github.com/sunnypilot/sunnypilot/issues/1208

## Summary by Sourcery

Bug Fixes:
- Clamp self.personality to avoid exceeding the maximum defined in LONGITUDINAL_PERSONALITY_MAP