### PR TITLE
docs: fix README.md install instructions referring to orphaned branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ Please refer to [Recommended Branches](#-recommended-branches) to find your pref
 
 |      Branch      |                 Installation URL              |
 |:----------------:|:---------------------------------------------:|
-| `staging` | `https://staging.sunnypilot.ai`        |
-|   `dev`   | `https://dev.sunnypilot.ai`            |
+| `staging` | `https://install.sunnypilot.ai/staging`        |
+|   `dev`   | `https://install.sunnypilot.ai/dev`            |
 | `custom-branch`  | `https://install.sunnypilot.ai/{branch_name}` |
 | `release-tizi` |            **Not yet available**.             |
-| `staging-tici` (for legacy Comma three) | `https://staging-tici.sunnypilot.ai`        |
+| `staging-tici` (for legacy Comma three) | `https://install.sunnypilot.ai/staging-tici`        |
 | `release-tici` (for legacy Comma three) |            **Not yet available**.             |
 
 > [!TIP]


### PR DESCRIPTION
Align with https://github.com/sunnypilot/sunnypilot/issues/1217 and with how the installer works these days on 3X devices.

Also remove section referring to even older legacy branches.

The main reason for the PR is so that a fresh user can easily switch from OP to SP by reading the SP's README.md.
Before this change, the user is met with software download errors/404s when following the old README with the old branch names/URLs.

