### PR TITLE
ui: dynamic ICBM status

### DIFF
--- a/selfdrive/ui/sunnypilot/qt/onroad/hud.cc
+++ b/selfdrive/ui/sunnypilot/qt/onroad/hud.cc
@@ -30,7 +30,6 @@ void HudRendererSP::updateState(const UIState &s) {
   const auto cs = sm["controlsState"].getControlsState();
   const auto car_state = sm["carState"].getCarState();
   const auto car_control = sm["carControl"].getCarControl();
-  const auto car_control_sp = sm["carControlSP"].getCarControlSP();
   const auto radar_state = sm["radarState"].getRadarState();
   const auto is_gps_location_external = sm.rcv_frame("gpsLocationExternal") > 1;
   const auto gpsLocation = is_gps_location_external ? sm["gpsLocationExternal"].getGpsLocationExternal() : sm["gpsLocation"].getGpsLocation();
@@ -129,7 +128,7 @@ void HudRendererSP::updateState(const UIState &s) {
   rightBlindspot = car_state.getRightBlindspot();
   showTurnSignals = s.scene.turn_signals;
 
-  ICBMState = car_control_sp.getIntelligentCruiseButtonManagement().getState();
+  carControlEnabled = car_control.getEnabled();
   speedCluster = car_state.getCruiseState().getSpeedCluster() * speedConv;
 }
 
@@ -690,7 +689,7 @@ void HudRendererSP::drawSetSpeedSP(QPainter &p, const QRect &surface_rect) {
   }
 
   // Draw "MAX" or carState.cruiseState.speedCluster (when ICBM is active) text
-  if (ICBMState != cereal::IntelligentCruiseButtonManagement::IntelligentCruiseButtonManagementState::INACTIVE) {
+  if (carControlEnabled) {
     if (std::nearbyint(set_speed) != std::nearbyint(speedCluster)) {
       icbm_active_counter = 3 * UI_FREQ;
     } else if (icbm_active_counter > 0) {

--- a/selfdrive/ui/sunnypilot/qt/onroad/hud.h
+++ b/selfdrive/ui/sunnypilot/qt/onroad/hud.h
@@ -116,7 +116,7 @@ private:
   int blinkerFrameCounter;
   bool showTurnSignals;
 
-  cereal::IntelligentCruiseButtonManagement::IntelligentCruiseButtonManagementState ICBMState;
+  bool carControlEnabled;
   float speedCluster = 0;
   int icbm_active_counter = 0;
 };

--- a/selfdrive/ui/sunnypilot/ui.cc
+++ b/selfdrive/ui/sunnypilot/ui.cc
@@ -29,7 +29,7 @@ UIStateSP::UIStateSP(QObject *parent) : UIState(parent) {
     "wideRoadCameraState", "managerState", "selfdriveState", "longitudinalPlan",
     "modelManagerSP", "selfdriveStateSP", "longitudinalPlanSP", "backupManagerSP",
     "carControl", "gpsLocationExternal", "gpsLocation", "liveTorqueParameters",
-    "carStateSP", "liveParameters", "liveMapDataSP", "carControlSP"
+    "carStateSP", "liveParameters", "liveMapDataSP"
   });
 
   // update timer


### PR DESCRIPTION
## Summary by Sourcery

Update the SunnyPilot HUD to dynamically display ICBM status by showing the current speed cluster value for a short duration when car control is enabled, instead of always rendering "MAX".

New Features:
- Temporarily replace the static "MAX" indicator with the real-time speed cluster value when car control is active and the cluster speed differs from the set speed

Enhancements:
- Introduce carControlEnabled, speedCluster, and icbm_active_counter state variables in HudRendererSP
- Populate the new state variables in updateState to track car control status and current cluster speed