### PR TITLE
Device: Wake for all visual alerts

### DIFF
--- a/selfdrive/ui/sunnypilot/qt/onroad/hud.cc
+++ b/selfdrive/ui/sunnypilot/qt/onroad/hud.cc
@@ -207,6 +207,8 @@ void HudRendererSP::draw(QPainter &p, const QRect &surface_rect) {
     // Green Light Alert
     if (greenLightAlert) {
       e2eAlertDisplayTimer = 3 * UI_FREQ;
+      // reset onroad sleep timer for e2e alerts
+      uiStateSP()->reset_onroad_sleep_timer();
     }
 
     if (e2eAlertDisplayTimer > 0) {

--- a/selfdrive/ui/sunnypilot/ui.cc
+++ b/selfdrive/ui/sunnypilot/ui.cc
@@ -14,8 +14,7 @@ void UIStateSP::updateStatus() {
 
   if (scene.started && scene.onroadScreenOffControl) {
     auto selfdriveState = (*sm)["selfdriveState"].getSelfdriveState();
-    if (selfdriveState.getAlertSize() != cereal::SelfdriveState::AlertSize::NONE &&
-        selfdriveState.getAlertStatus() != cereal::SelfdriveState::AlertStatus::NORMAL) {
+    if (selfdriveState.getAlertSize() != cereal::SelfdriveState::AlertSize::NONE) {
       reset_onroad_sleep_timer();
     } else if (scene.onroadScreenOffTimer > 0) {
       scene.onroadScreenOffTimer--;


### PR DESCRIPTION
## Summary by Sourcery

Ensure the device stays awake for all visual alerts by resetting the onroad screen off timer whenever an alert is active, including e2e green light alerts.

Enhancements:
- Reset onroad sleep timer for any active visual alert rather than only non-normal alerts
- Reset onroad sleep timer for e2e green light alerts in the HUD