### PR TITLE
Revert "ui: generic check with ICBM param"

### DIFF
--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/longitudinal_panel.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/longitudinal_panel.cc
@@ -87,7 +87,6 @@ void LongitudinalPanel::showEvent(QShowEvent *event) {
 }
 
 void LongitudinalPanel::refresh(bool _offroad) {
-  auto icbm_available = false;
   auto cp_bytes = params.get("CarParamsPersistent");
   auto cp_sp_bytes = params.get("CarParamsSPPersistent");
   if (!cp_bytes.empty() && !cp_sp_bytes.empty()) {
@@ -100,12 +99,11 @@ void LongitudinalPanel::refresh(bool _offroad) {
 
     has_longitudinal_control = hasLongitudinalControl(CP);
     is_pcm_cruise = CP.getPcmCruise();
-    icbm_available = CP_SP.getIntelligentCruiseButtonManagementAvailable();
-    has_intelligent_cruise_button_management = hasIntelligentCruiseButtonManagement(CP_SP);
+    intelligent_cruise_button_management_available = CP_SP.getIntelligentCruiseButtonManagementAvailable();
   } else {
     has_longitudinal_control = false;
     is_pcm_cruise = false;
-    has_intelligent_cruise_button_management = false;
+    intelligent_cruise_button_management_available = false;
   }
 
   QString accEnabledDescription = tr("Enable custom Short & Long press increments for cruise speed increase/decrease.");
@@ -117,7 +115,7 @@ void LongitudinalPanel::refresh(bool _offroad) {
     customAccIncrement->setDescription(onroadOnlyDescription);
     customAccIncrement->showDescription();
   } else {
-    if (has_longitudinal_control || icbm_available) {
+    if (has_longitudinal_control || intelligent_cruise_button_management_available) {
       if (is_pcm_cruise) {
         customAccIncrement->setDescription(accPcmCruiseDisabledDescription);
         customAccIncrement->showDescription();
@@ -134,7 +132,7 @@ void LongitudinalPanel::refresh(bool _offroad) {
     }
   }
 
-  bool icbm_allowed = has_intelligent_cruise_button_management && !has_longitudinal_control;
+  bool icbm_allowed = intelligent_cruise_button_management_available && !has_longitudinal_control;
   intelligentCruiseButtonManagement->setEnabled(icbm_allowed && offroad);
 
   // enable toggle when long is available and is not PCM cruise

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/longitudinal_panel.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/longitudinal_panel.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include "selfdrive/ui/sunnypilot/qt/util.h"
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/longitudinal/custom_acc_increment.h"
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/longitudinal/speed_limit/speed_limit_settings.h"
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/settings.h"
@@ -25,7 +24,7 @@ private:
   Params params;
   bool has_longitudinal_control = false;
   bool is_pcm_cruise = false;
-  bool has_intelligent_cruise_button_management = false;;
+  bool intelligent_cruise_button_management_available = false;;
   bool offroad = false;
 
   QStackedLayout *main_layout = nullptr;

--- a/selfdrive/ui/sunnypilot/qt/util.cc
+++ b/selfdrive/ui/sunnypilot/qt/util.cc
@@ -123,7 +123,3 @@ std::optional<cereal::Event::Reader> loadCerealEvent(Params& params, const std::
     return std::nullopt;
   }
 }
-
-bool hasIntelligentCruiseButtonManagement(const cereal::CarParamsSP::Reader &car_params_sp) {
-  return car_params_sp.getIntelligentCruiseButtonManagementAvailable() && Params().getBool("IntelligentCruiseButtonManagement");
-}

--- a/selfdrive/ui/sunnypilot/qt/util.h
+++ b/selfdrive/ui/sunnypilot/qt/util.h
@@ -23,4 +23,3 @@ std::optional<QString> getParamIgnoringDefault(const std::string &param_name, co
 QMap<QString, QVariantMap> loadPlatformList();
 QStringList searchFromList(const QString &query, const QStringList &list);
 std::optional<cereal::Event::Reader> loadCerealEvent(Params& params, const std::string& _param);
-bool hasIntelligentCruiseButtonManagement(const cereal::CarParamsSP::Reader &car_params_sp);


### PR DESCRIPTION
Reverts sunnypilot/sunnypilot#1274

## Summary by Sourcery

Revert the previous introduction of a generic Intelligent Cruise Button Management (ICBM) parameter and restore direct use of CarParamsSP.getIntelligentCruiseButtonManagementAvailable in the UI.

Enhancements:
- Remove the hasIntelligentCruiseButtonManagement utility function and its import
- Inline the ICBM availability check and remove the generic ICBM parameter toggle
- Rename the UI flag from has_intelligent_cruise_button_management to intelligent_cruise_button_management_available