### PR TITLE
torqued_ext: adjust RELAXED_MIN_BUCKET_POINTS boundary values

### DIFF
--- a/sunnypilot/selfdrive/locationd/torqued_ext.py
+++ b/sunnypilot/selfdrive/locationd/torqued_ext.py
@@ -13,7 +13,7 @@ from openpilot.common.params import Params
 from openpilot.common.realtime import DT_MDL
 from openpilot.sunnypilot import PARAMS_UPDATE_PERIOD
 
-RELAXED_MIN_BUCKET_POINTS = np.array([0, 200, 300, 500, 500, 300, 200, 0])
+RELAXED_MIN_BUCKET_POINTS = np.array([1, 200, 300, 500, 500, 300, 200, 1])
 
 ALLOWED_CARS = ['toyota', 'hyundai', 'rivian', 'honda']
 


### PR DESCRIPTION
- Closes #1339

## Summary by Sourcery

Bug Fixes:
- Replace zero entries at the start and end of RELAXED_MIN_BUCKET_POINTS with one to address issue #1339