### PR TITLE
ui: separate road name toggle param and bigger fonts

### DIFF
--- a/common/params_keys.h
+++ b/common/params_keys.h
@@ -224,7 +224,8 @@ inline static std::unordered_map<std::string, ParamKeyAttributes> keys = {
     {"OsmStateName", {PERSISTENT, STRING, "All"}},
     {"OsmStateTitle", {PERSISTENT, STRING}},
     {"OsmWayTest", {PERSISTENT, STRING}},
-    {"RoadName", {PERSISTENT, STRING}},
+    {"RoadName", {CLEAR_ON_ONROAD_TRANSITION, STRING}},
+    {"RoadNameToggle", {PERSISTENT, STRING}},
 
     // Speed Limit
     {"SpeedLimitMode", {PERSISTENT | BACKUP, INT, "1"}},

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/visuals_panel.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/visuals_panel.cc
@@ -43,7 +43,7 @@ VisualsPanel::VisualsPanel(QWidget *parent) : QWidget(parent) {
       false,
     },
     {
-      "RoadName",
+      "RoadNameToggle",
       tr("Display Road Name"),
       tr("Displays the name of the road the car is traveling on. The OpenStreetMap database of the location must be downloaded from the OSM panel to fetch the road name."),
       "",

--- a/selfdrive/ui/sunnypilot/qt/onroad/hud.cc
+++ b/selfdrive/ui/sunnypilot/qt/onroad/hud.cc
@@ -541,7 +541,7 @@ void HudRendererSP::drawRoadName(QPainter &p, const QRect &surface_rect) {
   rect_width = std::max(min_width, std::min(rect_width, max_width));
 
   // Center at top of screen
-  QRect road_rect(surface_rect.width() / 2 - rect_width / 2, -6, rect_width, 60);
+  QRect road_rect(surface_rect.width() / 2 - rect_width / 2, -4, rect_width, 60);
 
   p.setPen(Qt::NoPen);
   p.setBrush(QColor(0, 0, 0, 120));

--- a/selfdrive/ui/sunnypilot/qt/onroad/hud.cc
+++ b/selfdrive/ui/sunnypilot/qt/onroad/hud.cc
@@ -528,7 +528,7 @@ void HudRendererSP::drawRoadName(QPainter &p, const QRect &surface_rect) {
   if (!roadName || roadNameStr.isEmpty()) return;
 
   // Measure text to size container
-  p.setFont(InterFont(40, QFont::Normal));
+  p.setFont(InterFont(46, QFont::DemiBold));
   QFontMetrics fm(p.font());
 
   int text_width = fm.horizontalAdvance(roadNameStr);

--- a/selfdrive/ui/sunnypilot/ui.cc
+++ b/selfdrive/ui/sunnypilot/ui.cc
@@ -54,7 +54,7 @@ void ui_update_params_sp(UIStateSP *s) {
   s->scene.dev_ui_info = std::atoi(params.get("DevUIInfo").c_str());
   s->scene.standstill_timer = params.getBool("StandstillTimer");
   s->scene.speed_limit_mode = std::atoi(params.get("SpeedLimitMode").c_str());
-  s->scene.road_name = params.getBool("RoadName");
+  s->scene.road_name = params.getBool("RoadNameToggle");
 }
 
 DeviceSP::DeviceSP(QObject *parent) : Device(parent) {


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Separate the road name display toggle into its own persistent parameter and clear the stored road name on on-road transitions, and update the HUD to use a larger, bolder font for the road name with a slight vertical adjustment.

Enhancements:
- Split the road name display toggle into a dedicated persistent parameter and clear the road name string on on-road transitions
- Increase the road name font size to 46 DemiBold and adjust its vertical positioning in the HUD window