### PR TITLE
Reapply "UI: Make Always Offroad more accessible" (#1327)

### DIFF
--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/device_panel.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/device_panel.cc
@@ -88,7 +88,7 @@ DevicePanelSP::DevicePanelSP(SettingsWindowSP *parent) : DevicePanel(parent) {
 
   connect(toggleDeviceBootMode, &ButtonParamControlSP::buttonClicked, this, [=](int index) {
     params.put("DeviceBootMode", QString::number(index).toStdString());
-    updateState();
+    updateState(offroad);
   });
 
   addItem(device_grid_layout);
@@ -122,7 +122,7 @@ DevicePanelSP::DevicePanelSP(SettingsWindowSP *parent) : DevicePanel(parent) {
 
   addItem(power_group_layout);
 
-  std::vector always_enabled_btns = {
+  always_enabled_btns = {
     rebootBtn,
     poweroffBtn,
     offroadBtn,
@@ -130,17 +130,7 @@ DevicePanelSP::DevicePanelSP(SettingsWindowSP *parent) : DevicePanel(parent) {
     buttons["onroadUploadsBtn"],
   };
 
-  QObject::connect(uiState(), &UIState::offroadTransition, [=](bool _offroad) {
-    offroad = _offroad;
-    for (auto btn : findChildren<PushButtonSP*>()) {
-      bool always_enabled = std::find(always_enabled_btns.begin(), always_enabled_btns.end(), btn) != always_enabled_btns.end();
-
-      if (!always_enabled) {
-        btn->setEnabled(offroad);
-      }
-    }
-    updateState();
-  });
+  QObject::connect(uiState(), &UIState::offroadTransition, this, &DevicePanelSP::updateState);
 }
 
 void DevicePanelSP::setOffroadMode() {
@@ -164,7 +154,7 @@ void DevicePanelSP::setOffroadMode() {
     ConfirmationDialog::alert(tr("Disengage to Enter Always Offroad Mode"), this);
   }
 
-  updateState();
+  updateState(offroad);
 }
 
 void DevicePanelSP::resetSettings() {
@@ -181,12 +171,16 @@ void DevicePanelSP::resetSettings() {
 }
 
 void DevicePanelSP::showEvent(QShowEvent *event) {
-  updateState();
+  updateState(offroad);
 }
 
-void DevicePanelSP::updateState() {
-  if (!isVisible()) {
-    return;
+void DevicePanelSP::updateState(bool _offroad) {
+  for (auto btn : findChildren<PushButtonSP*>()) {
+    bool always_enabled = std::find(always_enabled_btns.begin(), always_enabled_btns.end(), btn) != always_enabled_btns.end();
+
+    if (!always_enabled) {
+      btn->setEnabled(_offroad);
+    }
   }
 
   bool offroad_mode_param = params.getBool("OffroadMode");
@@ -204,4 +198,6 @@ void DevicePanelSP::updateState() {
   } else {
     AddWidgetAt(0, offroadBtn);
   }
+
+  offroad = _offroad;
 }

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/device_panel.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/device_panel.h
@@ -23,7 +23,7 @@ public:
   explicit DevicePanelSP(SettingsWindowSP *parent = 0);
   void showEvent(QShowEvent *event) override;
   void setOffroadMode();
-  void updateState();
+  void updateState(bool _offroad);
   void resetSettings();
 
 private:
@@ -33,6 +33,8 @@ private:
   ButtonParamControlSP *toggleDeviceBootMode;
   QVBoxLayout *power_group_layout;
   bool offroad;
+
+  std::vector<PushButtonSP*> always_enabled_btns = {};
 
   const QString alwaysOffroadStyle = R"(
     PushButtonSP {


### PR DESCRIPTION
## Summary by Sourcery

Reimplement Always Offroad button behavior in the device settings panel to dynamically track offroad transitions, update its label, and reposition it within the power settings layout.

Enhancements:
- Track offroad transitions by adding an offroad flag in DevicePanelSP and connecting to UIState::offroadTransition
- Promote power_group_layout to a class member to support dynamic insertion of the offroad button
- Dynamically insert or relocate the offroad button based on the offroad flag and the OffroadMode parameter
- Update the offroad button text to “Enable Always Offroad” when offroad mode is disabled