### PR TITLE
ui: replace `static_cast<int>` with `std::nearbyint` for convert & rounding

### DIFF
--- a/selfdrive/ui/sunnypilot/qt/widgets/controls.h
+++ b/selfdrive/ui/sunnypilot/qt/widgets/controls.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cmath>
 #include <map>
 #include <optional>
 #include <string>
@@ -500,7 +501,7 @@ private:
 
   int getParamValueScaled() {
     const auto param_value = QString::fromStdString(params.get(key));
-    return static_cast<int>(param_value.toFloat() * 100);
+    return std::nearbyint(param_value.toFloat() * 100.0f);
   }
 
   void setParamValueScaled(const int new_value) {
@@ -576,8 +577,9 @@ public:
       QObject::connect(button, &QPushButton::clicked, [=]() {
         int change_value = (i == 0) ? -per_value_change : per_value_change;
         value = use_float_scaling ? getParamValueScaled() : getParamValue();
-        value += change_value;
-        value = std::clamp(value, range.min_value, range.max_value);
+        int _value = value;
+        _value += change_value;
+        value = std::clamp(_value, range.min_value, range.max_value);
 
         if (use_float_scaling) {
           setParamValueScaled(value);

--- a/selfdrive/ui/sunnypilot/qt/widgets/controls.h
+++ b/selfdrive/ui/sunnypilot/qt/widgets/controls.h
@@ -577,9 +577,8 @@ public:
       QObject::connect(button, &QPushButton::clicked, [=]() {
         int change_value = (i == 0) ? -per_value_change : per_value_change;
         value = use_float_scaling ? getParamValueScaled() : getParamValue();
-        int _value = value;
-        _value += change_value;
-        value = std::clamp(_value, range.min_value, range.max_value);
+        value += change_value;
+        value = std::clamp(value, range.min_value, range.max_value);
 
         if (use_float_scaling) {
           setParamValueScaled(value);


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Improve rounding and clamping behavior in OptionControlSP by switching to std::nearbyint for conversions and isolating value adjustments before clamping

Enhancements:
- Use std::nearbyint instead of static_cast<int> to round float parameters in getParamValueScaled
- Refactor button click handler to apply change and clamp on a temporary variable before updating the control value