### PR TITLE
ui: cleanup cereal event params parsing

### DIFF
--- a/common/params_keys.h
+++ b/common/params_keys.h
@@ -76,7 +76,7 @@ inline static std::unordered_map<std::string, ParamKeyAttributes> keys = {
     {"LastUpdateRouteCount", {PERSISTENT, INT, "0"}},
     {"LastUpdateTime", {PERSISTENT, TIME}},
     {"LastUpdateUptimeOnroad", {PERSISTENT, FLOAT, "0.0"}},
-    {"LiveDelay", {PERSISTENT | BACKUP, BYTES}},
+    {"LiveDelay", {PERSISTENT, BYTES}},
     {"LiveParameters", {PERSISTENT, JSON}},
     {"LiveParametersV2", {PERSISTENT, BYTES}},
     {"LiveTorqueParameters", {PERSISTENT | DONT_LOG, BYTES}},

--- a/common/params_keys.h
+++ b/common/params_keys.h
@@ -76,7 +76,7 @@ inline static std::unordered_map<std::string, ParamKeyAttributes> keys = {
     {"LastUpdateRouteCount", {PERSISTENT, INT, "0"}},
     {"LastUpdateTime", {PERSISTENT, TIME}},
     {"LastUpdateUptimeOnroad", {PERSISTENT, FLOAT, "0.0"}},
-    {"LiveDelay", {PERSISTENT, BYTES}},
+    {"LiveDelay", {PERSISTENT | BACKUP, BYTES}},
     {"LiveParameters", {PERSISTENT, JSON}},
     {"LiveParametersV2", {PERSISTENT, BYTES}},
     {"LiveTorqueParameters", {PERSISTENT | DONT_LOG, BYTES}},

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/models_panel.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/models_panel.cc
@@ -426,19 +426,19 @@ void ModelsPanel::updateLabels() {
   if (lagdEnabled) {
     auto liveDelayBytes = params.get("LiveDelay");
     if (!liveDelayBytes.empty()) {
-      AlignedBuffer aligned_buf;
-      capnp::FlatArrayMessageReader cmsg(aligned_buf.align(liveDelayBytes.data(), liveDelayBytes.size()));
+      AlignedBuffer aligned_buf_ld;
+      capnp::FlatArrayMessageReader cmsg(aligned_buf_ld.align(liveDelayBytes.data(), liveDelayBytes.size()));
       cereal::LiveDelayData::Reader LD = cmsg.getRoot<cereal::LiveDelayData>();
 
-      float lateralDelay = LD.getLateralDelay();
+      auto lateralDelay = LD.getLateralDelay();
       desc += QString("<br><br><b><span style=\"color:#e0e0e0\">%1</span></b> <span style=\"color:#e0e0e0\">%2 s</span>")
               .arg(tr("Live Steer Delay:")).arg(QString::number(lateralDelay, 'f', 3));
     }
   } else {
     auto carParamsBytes = params.get("CarParamsPersistent");
     if (!carParamsBytes.empty()) {
-      AlignedBuffer aligned_buf;
-      capnp::FlatArrayMessageReader cmsg(aligned_buf.align(carParamsBytes.data(), carParamsBytes.size()));
+      AlignedBuffer aligned_buf_cp;
+      capnp::FlatArrayMessageReader cmsg(aligned_buf_cp.align(carParamsBytes.data(), carParamsBytes.size()));
       cereal::CarParams::Reader CP = cmsg.getRoot<cereal::CarParams>();
 
       float steerDelay = CP.getSteerActuatorDelay();

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/models_panel.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/models_panel.cc
@@ -134,9 +134,9 @@ ModelsPanel::ModelsPanel(QWidget *parent) : QWidget(parent) {
 
   // Software delay control
   delay_control = new OptionControlSP("LagdToggleDelay", tr("Adjust Software Delay"),
-                                     tr("Adjust the software delay when Live Learning Steer Delay is toggled off."
-                                        "\nThe default software delay value is 0.2"),
-                                     "", {5, 50}, 1, false, nullptr, true, true);
+                                      tr("Adjust the software delay when Live Learning Steer Delay is toggled off."
+                                         "\nThe default software delay value is 0.2"),
+                                      "", {5, 50}, 1, false, nullptr, true, true);
 
   connect(delay_control, &OptionControlSP::updateLabels, [=]() {
     float value = QString::fromStdString(params.get("LagdToggleDelay")).toFloat();

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/models_panel.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/models_panel.cc
@@ -48,25 +48,6 @@ static const QString progressStyleError = progressStyleActive +
     "  background-color: transparent;"
     "}";
 
-std::optional<cereal::Event::Reader> safeParamEventLoad(Params& params, const std::string& paramName) {
-  std::string raw = params.get(paramName);
-  if (raw.empty()) {
-    return std::nullopt;
-  }
-
-  try {
-    AlignedBuffer alignedBuf;
-    auto buf = alignedBuf.align(raw.data(), raw.size());
-
-    capnp::FlatArrayMessageReader msg(kj::ArrayPtr<const capnp::word>(buf.begin(), buf.size()));
-    return msg.getRoot<cereal::Event>();
-  }
-  catch (const kj::Exception& e) {
-    qInfo() << "Invalid param" << QString::fromStdString(paramName) << ":" << e.getDescription().cStr();
-    return std::nullopt;
-  }
-}
-
 ModelsPanel::ModelsPanel(QWidget *parent) : QWidget(parent) {
   QVBoxLayout *main_layout = new QVBoxLayout(this);
   main_layout->setContentsMargins(50, 20, 50, 20);
@@ -153,10 +134,17 @@ ModelsPanel::ModelsPanel(QWidget *parent) : QWidget(parent) {
 
   // Software delay control
   int liveDelayMaxInt = 30;
-  if (const auto event = safeParamEventLoad(params, "LiveDelay"); event && event->hasLiveDelay()) {
-    auto liveDelay = event->getLiveDelay();
-    float lateralDelay = liveDelay.getLateralDelay();
-    liveDelayMaxInt = static_cast<int>(lateralDelay * 100.0f) + 20;
+  std::string liveDelayBytes = params.get("LiveDelay");
+  if (!liveDelayBytes.empty()) {
+    capnp::FlatArrayMessageReader msg(kj::ArrayPtr<const capnp::word>(
+      reinterpret_cast<const capnp::word*>(liveDelayBytes.data()),
+      liveDelayBytes.size() / sizeof(capnp::word)));
+    auto event = msg.getRoot<cereal::Event>();
+    if (event.hasLiveDelay()) {
+      auto liveDelay = event.getLiveDelay();
+      float lateralDelay = liveDelay.getLateralDelay();
+      liveDelayMaxInt = static_cast<int>(lateralDelay * 100.0f) + 20;
+    }
   }
   delay_control = new OptionControlSP("LagdToggleDelay", tr("Adjust Software Delay"),
                                      tr("Adjust the software delay when Live Learning Steer Delay is toggled off."
@@ -449,11 +437,18 @@ void ModelsPanel::updateLabels() {
                    "Disable to use a fixed steering response time. Keeping this on provides the stock openpilot experience.");
   bool lagdEnabled = params.getBool("LagdToggle");
   if (lagdEnabled) {
-    if (const auto event = safeParamEventLoad(params, "LiveDelay"); event && event->hasLiveDelay()) {
-      auto liveDelay = event->getLiveDelay();
-      float lateralDelay = liveDelay.getLateralDelay();
-      desc += QString("<br><br><b><span style=\"color:#e0e0e0\">%1</span></b> <span style=\"color:#e0e0e0\">%2 s</span>")
+    std::string liveDelayBytes = params.get("LiveDelay");
+    if (!liveDelayBytes.empty()) {
+      capnp::FlatArrayMessageReader msg(kj::ArrayPtr<const capnp::word>(
+        reinterpret_cast<const capnp::word*>(liveDelayBytes.data()),
+        liveDelayBytes.size() / sizeof(capnp::word)));
+      auto event = msg.getRoot<cereal::Event>();
+      if (event.hasLiveDelay()) {
+        auto liveDelay = event.getLiveDelay();
+        float lateralDelay = liveDelay.getLateralDelay();
+        desc += QString("<br><br><b><span style=\"color:#e0e0e0\">%1</span></b> <span style=\"color:#e0e0e0\">%2 s</span>")
                 .arg(tr("Live Steer Delay:")).arg(QString::number(lateralDelay, 'f', 3));
+      }
     }
   } else {
     std::string carParamsBytes = params.get("CarParamsPersistent");

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/models_panel.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/models_panel.cc
@@ -419,8 +419,6 @@ void ModelsPanel::updateLabels() {
   currentModelLblBtn->setEnabled(!is_onroad && !isDownloading());
   currentModelLblBtn->setValue(GetActiveModelInternalName());
 
-  AlignedBuffer aligned_buf;
-
   // Update lagdToggle description with current value
   QString desc = tr("Enable this for the car to learn and adapt its steering response time. "
                    "Disable to use a fixed steering response time. Keeping this on provides the stock openpilot experience.");
@@ -428,6 +426,7 @@ void ModelsPanel::updateLabels() {
   if (lagdEnabled) {
     auto liveDelayBytes = params.get("LiveDelay");
     if (!liveDelayBytes.empty()) {
+      AlignedBuffer aligned_buf;
       capnp::FlatArrayMessageReader cmsg(aligned_buf.align(liveDelayBytes.data(), liveDelayBytes.size()));
       cereal::LiveDelayData::Reader LD = cmsg.getRoot<cereal::LiveDelayData>();
 
@@ -438,6 +437,7 @@ void ModelsPanel::updateLabels() {
   } else {
     auto carParamsBytes = params.get("CarParamsPersistent");
     if (!carParamsBytes.empty()) {
+      AlignedBuffer aligned_buf;
       capnp::FlatArrayMessageReader cmsg(aligned_buf.align(carParamsBytes.data(), carParamsBytes.size()));
       cereal::CarParams::Reader CP = cmsg.getRoot<cereal::CarParams>();
 

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/models_panel.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/models_panel.cc
@@ -426,11 +426,8 @@ void ModelsPanel::updateLabels() {
   if (lagdEnabled) {
     auto liveDelayBytes = params.get("LiveDelay");
     if (!liveDelayBytes.empty()) {
-      AlignedBuffer aligned_buf_ld;
-      capnp::FlatArrayMessageReader cmsg(aligned_buf_ld.align(liveDelayBytes.data(), liveDelayBytes.size()));
-      cereal::LiveDelayData::Reader LD = cmsg.getRoot<cereal::LiveDelayData>();
-
-      auto lateralDelay = LD.getLateralDelay();
+      auto LD = loadCerealEvent(params, "LiveDelay");
+      float lateralDelay = LD->getLiveDelay().getLateralDelay();
       desc += QString("<br><br><b><span style=\"color:#e0e0e0\">%1</span></b> <span style=\"color:#e0e0e0\">%2 s</span>")
               .arg(tr("Live Steer Delay:")).arg(QString::number(lateralDelay, 'f', 3));
     }

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/models_panel.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/models_panel.cc
@@ -133,23 +133,10 @@ ModelsPanel::ModelsPanel(QWidget *parent) : QWidget(parent) {
   list->addItem(lagd_toggle_control);
 
   // Software delay control
-  int liveDelayMaxInt = 30;
-  std::string liveDelayBytes = params.get("LiveDelay");
-  if (!liveDelayBytes.empty()) {
-    capnp::FlatArrayMessageReader msg(kj::ArrayPtr<const capnp::word>(
-      reinterpret_cast<const capnp::word*>(liveDelayBytes.data()),
-      liveDelayBytes.size() / sizeof(capnp::word)));
-    auto event = msg.getRoot<cereal::Event>();
-    if (event.hasLiveDelay()) {
-      auto liveDelay = event.getLiveDelay();
-      float lateralDelay = liveDelay.getLateralDelay();
-      liveDelayMaxInt = static_cast<int>(lateralDelay * 100.0f) + 20;
-    }
-  }
   delay_control = new OptionControlSP("LagdToggleDelay", tr("Adjust Software Delay"),
                                      tr("Adjust the software delay when Live Learning Steer Delay is toggled off."
                                         "\nThe default software delay value is 0.2"),
-                                     "", {5, liveDelayMaxInt}, 1, false, nullptr, true, true);
+                                     "", {5, 50}, 1, false, nullptr, true, true);
 
   connect(delay_control, &OptionControlSP::updateLabels, [=]() {
     float value = QString::fromStdString(params.get("LagdToggleDelay")).toFloat();
@@ -432,39 +419,36 @@ void ModelsPanel::updateLabels() {
   currentModelLblBtn->setEnabled(!is_onroad && !isDownloading());
   currentModelLblBtn->setValue(GetActiveModelInternalName());
 
+  AlignedBuffer aligned_buf;
+
   // Update lagdToggle description with current value
   QString desc = tr("Enable this for the car to learn and adapt its steering response time. "
                    "Disable to use a fixed steering response time. Keeping this on provides the stock openpilot experience.");
   bool lagdEnabled = params.getBool("LagdToggle");
   if (lagdEnabled) {
-    std::string liveDelayBytes = params.get("LiveDelay");
+    auto liveDelayBytes = params.get("LiveDelay");
     if (!liveDelayBytes.empty()) {
-      capnp::FlatArrayMessageReader msg(kj::ArrayPtr<const capnp::word>(
-        reinterpret_cast<const capnp::word*>(liveDelayBytes.data()),
-        liveDelayBytes.size() / sizeof(capnp::word)));
-      auto event = msg.getRoot<cereal::Event>();
-      if (event.hasLiveDelay()) {
-        auto liveDelay = event.getLiveDelay();
-        float lateralDelay = liveDelay.getLateralDelay();
-        desc += QString("<br><br><b><span style=\"color:#e0e0e0\">%1</span></b> <span style=\"color:#e0e0e0\">%2 s</span>")
-                .arg(tr("Live Steer Delay:")).arg(QString::number(lateralDelay, 'f', 3));
-      }
+      capnp::FlatArrayMessageReader cmsg(aligned_buf.align(liveDelayBytes.data(), liveDelayBytes.size()));
+      cereal::LiveDelayData::Reader LD = cmsg.getRoot<cereal::LiveDelayData>();
+
+      float lateralDelay = LD.getLateralDelay();
+      desc += QString("<br><br><b><span style=\"color:#e0e0e0\">%1</span></b> <span style=\"color:#e0e0e0\">%2 s</span>")
+              .arg(tr("Live Steer Delay:")).arg(QString::number(lateralDelay, 'f', 3));
     }
   } else {
-    std::string carParamsBytes = params.get("CarParamsPersistent");
+    auto carParamsBytes = params.get("CarParamsPersistent");
     if (!carParamsBytes.empty()) {
-      capnp::FlatArrayMessageReader msg(kj::ArrayPtr<const capnp::word>(
-        reinterpret_cast<const capnp::word*>(carParamsBytes.data()),
-        carParamsBytes.size() / sizeof(capnp::word)));
-      auto carParams = msg.getRoot<cereal::CarParams>();
-      float steerDelay = carParams.getSteerActuatorDelay();
+      capnp::FlatArrayMessageReader cmsg(aligned_buf.align(carParamsBytes.data(), carParamsBytes.size()));
+      cereal::CarParams::Reader CP = cmsg.getRoot<cereal::CarParams>();
+
+      float steerDelay = CP.getSteerActuatorDelay();
       float softwareDelay = QString::fromStdString(params.get("LagdToggleDelay")).toFloat();
       float totalLag = steerDelay + softwareDelay;
       desc += QString("<br><br><span style=\"color:#e0e0e0\">"
                       "<b>%1</b> %2 s + <b>%3</b> %4 s = <b>%5</b> %6 s</span>")
-           .arg(tr("Actuator Delay:"), QString::number(steerDelay, 'f', 2),
-                tr("Software Delay:"), QString::number(softwareDelay, 'f', 2),
-                tr("Total Delay:"), QString::number(totalLag, 'f', 2));
+             .arg(tr("Actuator Delay:"), QString::number(steerDelay, 'f', 2),
+                  tr("Software Delay:"), QString::number(softwareDelay, 'f', 2),
+                  tr("Total Delay:"), QString::number(totalLag, 'f', 2));
     }
   }
   lagd_toggle_control->setDescription(desc);

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/models_panel.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/models_panel.h
@@ -9,6 +9,7 @@
 
 #include <QProgressBar>
 
+#include "selfdrive/ui/sunnypilot/qt/util.h"
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/settings.h"
 
 class ModelsPanel : public QWidget {

--- a/selfdrive/ui/sunnypilot/qt/util.cc
+++ b/selfdrive/ui/sunnypilot/qt/util.cc
@@ -110,3 +110,16 @@ QStringList searchFromList(const QString &query, const QStringList &list) {
   }
   return search_results;
 }
+
+std::optional<cereal::Event::Reader> loadCerealEvent(Params& params, const std::string& _param) {
+  std::string bytes = params.get(_param);
+
+  try {
+    AlignedBuffer aligned_buf;
+    capnp::FlatArrayMessageReader cmsg(aligned_buf.align(bytes.data(), bytes.size()));
+    return cmsg.getRoot<cereal::Event>();
+  } catch (kj::Exception& e) {
+    qInfo() << "invalid " << QString::fromStdString(_param) << ":" << e.getDescription().cStr();
+    return std::nullopt;
+  }
+}

--- a/selfdrive/ui/sunnypilot/qt/util.h
+++ b/selfdrive/ui/sunnypilot/qt/util.h
@@ -15,8 +15,11 @@
 #include <QRegularExpression>
 #include <QWidget>
 
+#include "selfdrive/ui/sunnypilot/ui.h"
+
 QString getUserAgent(bool sunnylink = false);
 std::optional<QString> getSunnylinkDongleId();
 std::optional<QString> getParamIgnoringDefault(const std::string &param_name, const std::string &default_value);
 QMap<QString, QVariantMap> loadPlatformList();
 QStringList searchFromList(const QString &query, const QStringList &list);
+std::optional<cereal::Event::Reader> loadCerealEvent(Params& params, const std::string& _param);


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Simplify and standardize cereal message parsing in ModelsPanel by replacing the custom loader with AlignedBuffer alignment for LiveDelay and CarParams data, remove the obsolete safeParamEventLoad function, and streamline the lag toggle delay control settings.

Enhancements:
- Remove safeParamEventLoad helper and parse Params data directly with AlignedBuffer.align
- Hardcode the lag-toggle software delay control range to {5, 50} instead of computing it dynamically
- Update live steer and total delay display to use aligned buffers when reading LiveDelayData and CarParams