### PR TITLE
Revert "UI: Make Always Offroad more accessible (#1327)"

### DIFF
--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/device_panel.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/device_panel.cc
@@ -83,7 +83,7 @@ DevicePanelSP::DevicePanelSP(SettingsWindowSP *parent) : DevicePanel(parent) {
   connect(maxTimeOffroad, &OptionControlSP::updateLabels, maxTimeOffroad, &MaxTimeOffroad::refresh);
   addItem(maxTimeOffroad);
 
-  toggleDeviceBootMode = new ButtonParamControlSP("DeviceBootMode", tr("Wake-Up Behavior"), "", "", {"Default", "Offroad"}, 375, true);
+    toggleDeviceBootMode = new ButtonParamControlSP("DeviceBootMode", tr("Wake-Up Behavior"), "", "", {"Default", "Offroad"}, 375, true);
   addItem(toggleDeviceBootMode);
 
   connect(toggleDeviceBootMode, &ButtonParamControlSP::buttonClicked, this, [=](int index) {
@@ -116,8 +116,9 @@ DevicePanelSP::DevicePanelSP(SettingsWindowSP *parent) : DevicePanel(parent) {
   offroadBtn->setFixedWidth(power_layout->sizeHint().width());
   QObject::connect(offroadBtn, &PushButtonSP::clicked, this, &DevicePanelSP::setOffroadMode);
 
-  power_group_layout = new QVBoxLayout();
+  QVBoxLayout *power_group_layout = new QVBoxLayout();
   power_group_layout->setSpacing(25);
+  power_group_layout->addWidget(offroadBtn, 0, Qt::AlignHCenter);
   power_group_layout->addLayout(power_layout);
 
   addItem(power_group_layout);
@@ -130,7 +131,7 @@ DevicePanelSP::DevicePanelSP(SettingsWindowSP *parent) : DevicePanel(parent) {
     buttons["onroadUploadsBtn"],
   };
 
-  QObject::connect(uiState(), &UIState::offroadTransition, [=](bool _offroad) {
+  QObject::connect(uiState(), &UIState::offroadTransition, [=](bool offroad) {
     for (auto btn : findChildren<PushButtonSP*>()) {
       bool always_enabled = std::find(always_enabled_btns.begin(), always_enabled_btns.end(), btn) != always_enabled_btns.end();
 
@@ -138,8 +139,6 @@ DevicePanelSP::DevicePanelSP(SettingsWindowSP *parent) : DevicePanel(parent) {
         btn->setEnabled(offroad);
       }
     }
-    offroad = _offroad;
-    updateState();
   });
 }
 
@@ -190,7 +189,7 @@ void DevicePanelSP::updateState() {
   }
 
   bool offroad_mode_param = params.getBool("OffroadMode");
-  offroadBtn->setText(offroad_mode_param ? tr("Exit Always Offroad") : tr("Enable Always Offroad"));
+  offroadBtn->setText(offroad_mode_param ? tr("Exit Always Offroad") : tr("Always Offroad"));
   offroadBtn->setStyleSheet(offroad_mode_param ? alwaysOffroadStyle : autoOffroadStyle);
 
   DeviceSleepModeStatus currStatus = DeviceSleepModeStatus::DEFAULT;
@@ -198,10 +197,4 @@ void DevicePanelSP::updateState() {
     currStatus = DeviceSleepModeStatus::OFFROAD;
   }
   toggleDeviceBootMode->setDescription(deviceSleepModeDescription(currStatus));
-
-  if (offroad and not offroad_mode_param) {
-    power_group_layout->insertWidget(0, offroadBtn, 0, Qt::AlignHCenter);
-  } else {
-    AddWidgetAt(0, offroadBtn);
-  }
 }

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/device_panel.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/device_panel.h
@@ -31,8 +31,6 @@ private:
   PushButtonSP *offroadBtn;
   MaxTimeOffroad *maxTimeOffroad;
   ButtonParamControlSP *toggleDeviceBootMode;
-  QVBoxLayout *power_group_layout;
-  bool offroad;
 
   const QString alwaysOffroadStyle = R"(
     PushButtonSP {


### PR DESCRIPTION
Reverts #1327

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Revert Always Offroad accessibility UI changes, restoring original button behavior and cleaning up related code

Enhancements:
- Remove dynamic repositioning of the Offroad button and restore its static placement in the power group layout
- Simplify layout by inlining the power group and directly adding the Offroad button
- Restore the 'Always Offroad' button label and remove conditional text toggling logic
- Clean up unused member variables and state tracking tied to the Offroad button