### PR TITLE
Revert & Reapply "UI: Developer UI" temporarily due to QT version mismatch

### DIFF
--- a/selfdrive/ui/sunnypilot/qt/onroad/hud.cc
+++ b/selfdrive/ui/sunnypilot/qt/onroad/hud.cc
@@ -171,7 +171,7 @@ int HudRendererSP::drawBottomDevUIElement(QPainter &p, int x, int y, const QStri
   real_rect3.moveTop(real_rect.top());
   real_rect3.moveLeft(real_rect2.right() + 10);
 
-  p.setPen(QColorConstants::White);
+  p.setPen(Qt::white);
   p.drawText(real_rect, Qt::AlignLeft | Qt::AlignVCenter, label);
 
   p.setPen(color);

--- a/selfdrive/ui/sunnypilot/qt/onroad/hud.h
+++ b/selfdrive/ui/sunnypilot/qt/onroad/hud.h
@@ -20,7 +20,7 @@ public:
 
 private:
   Params params;
-  void drawText(QPainter &p, int x, int y, const QString &text, QColor color = QColorConstants::White);
+  void drawText(QPainter &p, int x, int y, const QString &text, QColor color = Qt::white);
   void drawRightDevUI(QPainter &p, int x, int y);
   int drawRightDevUIElement(QPainter &p, int x, int y, const QString &value, const QString &label, const QString &units, QColor &color);
   int drawBottomDevUIElement(QPainter &p, int x, int y, const QString &value, const QString &label, const QString &units, QColor &color);


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Standardize white color usage in the developer HUD by replacing QColorConstants::White with Qt::white

Enhancements:
- Replace p.setPen(QColorConstants::White) with p.setPen(Qt::white) in the bottom developer UI element
- Update drawText default color parameter from QColorConstants::White to Qt::white in the HUD renderer header