### PR TITLE
SCC-M: overriding is an enabled state

### DIFF
--- a/sunnypilot/selfdrive/controls/lib/smart_cruise_control/map_controller.py
+++ b/sunnypilot/selfdrive/controls/lib/smart_cruise_control/map_controller.py
@@ -12,8 +12,8 @@ from openpilot.sunnypilot.selfdrive.controls.lib.smart_cruise_control import MIN
 
 MapState = VisionState = custom.LongitudinalPlanSP.SmartCruiseControl.MapState
 
-ACTIVE_STATES = (MapState.turning, MapState.overriding)
-ENABLED_STATES = (MapState.enabled, *ACTIVE_STATES)
+ACTIVE_STATES = (MapState.turning, )
+ENABLED_STATES = (MapState.enabled, MapState.overriding, *ACTIVE_STATES)
 
 R = 6373000.0  # approximate radius of earth in meters
 TO_RADIANS = math.pi / 180


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Enhancements:
- Remove overriding from ACTIVE_STATES and explicitly include it in ENABLED_STATES