### PR TITLE
ci: refine PR search query to avoid querying whole github

### DIFF
--- a/.github/workflows/sunnypilot-master-dev-prep.yaml
+++ b/.github/workflows/sunnypilot-master-dev-prep.yaml
@@ -149,7 +149,7 @@ jobs:
                   }
                 }
               }
-          }' -F search_query="repo:${{ github.repository }} is:pr is:open label:${PR_LABEL},${PR_LABEL}-c3 draft:false sort:created-asc")
+            }' -F search_query="repo:${{ github.repository }} is:pr is:open label:${PR_LABEL},${PR_LABEL}-c3 draft:false sort:created-asc")
 
           PR_LIST=${PR_LIST//\'/}
           echo "PR_LIST=${PR_LIST}" >> $GITHUB_OUTPUT

--- a/.github/workflows/sunnypilot-master-dev-prep.yaml
+++ b/.github/workflows/sunnypilot-master-dev-prep.yaml
@@ -118,8 +118,8 @@ jobs:
         run: |
           # Use GitHub API to get PRs with specific label, ordered by creation date
           PR_LIST=$(gh api graphql -f query='
-            query($label:String!) {
-              search(query: $label, type:ISSUE, first:100) {
+            query($search_query:String!) {
+              search(query: $search_query, type:ISSUE, first:100) {
                 nodes {
                   ... on PullRequest {
                     number
@@ -149,7 +149,7 @@ jobs:
                   }
                 }
               }
-            }' -F label="is:pr is:open label:${PR_LABEL} draft:false sort:created-asc")
+          }' -F search_query="repo:${{ github.repository }} is:pr is:open (label:${PR_LABEL} OR label:${PR_LABEL}-c3) draft:false sort:created-asc")
 
           PR_LIST=${PR_LIST//\'/}
           echo "PR_LIST=${PR_LIST}" >> $GITHUB_OUTPUT

--- a/.github/workflows/sunnypilot-master-dev-prep.yaml
+++ b/.github/workflows/sunnypilot-master-dev-prep.yaml
@@ -149,7 +149,7 @@ jobs:
                   }
                 }
               }
-          }' -F search_query="repo:${{ github.repository }} is:pr is:open (label:${PR_LABEL} OR label:${PR_LABEL}-c3) draft:false sort:created-asc")
+          }' -F search_query="repo:${{ github.repository }} is:pr is:open label:${PR_LABEL},${PR_LABEL}-c3 draft:false sort:created-asc")
 
           PR_LIST=${PR_LIST//\'/}
           echo "PR_LIST=${PR_LIST}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
How did that happen haha

## Summary by Sourcery

Refine the GitHub Actions PR search to target the current repository and include PRs labeled with either the main or '-c3' variant

CI:
- Change the GraphQL variable from 'label' to 'search_query'
- Add 'repo:${{ github.repository }}' filter and include both 'label:${PR_LABEL}' and 'label:${PR_LABEL}-c3' in the search query