### PR TITLE
Revert "capnp: consolidate TurnDirection enum"

### DIFF
--- a/cereal/custom.capnp
+++ b/cereal/custom.capnp
@@ -404,12 +404,12 @@ struct LiveMapDataSP @0xf416ec09499d9d19 {
 
 struct ModelDataV2SP @0xa1680744031fdb2d {
   laneTurnDirection @0 :TurnDirection;
+}
 
-  enum TurnDirection {
-    none @0;
-    turnLeft @1;
-    turnRight @2;
-  }
+enum TurnDirection {
+  none @0;
+  turnLeft @1;
+  turnRight @2;
 }
 
 struct CustomReserved10 @0xcb9fd56c7057593a {

--- a/selfdrive/controls/lib/desire_helper.py
+++ b/selfdrive/controls/lib/desire_helper.py
@@ -32,9 +32,9 @@ DESIRES = {
 }
 
 TURN_DESIRES = {
-  custom.ModelDataV2SP.TurnDirection.none: log.Desire.none,
-  custom.ModelDataV2SP.TurnDirection.turnLeft: log.Desire.turnLeft,
-  custom.ModelDataV2SP.TurnDirection.turnRight: log.Desire.turnRight,
+  custom.TurnDirection.none: log.Desire.none,
+  custom.TurnDirection.turnLeft: log.Desire.turnLeft,
+  custom.TurnDirection.turnRight: log.Desire.turnRight,
 }
 
 
@@ -49,7 +49,7 @@ class DesireHelper:
     self.desire = log.Desire.none
     self.alc = AutoLaneChangeController(self)
     self.lane_turn_controller = LaneTurnController(self)
-    self.lane_turn_direction = custom.ModelDataV2SP.TurnDirection.none
+    self.lane_turn_direction = custom.TurnDirection.none
 
   @staticmethod
   def get_lane_change_direction(CS):
@@ -126,7 +126,7 @@ class DesireHelper:
 
     self.prev_one_blinker = one_blinker
 
-    if self.lane_turn_direction != custom.ModelDataV2SP.TurnDirection.none:
+    if self.lane_turn_direction != custom.TurnDirection.none:
       self.desire = TURN_DESIRES[self.lane_turn_direction]
     else:
       self.desire = DESIRES[self.lane_change_direction][self.lane_change_state]

--- a/sunnypilot/selfdrive/controls/lib/lane_turn_desire.py
+++ b/sunnypilot/selfdrive/controls/lib/lane_turn_desire.py
@@ -15,7 +15,7 @@ LANE_CHANGE_SPEED_MIN = 20 * CV.MPH_TO_MS
 class LaneTurnController:
   def __init__(self, desire_helper):
     self.DH = desire_helper
-    self.turn_direction = custom.ModelDataV2SP.TurnDirection.none
+    self.turn_direction = custom.TurnDirection.none
     self.params = Params()
     self.lane_turn_value = float(self.params.get("LaneTurnValue", return_default=True)) * CV.MPH_TO_MS
     self.param_read_counter = 0
@@ -33,13 +33,13 @@ class LaneTurnController:
 
   def update_lane_turn(self, blindspot_left: bool, blindspot_right: bool, left_blinker: bool, right_blinker: bool, v_ego: float) -> None:
     if left_blinker and not right_blinker and v_ego < self.lane_turn_value and not blindspot_left:
-      self.turn_direction = custom.ModelDataV2SP.TurnDirection.turnLeft
+      self.turn_direction = custom.TurnDirection.turnLeft
     elif right_blinker and not left_blinker and v_ego < self.lane_turn_value and not blindspot_right:
-      self.turn_direction = custom.ModelDataV2SP.TurnDirection.turnRight
+      self.turn_direction = custom.TurnDirection.turnRight
     else:
-      self.turn_direction = custom.ModelDataV2SP.TurnDirection.none
+      self.turn_direction = custom.TurnDirection.none
 
   def get_turn_direction(self):
     if not self.enabled:
-      return custom.ModelDataV2SP.TurnDirection.none
+      return custom.TurnDirection.none
     return self.turn_direction


### PR DESCRIPTION
Reverts sunnypilot/sunnypilot#1370

<img width="1186" height="338" alt="image" src="https://github.com/user-attachments/assets/d857de8d-26be-411b-b6c8-efc979dc4a0f" />

## Summary by Sourcery

Revert the previous change that nested TurnDirection inside ModelDataV2SP by moving the enum back to the top level and adjusting all related references in desire_helper.py and lane_turn_desire.py.

Enhancements:
- Revert the consolidation of the TurnDirection enum under ModelDataV2SP
- Restore TurnDirection as a top-level enum in custom.capnp and update all code references from custom.ModelDataV2SP.TurnDirection to custom.TurnDirection