### PR TITLE
relock after inplace metadrive update

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -945,7 +945,7 @@ dependencies = [
     { name = "yapf", marker = "platform_machine != 'aarch64' or sys_platform != 'linux'" },
 ]
 wheels = [
-    { url = "https://github.com/commaai/metadrive/releases/download/MetaDrive-minimal-0.4.2.4/metadrive_simulator-0.4.2.4-py3-none-any.whl", hash = "sha256:fbf0ea9be67e65cd45d38ff930e3d49f705dd76c9ddbd1e1482e3f87b61efcef" },
+    { url = "https://github.com/commaai/metadrive/releases/download/MetaDrive-minimal-0.4.2.4/metadrive_simulator-0.4.2.4-py3-none-any.whl", hash = "sha256:d0afaf3b005e35e14b929d5491d2d5b64562d0c1cd5093ba969fb63908670dd4" },
 ]
 
 [package.metadata]


### PR DESCRIPTION
Updates the hash of metadrive to unblock pipelines

## Summary by Sourcery

Build:
- Bump metadrive hash in uv.lock to match inplace update