### PR TITLE
liveMapDataSP: parse bearing from GPS

### DIFF
--- a/sunnypilot/mapd/live_map_data/osm_map_data.py
+++ b/sunnypilot/mapd/live_map_data/osm_map_data.py
@@ -9,6 +9,7 @@ import math
 import platform
 
 from openpilot.common.params import Params
+from openpilot.common.realtime import DT_MDL
 from openpilot.sunnypilot.mapd.live_map_data.base_map_data import BaseMapData
 from openpilot.sunnypilot.navd.helpers import Coordinate
 

--- a/sunnypilot/mapd/live_map_data/osm_map_data.py
+++ b/sunnypilot/mapd/live_map_data/osm_map_data.py
@@ -5,6 +5,7 @@ This file is part of sunnypilot and is licensed under the MIT License.
 See the LICENSE.md file in the root directory for more details.
 """
 import json
+import math
 import platform
 
 from openpilot.common.params import Params
@@ -15,17 +16,26 @@ from openpilot.sunnypilot.navd.helpers import Coordinate
 class OsmMapData(BaseMapData):
   def __init__(self):
     super().__init__()
-    self.params = Params()
     self.mem_params = Params("/dev/shm/params") if platform.system() != "Darwin" else self.params
 
   def update_location(self) -> None:
-    if self.last_position is None or self.last_altitude is None:
+    gps = self.sm[self.gps_location_service]
+    gps_ok = self.sm.recv_frame[self.gps_location_service] > 0 and (self.sm.frame - self.sm.recv_frame[self.gps_location_service]) * DT_MDL < 2.0
+
+    if gps_ok:
+      self.last_bearing = gps.bearingDeg * 180/math.pi
+      self.last_position = Coordinate(gps.latitude, gps.longitude)
+
+    if not gps_ok and self.sm['livePose'].inputsOK:
+      return
+
+    if self.last_position is None:
       return
 
     params = {
       "latitude": self.last_position.latitude,
       "longitude": self.last_position.longitude,
-      "altitude": self.last_altitude,
+      "bearing": self.last_bearing,
     }
 
     self.mem_params.put("LastGPSPosition", json.dumps(params))


### PR DESCRIPTION
Not as reliable as KF-ed positions, so maybe we want LLK back or fused with LivePose at some point? Time will tell.

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Add GPS bearing parsing to live map data and remove outdated altitude and fallback logic

New Features:
- Parse and store GPS bearing in live map data

Enhancements:
- Drop legacy get_current_location method and remove last_altitude tracking
- Simplify tick logic by using sm.update(0) and consolidating location updates
- Remove unused imports and redundant Params initialization