### PR TITLE
ui: only longitudinal cars can use Speed Limit Assist

### DIFF
--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/longitudinal/speed_limit/speed_limit_settings.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/longitudinal/speed_limit/speed_limit_settings.cc
@@ -108,6 +108,25 @@ void SpeedLimitSettings::refresh() {
   SpeedLimitOffsetType offset_type_param = static_cast<SpeedLimitOffsetType>(std::atoi(params.get("SpeedLimitOffsetType").c_str()));
   QString offsetLabel = QString::fromStdString(params.get("SpeedLimitValueOffset"));
 
+  bool has_longitudinal_control;
+  bool intelligent_cruise_button_management_available;
+  auto cp_bytes = params.get("CarParamsPersistent");
+  auto cp_sp_bytes = params.get("CarParamsSPPersistent");
+  if (!cp_bytes.empty() && !cp_sp_bytes.empty()) {
+    AlignedBuffer aligned_buf;
+    AlignedBuffer aligned_buf_sp;
+    capnp::FlatArrayMessageReader cmsg(aligned_buf.align(cp_bytes.data(), cp_bytes.size()));
+    capnp::FlatArrayMessageReader cmsg_sp(aligned_buf_sp.align(cp_sp_bytes.data(), cp_sp_bytes.size()));
+    cereal::CarParams::Reader CP = cmsg.getRoot<cereal::CarParams>();
+    cereal::CarParamsSP::Reader CP_SP = cmsg_sp.getRoot<cereal::CarParamsSP>();
+
+    has_longitudinal_control = hasLongitudinalControl(CP);
+    intelligent_cruise_button_management_available = CP_SP.getIntelligentCruiseButtonManagementAvailable();
+  } else {
+    has_longitudinal_control = false;
+    intelligent_cruise_button_management_available = false;
+  }
+
   speed_limit_mode_settings->setDescription(modeDescription(speed_limit_mode_param));
   speed_limit_offset->setDescription(offsetDescription(offset_type_param));
 
@@ -123,6 +142,13 @@ void SpeedLimitSettings::refresh() {
     speed_limit_offset->setVisible(true);
     speed_limit_offset->setLabel(offsetLabel);
     speed_limit_offset->showDescription();
+  }
+
+  if (has_longitudinal_control || intelligent_cruise_button_management_available) {
+    speed_limit_mode_settings->setEnableSelectedButtons(true, convertSpeedLimitModeValues(getSpeedLimitModeValues()));
+  } else {
+    speed_limit_mode_settings->setEnableSelectedButtons(true, convertSpeedLimitModeValues(
+      {SpeedLimitMode::OFF,SpeedLimitMode::INFORMATION, SpeedLimitMode::WARNING}));
   }
 
   speed_limit_mode_settings->showDescription();

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/longitudinal/speed_limit/speed_limit_settings.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/longitudinal/speed_limit/speed_limit_settings.h
@@ -76,4 +76,21 @@ private:
         .arg(warning_str)
         .arg(assist_str);
   }
+
+  static std::vector<SpeedLimitMode> getSpeedLimitModeValues() {
+    std::vector<SpeedLimitMode> values;
+    for (int i = static_cast<int>(SpeedLimitMode::OFF);
+         i <= static_cast<int>(SpeedLimitMode::ASSIST); ++i) {
+      values.push_back(static_cast<SpeedLimitMode>(i));
+    }
+    return values;
+  }
+
+  static std::vector<int> convertSpeedLimitModeValues(const std::vector<SpeedLimitMode> &modes) {
+    std::vector<int> values;
+    for (const auto& mode : modes) {
+      values.push_back(static_cast<int>(mode));
+    }
+    return values;
+  }
 };


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Restrict Speed Limit Assist selection in the UI to vehicles that support longitudinal control or intelligent cruise button management and introduce utility functions for handling speed limit modes

Enhancements:
- Allow Speed Limit Assist only on cars with longitudinal control or intelligent cruise button management by reading persisted CarParams and CarParamsSP
- Add helper methods to enumerate and convert SpeedLimitMode values for UI settings