### PR TITLE
ui: generic check with ICBM param

### DIFF
--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/longitudinal_panel.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/longitudinal_panel.cc
@@ -80,6 +80,7 @@ void LongitudinalPanel::showEvent(QShowEvent *event) {
 }
 
 void LongitudinalPanel::refresh(bool _offroad) {
+  auto icbm_available = false;
   auto cp_bytes = params.get("CarParamsPersistent");
   auto cp_sp_bytes = params.get("CarParamsSPPersistent");
   if (!cp_bytes.empty() && !cp_sp_bytes.empty()) {
@@ -92,11 +93,12 @@ void LongitudinalPanel::refresh(bool _offroad) {
 
     has_longitudinal_control = hasLongitudinalControl(CP);
     is_pcm_cruise = CP.getPcmCruise();
-    intelligent_cruise_button_management_available = CP_SP.getIntelligentCruiseButtonManagementAvailable();
+    icbm_available = CP_SP.getIntelligentCruiseButtonManagementAvailable();
+    has_intelligent_cruise_button_management = hasIntelligentCruiseButtonManagement(CP_SP);
   } else {
     has_longitudinal_control = false;
     is_pcm_cruise = false;
-    intelligent_cruise_button_management_available = false;
+    has_intelligent_cruise_button_management = false;
   }
 
   QString accEnabledDescription = tr("Enable custom Short & Long press increments for cruise speed increase/decrease.");
@@ -108,7 +110,7 @@ void LongitudinalPanel::refresh(bool _offroad) {
     customAccIncrement->setDescription(onroadOnlyDescription);
     customAccIncrement->showDescription();
   } else {
-    if (has_longitudinal_control || intelligent_cruise_button_management_available) {
+    if (has_longitudinal_control || icbm_available) {
       if (is_pcm_cruise) {
         customAccIncrement->setDescription(accPcmCruiseDisabledDescription);
         customAccIncrement->showDescription();
@@ -125,7 +127,7 @@ void LongitudinalPanel::refresh(bool _offroad) {
     }
   }
 
-  bool icbm_allowed = intelligent_cruise_button_management_available && !has_longitudinal_control;
+  bool icbm_allowed = has_intelligent_cruise_button_management && !has_longitudinal_control;
   intelligentCruiseButtonManagement->setEnabled(icbm_allowed && offroad);
 
   // enable toggle when long is available and is not PCM cruise

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/longitudinal_panel.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/longitudinal_panel.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include "selfdrive/ui/sunnypilot/qt/util.h"
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/longitudinal/custom_acc_increment.h"
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/longitudinal/speed_limit/speed_limit_settings.h"
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/settings.h"
@@ -24,7 +25,7 @@ private:
   Params params;
   bool has_longitudinal_control = false;
   bool is_pcm_cruise = false;
-  bool intelligent_cruise_button_management_available = false;;
+  bool has_intelligent_cruise_button_management = false;;
   bool offroad = false;
 
   QStackedLayout *main_layout = nullptr;

--- a/selfdrive/ui/sunnypilot/qt/util.cc
+++ b/selfdrive/ui/sunnypilot/qt/util.cc
@@ -123,3 +123,7 @@ std::optional<cereal::Event::Reader> loadCerealEvent(Params& params, const std::
     return std::nullopt;
   }
 }
+
+bool hasIntelligentCruiseButtonManagement(const cereal::CarParamsSP::Reader &car_params_sp) {
+  return car_params_sp.getIntelligentCruiseButtonManagementAvailable() && Params().getBool("IntelligentCruiseButtonManagement");
+}

--- a/selfdrive/ui/sunnypilot/qt/util.h
+++ b/selfdrive/ui/sunnypilot/qt/util.h
@@ -23,3 +23,4 @@ std::optional<QString> getParamIgnoringDefault(const std::string &param_name, co
 QMap<QString, QVariantMap> loadPlatformList();
 QStringList searchFromList(const QString &query, const QStringList &list);
 std::optional<cereal::Event::Reader> loadCerealEvent(Params& params, const std::string& _param);
+bool hasIntelligentCruiseButtonManagement(const cereal::CarParamsSP::Reader &car_params_sp);


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Introduce a generic ICBM parameter check and integrate it into the LongitudinalPanel UI logic to properly gate Intelligent Cruise Button Management based on both CarParamsSP capability and user setting

Enhancements:
- Add hasIntelligentCruiseButtonManagement helper to combine CarParamsSP availability and user Params flag for ICBM
- Refactor LongitudinalPanel to use new ICBM availability and renamed has_intelligent_cruise_button_management flag in UI gating logic