### PR TITLE
ui: more speed limit improvements

### DIFF
--- a/selfdrive/ui/sunnypilot/qt/onroad/hud.cc
+++ b/selfdrive/ui/sunnypilot/qt/onroad/hud.cc
@@ -335,7 +335,8 @@ void HudRendererSP::drawStandstillTimer(QPainter &p, int x, int y) {
 void HudRendererSP::drawSpeedLimitSigns(QPainter &p) {
   bool speedLimitValid = speedLimit > 0;
   int speedLimitRounded = std::nearbyint(speedLimit);
-  bool overspeed = speedLimitRounded < std::nearbyint(speed) && speedLimitRounded > 0;
+  int speedLimitFinalRounded = std::nearbyint(speedLimit + speedLimitOffset);
+  bool overspeed = speedLimitFinalRounded < std::nearbyint(speed) && speedLimitRounded > 0;
   bool speedLimitWarningEnabled = speedLimitMode == SpeedLimitMode::WARNING;
   QString speedLimitStr = speedLimitValid ? QString::number(speedLimitRounded) : "---";
 

--- a/selfdrive/ui/sunnypilot/qt/onroad/hud.cc
+++ b/selfdrive/ui/sunnypilot/qt/onroad/hud.cc
@@ -48,7 +48,7 @@ void HudRendererSP::updateState(const UIState &s) {
   speedLimitAheadDistancePrev = speedLimitAheadDistance;
 
   if (speedLimitValid) {
-    speedLimitLastValid = speedLimit;
+    speedLimitLast = speedLimit;
   }
 
   static int reverse_delay = 0;
@@ -339,12 +339,12 @@ void HudRendererSP::drawStandstillTimer(QPainter &p, int x, int y) {
 
 void HudRendererSP::drawSpeedLimitSigns(QPainter &p) {
   int speedLimitRounded = std::nearbyint(speedLimit);
-  bool useLastValidSpeedLimit = !speedLimitValid && speedLimitLastValid > 0;
+  bool useLastValidSpeedLimit = !speedLimitValid && speedLimitLast > 0;
   int speedLimitFinalRounded = std::nearbyint(speedLimit + speedLimitOffset);
   bool overspeed = speedLimitFinalRounded < std::nearbyint(speed) && speedLimitRounded > 0;
   bool speedLimitWarningEnabled = speedLimitMode == SpeedLimitMode::WARNING;
   QString speedLimitStr = speedLimitValid ? QString::number(speedLimitRounded) :
-                          (useLastValidSpeedLimit ? QString::number(speedLimitLastValid) : "---");
+                          (useLastValidSpeedLimit ? QString::number(speedLimitLast) : "---");
 
   // Offset display text
   QString speedLimitSubText = "";

--- a/selfdrive/ui/sunnypilot/qt/onroad/hud.cc
+++ b/selfdrive/ui/sunnypilot/qt/onroad/hud.cc
@@ -340,9 +340,9 @@ void HudRendererSP::drawStandstillTimer(QPainter &p, int x, int y) {
 
 void HudRendererSP::drawSpeedLimitSigns(QPainter &p) {
   bool hasSpeedLimit = speedLimitValid || speedLimitLastValid;
-  int speedLimitFinal = speedLimitValid ? std::nearbyint(speedLimit) : std::nearbyint(speedLimitLast);
+  int speedLimitFinal = std::nearbyint(speedLimitValid ? speedLimit : speedLimitLast);
   int speedLimitOffsetFinal = speedLimitFinal + std::nearbyint(speedLimitOffset);
-  bool overspeed = speedLimitOffsetFinal < std::nearbyint(speed) && hasSpeedLimit;
+  bool overspeed = hasSpeedLimit && speedLimitOffsetFinal < std::nearbyint(speed);
   bool speedLimitWarningEnabled = speedLimitMode == SpeedLimitMode::WARNING;  // TODO-SP: update to include SpeedLimitMode::ASSIST
   QString speedLimitStr = hasSpeedLimit ? QString::number(speedLimitFinal) : "---";
 
@@ -354,7 +354,7 @@ void HudRendererSP::drawSpeedLimitSigns(QPainter &p) {
 
   float speedLimitSubTextFactor = is_metric ? 0.5 : 0.6;
   if (speedLimitSubText.size() >= 3) {
-    speedLimitSubTextFactor = is_metric ? 0.475 : 0.475;
+    speedLimitSubTextFactor = 0.475;
   }
 
   // Position next to MAX speed box

--- a/selfdrive/ui/sunnypilot/qt/onroad/hud.cc
+++ b/selfdrive/ui/sunnypilot/qt/onroad/hud.cc
@@ -40,7 +40,7 @@ void HudRendererSP::updateState(const UIState &s) {
     speedLimitAheadValid = lmd.getSpeedLimitAheadValid();
     speedLimitAhead = lmd.getSpeedLimitAhead() * speedConv;
     speedLimitAheadDistance = lmd.getSpeedLimitAheadDistance();
-    if (speedLimitAheadDistance < speedLimitAheadDistancePrev && speedLimitAheadValidFrame < 2) {
+    if (speedLimitAheadDistance < speedLimitAheadDistancePrev && speedLimitAheadValidFrame < SPEED_LIMIT_AHEAD_VALID_FRAME_THRESHOLD) {
       speedLimitAheadValidFrame++;
     } else if (speedLimitAheadDistance > speedLimitAheadDistancePrev && speedLimitAheadValidFrame > 0) {
       speedLimitAheadValidFrame--;

--- a/selfdrive/ui/sunnypilot/qt/onroad/hud.cc
+++ b/selfdrive/ui/sunnypilot/qt/onroad/hud.cc
@@ -339,12 +339,12 @@ void HudRendererSP::drawStandstillTimer(QPainter &p, int x, int y) {
 }
 
 void HudRendererSP::drawSpeedLimitSigns(QPainter &p) {
-  int speedLimitRounded = std::nearbyint(speedLimit);
-  int speedLimitFinalRounded = std::nearbyint(speedLimit + speedLimitOffset);
-  bool overspeed = speedLimitFinalRounded < std::nearbyint(speed) && speedLimitRounded > 0;
-  bool speedLimitWarningEnabled = speedLimitMode == SpeedLimitMode::WARNING;
-  QString speedLimitStr = speedLimitValid ? QString::number(speedLimitRounded) :
-                          (speedLimitLastValid ? QString::number(std::nearbyint(speedLimitLast)) : "---");
+  bool hasSpeedLimit = speedLimitValid || speedLimitLastValid;
+  int speedLimitFinal = speedLimitValid ? std::nearbyint(speedLimit) : std::nearbyint(speedLimitLast);
+  int speedLimitOffsetFinal = speedLimitFinal + std::nearbyint(speedLimitOffset);
+  bool overspeed = speedLimitOffsetFinal < std::nearbyint(speed) && hasSpeedLimit;
+  bool speedLimitWarningEnabled = speedLimitMode == SpeedLimitMode::WARNING;  // TODO-SP: update to include SpeedLimitMode::ASSIST
+  QString speedLimitStr = hasSpeedLimit ? QString::number(speedLimitFinal) : "---";
 
   // Offset display text
   QString speedLimitSubText = "";
@@ -406,7 +406,7 @@ void HudRendererSP::drawSpeedLimitSigns(QPainter &p) {
     p.drawText(center_circle, Qt::AlignCenter, speedLimitStr);
 
     // Offset value in small circular box
-    if (!speedLimitSubText.isEmpty() && (speedLimitValid || speedLimitLastValid)) {
+    if (!speedLimitSubText.isEmpty() && hasSpeedLimit) {
       int offset_circle_size = circle_size * 0.4;
       int overlap = offset_circle_size * 0.25;
       QRect offset_circle_rect(
@@ -451,7 +451,7 @@ void HudRendererSP::drawSpeedLimitSigns(QPainter &p) {
     p.drawText(inner_rect.adjusted(0, 80, 0, 0), Qt::AlignTop | Qt::AlignHCenter, speedLimitStr);
 
     // Offset value in small box
-    if (!speedLimitSubText.isEmpty() && (speedLimitValid || speedLimitLastValid)) {
+    if (!speedLimitSubText.isEmpty() && hasSpeedLimit) {
       int offset_box_size = sign_rect.width() * 0.4;
       int overlap = offset_box_size * 0.25;
       QRect offset_box_rect(

--- a/selfdrive/ui/sunnypilot/qt/onroad/hud.cc
+++ b/selfdrive/ui/sunnypilot/qt/onroad/hud.cc
@@ -349,7 +349,12 @@ void HudRendererSP::drawSpeedLimitSigns(QPainter &p) {
   // Offset display text
   QString speedLimitSubText = "";
   if (speedLimitOffset != 0) {
-    speedLimitSubText = (speedLimitOffset > 0 ? "+" : "-") + QString::number(std::nearbyint(speedLimitOffset));
+    speedLimitSubText = (speedLimitOffset > 0 ? "" : "-") + QString::number(std::nearbyint(speedLimitOffset));
+  }
+
+  float speedLimitSubTextFactor = is_metric ? 0.5 : 0.6;
+  if (speedLimitSubText.size() >= 3) {
+    speedLimitSubTextFactor = is_metric ? 0.475 : 0.475;
   }
 
   // Position next to MAX speed box
@@ -415,7 +420,7 @@ void HudRendererSP::drawSpeedLimitSigns(QPainter &p) {
       p.setBrush(QColor(0, 0, 0, alpha));
       p.drawEllipse(offset_circle_rect);
 
-      p.setFont(InterFont(offset_circle_size * 0.45, QFont::Bold));
+      p.setFont(InterFont(offset_circle_size * speedLimitSubTextFactor, QFont::Bold));
       p.setPen(QColor(255, 255, 255, alpha));
       p.drawText(offset_circle_rect, Qt::AlignCenter, speedLimitSubText);
     }
@@ -461,7 +466,7 @@ void HudRendererSP::drawSpeedLimitSigns(QPainter &p) {
       p.setBrush(QColor(0, 0, 0, alpha));
       p.drawRoundedRect(offset_box_rect, corner_radius, corner_radius);
 
-      p.setFont(InterFont(offset_box_size * 0.45, QFont::Bold));
+      p.setFont(InterFont(offset_box_size * speedLimitSubTextFactor, QFont::Bold));
       p.setPen(QColor(255, 255, 255, alpha));
       p.drawText(offset_box_rect, Qt::AlignCenter, speedLimitSubText);
     }

--- a/selfdrive/ui/sunnypilot/qt/onroad/hud.cc
+++ b/selfdrive/ui/sunnypilot/qt/onroad/hud.cc
@@ -344,7 +344,7 @@ void HudRendererSP::drawSpeedLimitSigns(QPainter &p) {
   bool overspeed = speedLimitFinalRounded < std::nearbyint(speed) && speedLimitRounded > 0;
   bool speedLimitWarningEnabled = speedLimitMode == SpeedLimitMode::WARNING;
   QString speedLimitStr = speedLimitValid ? QString::number(speedLimitRounded) :
-                          (useLastValidSpeedLimit ? QString::number(speedLimitLast) : "---");
+                          (useLastValidSpeedLimit ? QString::number(std::nearbyint(speedLimitLast)) : "---");
 
   // Offset display text
   QString speedLimitSubText = "";

--- a/selfdrive/ui/sunnypilot/qt/onroad/hud.h
+++ b/selfdrive/ui/sunnypilot/qt/onroad/hud.h
@@ -69,6 +69,8 @@ private:
   int smartCruiseControlVisionFrame;
   float speedLimit;
   float speedLimitOffset;
+  bool speedLimitValid;
+  float speedLimitLastValid;
   bool speedLimitAheadValid;
   float speedLimitAhead;
   float speedLimitAheadDistance;

--- a/selfdrive/ui/sunnypilot/qt/onroad/hud.h
+++ b/selfdrive/ui/sunnypilot/qt/onroad/hud.h
@@ -11,6 +11,8 @@
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/longitudinal/speed_limit/helpers.h"
 #include "selfdrive/ui/sunnypilot/qt/onroad/developer_ui/developer_ui.h"
 
+constexpr int SPEED_LIMIT_AHEAD_VALID_FRAME_THRESHOLD = 5;
+
 class HudRendererSP : public HudRenderer {
   Q_OBJECT
 

--- a/selfdrive/ui/sunnypilot/qt/onroad/hud.h
+++ b/selfdrive/ui/sunnypilot/qt/onroad/hud.h
@@ -68,9 +68,9 @@ private:
   bool smartCruiseControlVisionActive;
   int smartCruiseControlVisionFrame;
   float speedLimit;
+  float speedLimitLast;
   float speedLimitOffset;
   bool speedLimitValid;
-  float speedLimitLastValid;
   bool speedLimitAheadValid;
   float speedLimitAhead;
   float speedLimitAheadDistance;

--- a/selfdrive/ui/sunnypilot/qt/onroad/hud.h
+++ b/selfdrive/ui/sunnypilot/qt/onroad/hud.h
@@ -71,6 +71,7 @@ private:
   float speedLimitLast;
   float speedLimitOffset;
   bool speedLimitValid;
+  bool speedLimitLastValid;
   bool speedLimitAheadValid;
   float speedLimitAhead;
   float speedLimitAheadDistance;


### PR DESCRIPTION
- show speed limit offset with last valid speed limit
- show last valid speed limit if current speed limit is not valid

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Track and display the last valid speed limit when the current limit is unavailable, including its offset and a distinct color treatment.

Enhancements:
- Add speedLimitValid and speedLimitLastValid fields to HUD renderer state
- Record and update the last valid speed limit whenever a new valid limit is detected
- Fallback to displaying the last valid speed limit and its offset when the current limit is invalid
- Adjust speed sign text and color to reflect usage of the last valid speed limit