### PR TITLE
Revert "sunnylink: enhanced param keys fetch with data type"

### DIFF
--- a/sunnypilot/sunnylink/athena/sunnylinkd.py
+++ b/sunnypilot/sunnylink/athena/sunnylinkd.py
@@ -179,28 +179,11 @@ def getParamsAllKeys() -> list[str]:
 
 
 @dispatcher.add_method
-def getParamsAllKeysV1() -> dict[str, str]:
-  available_keys: list[str] = [k.decode('utf-8') for k in Params().all_keys()]
-
-  params_dict: dict[str, list[dict[str, str | bool | int | None]]] = {"params": []}
-  for key in available_keys:
-    value = get_param_as_byte(key, get_default=True)
-    params_dict["params"].append({
-      "key": key,
-      "type": int(params.get_type(key).value),
-      "default_value": base64.b64encode(value).decode('utf-8') if value else None,
-    })
-
-  return {"keys": json.dumps(params_dict.get("params", []))}
-
-
-@dispatcher.add_method
 def getParams(params_keys: list[str], compression: bool = False) -> str | dict[str, str]:
   params = Params()
-  available_keys: list[str] = [k.decode('utf-8') for k in Params().all_keys()]
 
   try:
-    param_keys_validated = [key for key in params_keys if key in available_keys]
+    param_keys_validated = [key for key in params_keys if key in getParamsAllKeys()]
     params_dict: dict[str, list[dict[str, str | bool | int]]] = {"params": []}
     for key in param_keys_validated:
       value = get_param_as_byte(key)

--- a/sunnypilot/sunnylink/utils.py
+++ b/sunnypilot/sunnylink/utils.py
@@ -60,24 +60,20 @@ def get_api_token():
   print(f"API Token: {token}")
 
 
-def _to_bytes(value: bytes | None, param_type: ParamKeyType) -> bytes | None:
-  """Convert a parameter value to bytes based on its type."""
-  if value is None:
+def get_param_as_byte(param_name: str, params=None) -> bytes | None:
+  """Get a parameter as bytes. Returns None if the parameter does not exist."""
+  params = params or Params() # Use existing Params instance if provided
+  param = params.get(param_name)
+  if param is None:
     return None
 
-  if param_type == ParamKeyType.BYTES:
-    return bytes(value)
-  if param_type == ParamKeyType.JSON:
-    return json.dumps(value).encode("utf-8")
-  return str(value).encode("utf-8")
-
-
-def get_param_as_byte(param_name: str, params=None, get_default=False) -> bytes | None:
-  """Get a parameter as bytes. Returns None if the parameter does not exist."""
-  params = params or Params()
-  value = params.get(param_name) if not get_default else params.get_default_value(param_name)
   param_type = params.get_type(param_name)
-  return _to_bytes(value, param_type)
+  if param_type == ParamKeyType.BYTES:
+    return bytes(param)
+  elif param_type == ParamKeyType.JSON:
+    return json.dumps(param).encode('utf-8')
+  return str(param).encode('utf-8')
+
 
 def save_param_from_base64_encoded_string(param_name: str, base64_encoded_data: str, is_compressed=False) -> None:
   """Save a parameter from bytes. Overwrites the parameter if it already exists."""


### PR DESCRIPTION
Reverts sunnypilot/sunnypilot#1308

Reports of some deadlocks have been received, likely related to the utils change used also by params store

## Summary by Sourcery

Revert the parameter utilities enhancements and remove the deprecated all-keys endpoint to address reported deadlocks

Bug Fixes:
- Undo the enhanced get_param_as_byte implementation to prevent deadlock issues in the params store

Chores:
- Remove the getParamsAllKeysV1 method from the Athena sunnylinkd dispatcher