### PR TITLE
sunnylink: enhanced param keys fetch with data type

### DIFF
--- a/sunnypilot/sunnylink/athena/sunnylinkd.py
+++ b/sunnypilot/sunnylink/athena/sunnylinkd.py
@@ -185,7 +185,7 @@ def getParamsAllKeys() -> dict[str, str]:
       "default_value": base64.b64encode(value).decode('utf-8') if value else None,
     })
 
-  return {"keys": json.dumps(available_keys), "keys_v1": json.dumps(params_dict.get("params", []))}
+  return {"keys": json.dumps(params_dict.get("params", []))}
 
 
 @dispatcher.add_method

--- a/sunnypilot/sunnylink/athena/sunnylinkd.py
+++ b/sunnypilot/sunnylink/athena/sunnylinkd.py
@@ -173,17 +173,31 @@ def toggleLogUpload(enabled: bool):
 
 
 @dispatcher.add_method
-def getParamsAllKeys() -> list[str]:
-  keys: list[str] = [k.decode('utf-8') for k in Params().all_keys()]
-  return keys
+def getParamsAllKeys() -> dict[str, str]:
+  available_keys: list[str] = [k.decode('utf-8') for k in Params().all_keys()]
+
+  params_dict: dict[str, list[dict[str, str | bool | int | None]]] = {"params": []}
+  for key in available_keys:
+    value = get_param_as_byte(key, get_default=True)
+    if value is None:
+      continue
+
+    params_dict["params"].append({
+      "key": key,
+      "type": int(params.get_type(key).value),
+      "default_value": base64.b64encode(value).decode('utf-8') if value else None,
+    })
+
+  return {"keys_v0": json.dumps(available_keys), "keys_v1": json.dumps(params_dict.get("params", []))}
 
 
 @dispatcher.add_method
 def getParams(params_keys: list[str], compression: bool = False) -> str | dict[str, str]:
   params = Params()
+  available_keys: list[str] = [k.decode('utf-8') for k in Params().all_keys()]
 
   try:
-    param_keys_validated = [key for key in params_keys if key in getParamsAllKeys()]
+    param_keys_validated = [key for key in params_keys if key in available_keys]
     params_dict: dict[str, list[dict[str, str | bool | int]]] = {"params": []}
     for key in param_keys_validated:
       value = get_param_as_byte(key)

--- a/sunnypilot/sunnylink/athena/sunnylinkd.py
+++ b/sunnypilot/sunnylink/athena/sunnylinkd.py
@@ -173,7 +173,12 @@ def toggleLogUpload(enabled: bool):
 
 
 @dispatcher.add_method
-def getParamsAllKeys() -> dict[str, str]:
+def getParamsAllKeys() -> list[str]:
+  keys: list[str] = [k.decode('utf-8') for k in Params().all_keys()]
+  return keys
+
+@dispatcher.add_method
+def getParamsAllKeysV1() -> dict[str, str]:
   available_keys: list[str] = [k.decode('utf-8') for k in Params().all_keys()]
 
   params_dict: dict[str, list[dict[str, str | bool | int | None]]] = {"params": []}

--- a/sunnypilot/sunnylink/athena/sunnylinkd.py
+++ b/sunnypilot/sunnylink/athena/sunnylinkd.py
@@ -188,7 +188,7 @@ def getParamsAllKeys() -> dict[str, str]:
       "default_value": base64.b64encode(value).decode('utf-8') if value else None,
     })
 
-  return {"keys_v0": json.dumps(available_keys), "keys_v1": json.dumps(params_dict.get("params", []))}
+  return {"keys": json.dumps(available_keys), "keys_v1": json.dumps(params_dict.get("params", []))}
 
 
 @dispatcher.add_method

--- a/sunnypilot/sunnylink/athena/sunnylinkd.py
+++ b/sunnypilot/sunnylink/athena/sunnylinkd.py
@@ -179,9 +179,6 @@ def getParamsAllKeys() -> dict[str, str]:
   params_dict: dict[str, list[dict[str, str | bool | int | None]]] = {"params": []}
   for key in available_keys:
     value = get_param_as_byte(key, get_default=True)
-    if value is None:
-      continue
-
     params_dict["params"].append({
       "key": key,
       "type": int(params.get_type(key).value),

--- a/sunnypilot/sunnylink/athena/sunnylinkd.py
+++ b/sunnypilot/sunnylink/athena/sunnylinkd.py
@@ -177,6 +177,7 @@ def getParamsAllKeys() -> list[str]:
   keys: list[str] = [k.decode('utf-8') for k in Params().all_keys()]
   return keys
 
+
 @dispatcher.add_method
 def getParamsAllKeysV1() -> dict[str, str]:
   available_keys: list[str] = [k.decode('utf-8') for k in Params().all_keys()]

--- a/sunnypilot/sunnylink/utils.py
+++ b/sunnypilot/sunnylink/utils.py
@@ -60,7 +60,7 @@ def get_api_token():
   print(f"API Token: {token}")
 
 
-def _to_bytes(value: bytes, param_type: ParamKeyType) -> bytes | None:
+def _to_bytes(value: bytes | None, param_type: ParamKeyType) -> bytes | None:
   """Convert a parameter value to bytes based on its type."""
   if value is None:
     return None

--- a/sunnypilot/sunnylink/utils.py
+++ b/sunnypilot/sunnylink/utils.py
@@ -60,7 +60,7 @@ def get_api_token():
   print(f"API Token: {token}")
 
 
-def _to_bytes(value: Any, param_type: ParamKeyType) -> bytes | None:
+def _to_bytes(value: bytes, param_type: ParamKeyType) -> bytes | None:
   """Convert a parameter value to bytes based on its type."""
   if value is None:
     return None

--- a/sunnypilot/sunnylink/utils.py
+++ b/sunnypilot/sunnylink/utils.py
@@ -75,7 +75,7 @@ def _to_bytes(value: bytes, param_type: ParamKeyType) -> bytes | None:
 def get_param_as_byte(param_name: str, params=None, get_default=False) -> bytes | None:
   """Get a parameter as bytes. Returns None if the parameter does not exist."""
   params = params or Params()
-  value = params.get(param_name) if not get_default else params.get_default(param_name)
+  value = params.get(param_name) if not get_default else params.get_default_value(param_name)
   param_type = params.get_type(param_name)
   return _to_bytes(value, param_type)
 

--- a/sunnypilot/sunnylink/utils.py
+++ b/sunnypilot/sunnylink/utils.py
@@ -60,20 +60,24 @@ def get_api_token():
   print(f"API Token: {token}")
 
 
-def get_param_as_byte(param_name: str, params=None) -> bytes | None:
-  """Get a parameter as bytes. Returns None if the parameter does not exist."""
-  params = params or Params() # Use existing Params instance if provided
-  param = params.get(param_name)
-  if param is None:
+def _to_bytes(value: Any, param_type: ParamKeyType) -> bytes | None:
+  """Convert a parameter value to bytes based on its type."""
+  if value is None:
     return None
 
-  param_type = params.get_type(param_name)
   if param_type == ParamKeyType.BYTES:
-    return bytes(param)
-  elif param_type == ParamKeyType.JSON:
-    return json.dumps(param).encode('utf-8')
-  return str(param).encode('utf-8')
+    return bytes(value)
+  if param_type == ParamKeyType.JSON:
+    return json.dumps(value).encode("utf-8")
+  return str(value).encode("utf-8")
 
+
+def get_param_as_byte(param_name: str, params=None, get_default=False) -> bytes | None:
+  """Get a parameter as bytes. Returns None if the parameter does not exist."""
+  params = params or Params()
+  value = params.get(param_name) if not get_default else params.get_default(param_name)
+  param_type = params.get_type(param_name)
+  return _to_bytes(value, param_type)
 
 def save_param_from_base64_encoded_string(param_name: str, base64_encoded_data: str, is_compressed=False) -> None:
   """Save a parameter from bytes. Overwrites the parameter if it already exists."""


### PR DESCRIPTION
## Summary by Sourcery

Improve parameter key fetching by refactoring byte conversion logic to support default values and introducing a versioned RPC for retrieving keys with types and default values.

New Features:
- Add getParamsAllKeysV1 RPC method to return parameter keys with their types and base64-encoded default values

Enhancements:
- Refactor get_param_as_byte to use a private _to_bytes helper and support fetching default values
- Update getParams to validate keys against a local list of available keys instead of calling getParamsAllKeys()