### PR TITLE
Speed Limit Assist: Update state machine for PCM long cars

### DIFF
--- a/sunnypilot/selfdrive/controls/lib/speed_limit/speed_limit_assist.py
+++ b/sunnypilot/selfdrive/controls/lib/speed_limit/speed_limit_assist.py
@@ -249,7 +249,7 @@ class SpeedLimitAssist:
         elif self.state == SpeedLimitAssistState.pending:
           if self.target_set_speed_confirmed:
             self._update_confirmed_state()
-          else:
+          elif self.speed_limit_changed:
             self.state = SpeedLimitAssistState.preActive
             self.pre_active_timer = int(PRE_ACTIVE_GUARD_PERIOD / DT_MDL)
 

--- a/sunnypilot/selfdrive/controls/lib/speed_limit/speed_limit_assist.py
+++ b/sunnypilot/selfdrive/controls/lib/speed_limit/speed_limit_assist.py
@@ -247,11 +247,11 @@ class SpeedLimitAssist:
 
         # PENDING
         elif self.state == SpeedLimitAssistState.pending:
-          if self._has_speed_limit:
-            if self.v_offset < LIMIT_SPEED_OFFSET_TH:
-              self.state = SpeedLimitAssistState.adapting
-            else:
-              self.state = SpeedLimitAssistState.active
+          if self.target_set_speed_confirmed:
+            self._update_confirmed_state()
+          else:
+            self.state = SpeedLimitAssistState.preActive
+            self.pre_active_timer = int(PRE_ACTIVE_GUARD_PERIOD / DT_MDL)
 
         # PRE_ACTIVE
         elif self.state == SpeedLimitAssistState.preActive:
@@ -275,9 +275,11 @@ class SpeedLimitAssist:
         elif self.long_engaged_timer <= 0:
           if self.target_set_speed_confirmed:
             self._update_confirmed_state()
-          else:
+          elif self._has_speed_limit:
             self.state = SpeedLimitAssistState.preActive
             self.pre_active_timer = int(PRE_ACTIVE_GUARD_PERIOD / DT_MDL)
+          else:
+            self.state = SpeedLimitAssistState.pending
 
     enabled = self.state in ENABLED_STATES
     active = self.state in ACTIVE_STATES

--- a/sunnypilot/selfdrive/controls/lib/speed_limit/tests/test_speed_limit_assist.py
+++ b/sunnypilot/selfdrive/controls/lib/speed_limit/tests/test_speed_limit_assist.py
@@ -16,7 +16,7 @@ from openpilot.sunnypilot.selfdrive.car import interfaces as sunnypilot_interfac
 from openpilot.sunnypilot.selfdrive.controls.lib.speed_limit.common import Mode
 from openpilot.sunnypilot.selfdrive.controls.lib.speed_limit import PCM_LONG_REQUIRED_MAX_SET_SPEED
 from openpilot.sunnypilot.selfdrive.controls.lib.speed_limit.speed_limit_assist import SpeedLimitAssist, \
-  PRE_ACTIVE_GUARD_PERIOD, ACTIVE_STATES, DISABLED_GUARD_PERIOD
+  PRE_ACTIVE_GUARD_PERIOD, ACTIVE_STATES
 from openpilot.sunnypilot.selfdrive.selfdrived.events import EventsSP
 
 SpeedLimitAssistState = custom.LongitudinalPlanSP.SpeedLimit.AssistState
@@ -129,7 +129,8 @@ class TestSpeedLimitAssist:
     self.sla.v_cruise_cluster_prev = self.pcm_long_max_set_speed
     self.sla.prev_v_cruise_cluster_conv = round(self.pcm_long_max_set_speed * self.speed_conv)
 
-    self.sla.update(True, False, SPEED_LIMITS['highway'], 0, self.pcm_long_max_set_speed, SPEED_LIMITS['highway'], SPEED_LIMITS['highway'], True, 0, self.events_sp)
+    self.sla.update(True, False, SPEED_LIMITS['highway'], 0, self.pcm_long_max_set_speed,
+                    SPEED_LIMITS['highway'], SPEED_LIMITS['highway'], True, 0, self.events_sp)
     assert self.sla.state == SpeedLimitAssistState.active
 
   def test_pending_to_adapting_when_below_speed_limit(self):
@@ -137,7 +138,8 @@ class TestSpeedLimitAssist:
     self.sla.v_cruise_cluster_prev = self.pcm_long_max_set_speed
     self.sla.prev_v_cruise_cluster_conv = round(self.pcm_long_max_set_speed * self.speed_conv)
 
-    self.sla.update(True, False, SPEED_LIMITS['highway'] + 5, 0, self.pcm_long_max_set_speed, SPEED_LIMITS['highway'], SPEED_LIMITS['highway'], True, 0, self.events_sp)
+    self.sla.update(True, False, SPEED_LIMITS['highway'] + 5, 0, self.pcm_long_max_set_speed,
+                    SPEED_LIMITS['highway'], SPEED_LIMITS['highway'], True, 0, self.events_sp)
     assert self.sla.state == SpeedLimitAssistState.adapting
     assert self.sla.is_enabled and self.sla.is_active
 

--- a/sunnypilot/selfdrive/controls/lib/speed_limit/tests/test_speed_limit_assist.py
+++ b/sunnypilot/selfdrive/controls/lib/speed_limit/tests/test_speed_limit_assist.py
@@ -120,12 +120,18 @@ class TestSpeedLimitAssist:
 
   def test_pending_to_active_when_speed_limit_available(self):
     self.sla.state = SpeedLimitAssistState.pending
-    self.sla.update(True, False, SPEED_LIMITS['city'], 0, self.pcm_long_max_set_speed, SPEED_LIMITS['city'], SPEED_LIMITS['city'], True, 0, self.events_sp)
+    self.sla.v_cruise_cluster_prev = self.pcm_long_max_set_speed
+    self.sla.prev_v_cruise_cluster_conv = round(self.pcm_long_max_set_speed * self.speed_conv)
+
+    self.sla.update(True, False, SPEED_LIMITS['highway'], 0, self.pcm_long_max_set_speed, SPEED_LIMITS['highway'], SPEED_LIMITS['highway'], True, 0, self.events_sp)
     assert self.sla.state == SpeedLimitAssistState.active
 
   def test_pending_to_adapting_when_below_speed_limit(self):
     self.sla.state = SpeedLimitAssistState.pending
-    self.sla.update(True, False, SPEED_LIMITS['city'] + 5, 0, self.pcm_long_max_set_speed, SPEED_LIMITS['city'], SPEED_LIMITS['city'], True, 0, self.events_sp)
+    self.sla.v_cruise_cluster_prev = self.pcm_long_max_set_speed
+    self.sla.prev_v_cruise_cluster_conv = round(self.pcm_long_max_set_speed * self.speed_conv)
+
+    self.sla.update(True, False, SPEED_LIMITS['highway'] + 5, 0, self.pcm_long_max_set_speed, SPEED_LIMITS['highway'], SPEED_LIMITS['highway'], True, 0, self.events_sp)
     assert self.sla.state == SpeedLimitAssistState.adapting
     assert self.sla.is_enabled and self.sla.is_active
 

--- a/sunnypilot/selfdrive/controls/lib/speed_limit/tests/test_speed_limit_assist.py
+++ b/sunnypilot/selfdrive/controls/lib/speed_limit/tests/test_speed_limit_assist.py
@@ -16,7 +16,7 @@ from openpilot.sunnypilot.selfdrive.car import interfaces as sunnypilot_interfac
 from openpilot.sunnypilot.selfdrive.controls.lib.speed_limit.common import Mode
 from openpilot.sunnypilot.selfdrive.controls.lib.speed_limit import PCM_LONG_REQUIRED_MAX_SET_SPEED
 from openpilot.sunnypilot.selfdrive.controls.lib.speed_limit.speed_limit_assist import SpeedLimitAssist, \
-  PRE_ACTIVE_GUARD_PERIOD, ACTIVE_STATES
+  PRE_ACTIVE_GUARD_PERIOD, ACTIVE_STATES, DISABLED_GUARD_PERIOD
 from openpilot.sunnypilot.selfdrive.selfdrived.events import EventsSP
 
 SpeedLimitAssistState = custom.LongitudinalPlanSP.SpeedLimit.AssistState
@@ -94,6 +94,12 @@ class TestSpeedLimitAssist:
     for _ in range(int(3. / DT_MDL)):
       self.sla.update(True, False, SPEED_LIMITS['city'], 0, SPEED_LIMITS['highway'], SPEED_LIMITS['city'], SPEED_LIMITS['city'], True, 0, self.events_sp)
     assert self.sla.state == SpeedLimitAssistState.preActive
+    assert self.sla.is_enabled and not self.sla.is_active
+
+  def test_transition_disabled_to_pending_no_speed_limit_not_max_initial_set_speed(self):
+    for _ in range(int(3. / DT_MDL)):
+      self.sla.update(True, False, SPEED_LIMITS['highway'], 0, SPEED_LIMITS['city'], 0, 0, False, 0, self.events_sp)
+    assert self.sla.state == SpeedLimitAssistState.pending
     assert self.sla.is_enabled and not self.sla.is_active
 
   def test_preactive_to_active_with_max_speed_confirmation(self):


### PR DESCRIPTION
- Updated how the state transitions in `disabled` state for PCM long cars
- Modified the behaviors when switching from 'pending' to other states based on target speed confirmation
- Changed state transition behavior when speed limits become available in `disabled` and `pending`
- Updated test cases to reflect the new state machine behavior
- Improved handling of speed limit validation and state management

## Summary by Sourcery

Refine the PCM long car speed limit assist state machine to rely on speed confirmation and a new preActive guard period instead of offset thresholds, and adjust transitions when limits become available or timers expire

Enhancements:
- Introduce a preActive state with a guard timer when target speed isn’t yet confirmed
- Replace the v_offset threshold with target_set_speed_confirmed to drive pending-to-active/adapting transitions
- Adjust long_engaged_timer expiration logic to transition correctly between preActive and pending based on speed limit availability

Tests:
- Populate v_cruise_cluster_prev and prev_v_cruise_cluster_conv in tests and update expected states to match the revised transitions