### PR TITLE
Speed Limit Assist: audible alerts for certain states

### DIFF
--- a/cereal/custom.capnp
+++ b/cereal/custom.capnp
@@ -107,6 +107,9 @@ struct SelfdriveStateSP @0x81c2f05a394cf4af {
     reserved28 @28;
     reserved29 @29;
     reserved30 @30;
+
+    promptSingleLow @31;
+    promptSingleHigh @32;
   }
 }
 

--- a/selfdrive/assets/sounds/prompt_single_high.wav
+++ b/selfdrive/assets/sounds/prompt_single_high.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dbfa5858c0a672411ffdc691efdecb06d01ae458cc1df409bcf3fdeaa4756f72
+size 34638

--- a/selfdrive/assets/sounds/prompt_single_low.wav
+++ b/selfdrive/assets/sounds/prompt_single_low.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db9671bb03e01f119bba1eb6cc0507e0f039ac4e5b7f9f839a87071c52e86e56
+size 44416

--- a/selfdrive/ui/soundd.py
+++ b/selfdrive/ui/soundd.py
@@ -31,6 +31,8 @@ AudibleAlertSP = custom.SelfdriveStateSP.AudibleAlert
 
 sound_list_sp: dict[int, tuple[str, int | None, float]] = {
   # AudibleAlertSP, file name, play count (none for infinite)
+  AudibleAlertSP.promptSingleLow: ("prompt_single_low.wav", 1, MAX_VOLUME),
+  AudibleAlertSP.promptSingleHigh: ("prompt_single_high.wav", 1, MAX_VOLUME),
 }
 
 sound_list: dict[int, tuple[str, int | None, float]] = {

--- a/sunnypilot/selfdrive/selfdrived/events.py
+++ b/sunnypilot/selfdrive/selfdrived/events.py
@@ -11,6 +11,7 @@ AlertSize = log.SelfdriveState.AlertSize
 AlertStatus = log.SelfdriveState.AlertStatus
 VisualAlert = car.CarControl.HUDControl.VisualAlert
 AudibleAlert = car.CarControl.HUDControl.AudibleAlert
+AudibleAlertSP = custom.SelfdriveStateSP.AudibleAlert
 EventNameSP = custom.OnroadEventSP.EventName
 
 
@@ -58,7 +59,7 @@ def speed_limit_pre_active_alert(CP: car.CarParams, CS: car.CarState, sm: messag
     "Speed Limit Assist: Activation Required",
     alert_2_str,
     AlertStatus.normal, AlertSize.mid,
-    Priority.LOW, VisualAlert.none, AudibleAlert.none, .1)
+    Priority.LOW, VisualAlert.none, AudibleAlertSP.promptSingleLow, .1)
 
 
 class EventsSP(EventsBase):
@@ -202,7 +203,7 @@ EVENTS_SP: dict[int, dict[str, Alert | AlertCallbackType]] = {
       "Automatically adjusting to the posted speed limit",
       "",
       AlertStatus.normal, AlertSize.small,
-      Priority.LOW, VisualAlert.none, AudibleAlert.none, 5.),
+      Priority.LOW, VisualAlert.none, AudibleAlertSP.promptSingleHigh, 5.),
   },
 
   EventNameSP.speedLimitChanged: {
@@ -210,7 +211,7 @@ EVENTS_SP: dict[int, dict[str, Alert | AlertCallbackType]] = {
       "Set speed changed",
       "",
       AlertStatus.normal, AlertSize.small,
-      Priority.LOW, VisualAlert.none, AudibleAlert.none, 5.),
+      Priority.LOW, VisualAlert.none, AudibleAlertSP.promptSingleHigh, 5.),
   },
 
   EventNameSP.speedLimitPreActive: {
@@ -222,7 +223,7 @@ EVENTS_SP: dict[int, dict[str, Alert | AlertCallbackType]] = {
       "Automatically adjusting to the last speed limit",
       "",
       AlertStatus.normal, AlertSize.small,
-      Priority.LOW, VisualAlert.none, AudibleAlert.none, 5.),
+      Priority.LOW, VisualAlert.none, AudibleAlertSP.promptSingleHigh, 5.),
   },
 
   EventNameSP.e2eChime: {


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Add audible alerts for speed limit assist by defining two new alert types and mapping them to sound files

New Features:
- Introduce promptSingleLow and promptSingleHigh in SelfdriveStateSP for speed limit assist
- Use promptSingleLow for pre-active speed limit activation required alert
- Use promptSingleHigh for active speed limit change events
- Add corresponding WAV assets and register them in soundd for playback