### PR TITLE
ui: HUD drawing optimizations and fixes

### DIFF
--- a/selfdrive/ui/sunnypilot/qt/onroad/hud.cc
+++ b/selfdrive/ui/sunnypilot/qt/onroad/hud.cc
@@ -21,6 +21,8 @@ HudRendererSP::HudRendererSP() {
   green_light_alert_large_img = loadPixmap("../../sunnypilot/selfdrive/assets/images/green_light.png", {large_max, large_max});
   lead_depart_alert_small_img = loadPixmap("../../sunnypilot/selfdrive/assets/images/lead_depart.png", {small_max, small_max});
   lead_depart_alert_large_img = loadPixmap("../../sunnypilot/selfdrive/assets/images/lead_depart.png", {large_max, large_max});
+
+  standstillTimerOctagon.reserve(8);
 }
 
 void HudRendererSP::updateState(const UIState &s) {
@@ -403,19 +405,19 @@ void HudRendererSP::drawStandstillTimer(QPainter &p, int x, int y) {
 
     // stop sign for standstill timer
     const int size = 190;  // size
-    const float angle = M_PI / 8.0;
+    const float angle = M_PI / 8.0f;
 
-    QPolygon octagon;
+    standstillTimerOctagon.clear();
     for (int i = 0; i < 8; i++) {
-      float curr_angle = angle + i * M_PI / 4.0;
+      float curr_angle = angle + i * M_PI / 4.0f;
       int point_x = x + size / 2 * cos(curr_angle);
       int point_y = y + size / 2 * sin(curr_angle);
-      octagon << QPoint(point_x, point_y);
+      standstillTimerOctagon << QPoint(point_x, point_y);
     }
 
     p.setPen(QPen(Qt::white, 6));
     p.setBrush(QColor(255, 90, 81, 200)); // red pastel
-    p.drawPolygon(octagon);
+    p.drawPolygon(standstillTimerOctagon);
 
     QString time_str = QString("%1:%2").arg(minute, 1, 10, QChar('0')).arg(second, 2, 10, QChar('0'));
     p.setFont(InterFont(55, QFont::Bold));

--- a/selfdrive/ui/sunnypilot/qt/onroad/hud.h
+++ b/selfdrive/ui/sunnypilot/qt/onroad/hud.h
@@ -69,6 +69,7 @@ private:
   bool standstillTimer;
   bool isStandstill;
   float standstillElapsedTime;
+  QPolygon standstillTimerOctagon;
   bool longOverride;
   bool smartCruiseControlVisionEnabled;
   bool smartCruiseControlVisionActive;


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Optimize HUD rendering by reusing a pre-allocated octagon polygon for the standstill timer and removing redundant speed display call

Enhancements:
- Add standstillTimerOctagon member and reserve capacity to avoid reallocating the polygon each frame
- Replace local octagon construction with clearing and reusing the member polygon for the stop-sign timer
- Use float literals for angle calculations to improve type consistency
- Remove duplicate drawCurrentSpeedSP invocation to prevent redundant speed rendering