### PR TITLE
sunnylink: Enabled by default

### DIFF
--- a/common/params_keys.h
+++ b/common/params_keys.h
@@ -192,7 +192,7 @@ inline static std::unordered_map<std::string, ParamKeyAttributes> keys = {
     {"SunnylinkCache_Users", {PERSISTENT, STRING}},
     {"SunnylinkDongleId", {PERSISTENT, STRING}},
     {"SunnylinkdPid", {PERSISTENT, INT}},
-    {"SunnylinkEnabled", {PERSISTENT, BOOL}},
+    {"SunnylinkEnabled", {PERSISTENT, BOOL, "1"}},
 
     // Backup Manager params
     {"BackupManager_CreateBackup", {PERSISTENT, BOOL}},


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Enable Sunnylink by default by setting its default parameter value for SunnylinkEnabled to true