### PR TITLE
Fix params loading delay on startup

### DIFF
--- a/sunnypilot/selfdrive/controls/lib/param_store.py
+++ b/sunnypilot/selfdrive/controls/lib/param_store.py
@@ -22,7 +22,7 @@ class ParamStore:
     self.keys = universal_params + brand_params
     self._params = {}
 
-    self.frame = 0
+    self.frame = -1
 
   def update(self, params: Params) -> None:
     self.frame += 1


### PR DESCRIPTION
Makes sure `self.param_store.update` gets processed on first call.

Partially fixes #1293 