### PR TITLE
Tesla: Cooperative Steering

### DIFF
--- a/common/params_keys.h
+++ b/common/params_keys.h
@@ -191,6 +191,7 @@ inline static std::unordered_map<std::string, ParamKeyAttributes> keys = {
 
     // sunnypilot car specific params
     {"HyundaiLongitudinalTuning", {PERSISTENT | BACKUP, INT, "0"}},
+    {"TeslaCoopSteering", {PERSISTENT | BACKUP, BOOL, "0"}},
 
     {"DynamicExperimentalControl", {PERSISTENT | BACKUP, BOOL, "0"}},
     {"BlindSpot", {PERSISTENT | BACKUP, BOOL, "0"}},

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.cc
@@ -6,7 +6,6 @@
  */
 
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.h"
-#include "selfdrive/ui/ui.h" // for uiState() signal offroadTransition
 #include "common/params.h"
 #include "common/util.h"
 

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.cc
@@ -10,29 +10,29 @@
 #include "common/util.h"
 
 TeslaSettings::TeslaSettings(QWidget *parent) : BrandSettingsInterface(parent) {
-	constexpr int coopSteeringMinKmh = 23; // minimum speed for cooperative steering (enforced by Tesla firmware)
-	Params params;
-	bool is_metric = params.getBool("IsMetric");
+  constexpr int coopSteeringMinKmh = 23; // minimum speed for cooperative steering (enforced by Tesla firmware)
+  Params params;
+  bool is_metric = params.getBool("IsMetric");
   QString unit = is_metric ? "km/h" : "mph";
   int display_value;
   if (is_metric) {
-		display_value = coopSteeringMinKmh;
-	} else {
+    display_value = coopSteeringMinKmh;
+  } else {
     display_value = static_cast<int>(std::round(coopSteeringMinKmh * KM_TO_MILE));
-	}
-	const QString coop_desc = tr("Allows the driver to provide limited steering input while openpilot is engaged. Only works above %1 %2.")
-																.arg(display_value)
-																.arg(unit);
+  }
+  const QString coop_desc = tr("Allows the driver to provide limited steering input while openpilot is engaged. Only works above %1 %2.")
+                                .arg(display_value)
+                                .arg(unit);
 
-	coopSteeringToggle = new ParamControlSP(
-		"TeslaCoopSteering",
-		tr("Cooperative Steering"),
-		coop_desc,
-		"",
-		this
-	);
-	list->addItem(coopSteeringToggle);
-	coopSteeringToggle->showDescription();
+  coopSteeringToggle = new ParamControlSP(
+    "TeslaCoopSteering",
+    tr("Cooperative Steering"),
+    coop_desc,
+    "",
+    this
+  );
+  list->addItem(coopSteeringToggle);
+  coopSteeringToggle->showDescription();
 }
 
 void TeslaSettings::updateSettings() {

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.cc
@@ -34,14 +34,7 @@ TeslaSettings::TeslaSettings(QWidget *parent) : BrandSettingsInterface(parent) {
 	);
 	list->addItem(coopSteeringToggle);
 	coopSteeringToggle->showDescription();
-
-	QObject::connect(uiState(), &UIState::offroadTransition, this, &TeslaSettings::offroadTransition);
-	offroadTransition(!uiState()->scene.started);
 }
 
 void TeslaSettings::updateSettings() {
-}
-
-void TeslaSettings::offroadTransition(bool offroad) {
-	coopSteeringToggle->setEnabled(offroad);
 }

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.cc
@@ -7,13 +7,26 @@
 
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.h"
 #include "selfdrive/ui/ui.h" // for uiState() signal offroadTransition
+#include "common/params.h"
+#include "common/util.h"
 
 TeslaSettings::TeslaSettings(QWidget *parent) : BrandSettingsInterface(parent) {
+	constexpr int coopSteeringMinMph = 15; // minimum speed for cooperative steering (enforced by Tesla firmware)
+	Params params;
+	bool is_metric = params.getBool("IsMetric");
+  QString unit = is_metric ? "km/h" : "mph";
+  float display_value = stored_mph;
+  if (is_metric) {
+    display_value = stored_mph * MILE_TO_KM;
+  }
+	const QString coop_desc = tr("Allows the driver to provide limited steering input while openpilot is engaged. Only works above %1 %2.")
+																.arg(threshold_display)
+																.arg(unit);
+
 	coopSteeringToggle = new ParamControlSP(
 		"TeslaCoopSteering",
 		tr("Cooperative Steering"),
-    // TODO:AMY USE USER METRICS AND GET CORRECT MAX VALUES
-		tr("Allows the driver to provide steering input while openpilot is engaged. Only works between 15 and 60 mph."),
+		coop_desc,
 		"",
 		this
 	);

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.cc
@@ -11,7 +11,7 @@
 #include "common/util.h"
 
 TeslaSettings::TeslaSettings(QWidget *parent) : BrandSettingsInterface(parent) {
-	constexpr int coopSteeringMinKmh = 25; // minimum speed for cooperative steering (enforced by Tesla firmware)
+	constexpr int coopSteeringMinKmh = 23; // minimum speed for cooperative steering (enforced by Tesla firmware)
 	Params params;
 	bool is_metric = params.getBool("IsMetric");
   QString unit = is_metric ? "km/h" : "mph";

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.cc
@@ -15,9 +15,9 @@ TeslaSettings::TeslaSettings(QWidget *parent) : BrandSettingsInterface(parent) {
 	Params params;
 	bool is_metric = params.getBool("IsMetric");
   QString unit = is_metric ? "km/h" : "mph";
-  float display_value = stored_mph;
+  float display_value = coopSteeringMinMph;
   if (is_metric) {
-    display_value = stored_mph * MILE_TO_KM;
+    display_value = coopSteeringMinMph * MILE_TO_KM;
   }
 	const QString coop_desc = tr("Allows the driver to provide limited steering input while openpilot is engaged. Only works above %1 %2.")
 																.arg(display_value)

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.cc
@@ -8,6 +8,15 @@
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.h"
 
 TeslaSettings::TeslaSettings(QWidget *parent) : BrandSettingsInterface(parent) {
+	coopSteeringToggle = new ParamControlSP(
+		"TeslaCoopSteering",
+		tr("Cooperative Steering"),
+    // TODO:AMY USE USER METRICS AND GET CORRECT MAX VALUES
+		tr("Allows the driver to provide steering input while openpilot is engaged. Only works between 15 and 60mph"),
+		"",
+		this
+	);
+	list->addItem(coopSteeringToggle);
 }
 
 void TeslaSettings::updateSettings() {

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.cc
@@ -11,14 +11,16 @@
 #include "common/util.h"
 
 TeslaSettings::TeslaSettings(QWidget *parent) : BrandSettingsInterface(parent) {
-	constexpr int coopSteeringMinMph = 15; // minimum speed for cooperative steering (enforced by Tesla firmware)
+	constexpr int coopSteeringMinKmh = 25; // minimum speed for cooperative steering (enforced by Tesla firmware)
 	Params params;
 	bool is_metric = params.getBool("IsMetric");
   QString unit = is_metric ? "km/h" : "mph";
-  float display_value = coopSteeringMinMph;
+  int display_value;
   if (is_metric) {
-    display_value = coopSteeringMinMph * MILE_TO_KM;
-  }
+		display_value = coopSteeringMinKmh;
+	} else {
+    display_value = static_cast<int>(std::round(coopSteeringMinKmh * KM_TO_MILE));
+	}
 	const QString coop_desc = tr("Allows the driver to provide limited steering input while openpilot is engaged. Only works above %1 %2.")
 																.arg(display_value)
 																.arg(unit);

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.cc
@@ -6,18 +6,27 @@
  */
 
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.h"
+#include "selfdrive/ui/ui.h" // for uiState() signal offroadTransition
 
 TeslaSettings::TeslaSettings(QWidget *parent) : BrandSettingsInterface(parent) {
 	coopSteeringToggle = new ParamControlSP(
 		"TeslaCoopSteering",
 		tr("Cooperative Steering"),
     // TODO:AMY USE USER METRICS AND GET CORRECT MAX VALUES
-		tr("Allows the driver to provide steering input while openpilot is engaged. Only works between 15 and 60mph"),
+		tr("Allows the driver to provide steering input while openpilot is engaged. Only works between 15 and 60 mph."),
 		"",
 		this
 	);
 	list->addItem(coopSteeringToggle);
+	coopSteeringToggle->showDescription();
+
+	QObject::connect(uiState(), &UIState::offroadTransition, this, &TeslaSettings::offroadTransition);
+	offroadTransition(!uiState()->scene.started);
 }
 
 void TeslaSettings::updateSettings() {
+}
+
+void TeslaSettings::offroadTransition(bool offroad) {
+	coopSteeringToggle->setEnabled(offroad);
 }

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.cc
@@ -21,7 +21,7 @@ TeslaSettings::TeslaSettings(QWidget *parent) : BrandSettingsInterface(parent) {
 	} else {
     display_value = static_cast<int>(std::round(coopSteeringMinKmh * KM_TO_MILE));
 	}
-	const QString coop_desc = tr("Allows the driver to provide limited steering input while openpilot is engaged. Only works above %1 %2.")
+	const QString coop_desc = tr("Allows the driver to provide limited steering input while openpilot is engaged. Only works above %1 %2. Always enabled when in MADS.")
 																.arg(display_value)
 																.arg(unit);
 

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.cc
@@ -20,7 +20,7 @@ TeslaSettings::TeslaSettings(QWidget *parent) : BrandSettingsInterface(parent) {
     display_value = stored_mph * MILE_TO_KM;
   }
 	const QString coop_desc = tr("Allows the driver to provide limited steering input while openpilot is engaged. Only works above %1 %2.")
-																.arg(threshold_display)
+																.arg(display_value)
 																.arg(unit);
 
 	coopSteeringToggle = new ParamControlSP(

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.cc
@@ -21,7 +21,7 @@ TeslaSettings::TeslaSettings(QWidget *parent) : BrandSettingsInterface(parent) {
 	} else {
     display_value = static_cast<int>(std::round(coopSteeringMinKmh * KM_TO_MILE));
 	}
-	const QString coop_desc = tr("Allows the driver to provide limited steering input while openpilot is engaged. Only works above %1 %2. Always enabled when in MADS.")
+	const QString coop_desc = tr("Allows the driver to provide limited steering input while openpilot is engaged. Only works above %1 %2.")
 																.arg(display_value)
 																.arg(unit);
 

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.h
@@ -22,5 +22,5 @@ public:
   void updateSettings() override;
 
 private:
-  bool offroad = false;
+  ParamControlSP *coopSteeringToggle = nullptr;
 };

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.h
@@ -23,4 +23,7 @@ public:
 
 private:
   ParamControlSP *coopSteeringToggle = nullptr;
+
+private slots:
+  void offroadTransition(bool offroad);
 };

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/vehicle/tesla_settings.h
@@ -23,7 +23,4 @@ public:
 
 private:
   ParamControlSP *coopSteeringToggle = nullptr;
-
-private slots:
-  void offroadTransition(bool offroad);
 };

--- a/sunnypilot/selfdrive/car/interfaces.py
+++ b/sunnypilot/selfdrive/car/interfaces.py
@@ -55,7 +55,12 @@ def initialize_params(params) -> list[dict[str, Any]]:
 
   # hyundai
   keys.extend([
-    "HyundaiLongitudinalTuning"
+    "HyundaiLongitudinalTuning",
+  ])
+
+  # tesla
+  keys.extend([
+    "TeslaCoopSteering",
   ])
 
   return [{k: params.get(k, return_default=True)} for k in keys]

--- a/sunnypilot/selfdrive/car/interfaces.py
+++ b/sunnypilot/selfdrive/car/interfaces.py
@@ -55,12 +55,7 @@ def initialize_params(params) -> list[dict[str, Any]]:
 
   # hyundai
   keys.extend([
-    "HyundaiLongitudinalTuning",
-  ])
-
-  # tesla
-  keys.extend([
-    "TeslaCoopSteering",
+    "HyundaiLongitudinalTuning"
   ])
 
   return [{k: params.get(k, return_default=True)} for k in keys]

--- a/sunnypilot/selfdrive/controls/lib/param_store.py
+++ b/sunnypilot/selfdrive/controls/lib/param_store.py
@@ -20,6 +20,11 @@ class ParamStore:
     universal_params: list[str] = []
     brand_params: list[str] = []
 
+    if CP.brand == "tesla":
+      brand_params.extend([
+        "TeslaCoopSteering",
+      ])
+
     self.keys = universal_params + brand_params
     self.values = {}
     self.cached_params_list: list[capnp.lib.capnp._DynamicStructBuilder] | None = None

--- a/sunnypilot/selfdrive/controls/lib/param_store.py
+++ b/sunnypilot/selfdrive/controls/lib/param_store.py
@@ -34,7 +34,7 @@ class ParamStore:
   def update(self, params: Params) -> None:
     if self.frame % 300 == 0:
       old_values = dict(self.values)
-      self.values = {k: params.get(k) or "0" for k in self.keys}
+      self.values = {k: str(params.get(k) or "0") for k in self.keys}
       if old_values != self.values:
         self.cached_params_list = None
 


### PR DESCRIPTION
**Description**

## BLOCKED: Wait for related PR to merge and then update opendbc to latest upstream master branch

Added Cooperative Steering (aka torque blending) using Tesla's native LKAS control type.

See related opendbc PR: https://github.com/sunnypilot/opendbc/pull/266

There is a new UI option to enable/disable this feature. It is disabled by default.

Video showing new UI in action, including respecting metric/imperial settings and disabling the control when not off-road:

https://github.com/user-attachments/assets/6988316f-890a-4387-ba6a-2430f2f0ba8c

(Note: Since this video I updated the kmh value with a more accurate one which is why it's different)

**Routes**
- Coop steering enabled: https://connect.comma.ai/4b3cbd6038d07ca6/00000049--8f5a8c4663
- Coop steering disabled: https://connect.comma.ai/4b3cbd6038d07ca6/0000004a--285758468a

## Summary by Sourcery

Introduce Tesla Cooperative Steering support by exposing a new offroad-only toggle in the settings UI, displaying the threshold speed in the user’s preferred units, and wiring up a persistent parameter to control torque blending via Tesla’s native LKAS.

New Features:
- Add Cooperative Steering toggle in Tesla settings to enable torque blending using native LKAS control
- Display the minimum speed requirement dynamically in metric or imperial units in the UI
- Disable the Cooperative Steering toggle when the car is engaged (onroad)

Enhancements:
- Register the new 'TeslaCoopSteering' parameter in common params and car interface for persistence