### PR TITLE
UI: Fix Speed Limit Assist (SLA) Translations

### DIFF
--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/longitudinal/speed_limit/helpers.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/longitudinal/speed_limit/helpers.h
@@ -13,9 +13,9 @@ enum class SpeedLimitOffsetType {
 };
 
 inline const QString SpeedLimitOffsetTypeTexts[]{
-  QObject::tr("None"),
-  QObject::tr("Fixed"),
-  QObject::tr("Percent"),
+  QT_TRANSLATE_NOOP("SpeedLimitSettings", "None"),
+  QT_TRANSLATE_NOOP("SpeedLimitSettings", "Fixed"),
+  QT_TRANSLATE_NOOP("SpeedLimitSettings", "Percent"),
 };
 
 enum class SpeedLimitSourcePolicy {
@@ -27,11 +27,11 @@ enum class SpeedLimitSourcePolicy {
 };
 
 inline const QString SpeedLimitSourcePolicyTexts[]{
-  QObject::tr("Car\nOnly"),
-  QObject::tr("Map\nOnly"),
-  QObject::tr("Car\nFirst"),
-  QObject::tr("Map\nFirst"),
-  QObject::tr("Combined\nData")
+  QT_TRANSLATE_NOOP("SpeedLimitPolicy", "Car\nOnly"),
+  QT_TRANSLATE_NOOP("SpeedLimitPolicy", "Map\nOnly"),
+  QT_TRANSLATE_NOOP("SpeedLimitPolicy", "Car\nFirst"),
+  QT_TRANSLATE_NOOP("SpeedLimitPolicy", "Map\nFirst"),
+  QT_TRANSLATE_NOOP("SpeedLimitPolicy", "Combined\nData")
 };
 
 enum class SpeedLimitMode {
@@ -42,8 +42,8 @@ enum class SpeedLimitMode {
 };
 
 inline const QString SpeedLimitModeTexts[]{
-  QObject::tr("Off"),
-  QObject::tr("Information"),
-  QObject::tr("Warning"),
-  QObject::tr("Assist"),
+  QT_TRANSLATE_NOOP("SpeedLimitSettings", "Off"),
+  QT_TRANSLATE_NOOP("SpeedLimitSettings", "Information"),
+  QT_TRANSLATE_NOOP("SpeedLimitSettings", "Warning"),
+  QT_TRANSLATE_NOOP("SpeedLimitSettings", "Assist"),
 };

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/longitudinal/speed_limit/speed_limit_policy.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/longitudinal/speed_limit/speed_limit_policy.cc
@@ -23,11 +23,11 @@ SpeedLimitPolicy::SpeedLimitPolicy(QWidget *parent) : QWidget(parent) {
   ListWidgetSP *list = new ListWidgetSP(this);
 
   std::vector<QString> speed_limit_policy_texts{
-    SpeedLimitSourcePolicyTexts[static_cast<int>(SpeedLimitSourcePolicy::CAR_ONLY)],
-    SpeedLimitSourcePolicyTexts[static_cast<int>(SpeedLimitSourcePolicy::MAP_ONLY)],
-    SpeedLimitSourcePolicyTexts[static_cast<int>(SpeedLimitSourcePolicy::CAR_FIRST)],
-    SpeedLimitSourcePolicyTexts[static_cast<int>(SpeedLimitSourcePolicy::MAP_FIRST)],
-    SpeedLimitSourcePolicyTexts[static_cast<int>(SpeedLimitSourcePolicy::COMBINED)]
+    tr(SpeedLimitSourcePolicyTexts[static_cast<int>(SpeedLimitSourcePolicy::CAR_ONLY)].toStdString().c_str()),
+    tr(SpeedLimitSourcePolicyTexts[static_cast<int>(SpeedLimitSourcePolicy::MAP_ONLY)].toStdString().c_str()),
+    tr(SpeedLimitSourcePolicyTexts[static_cast<int>(SpeedLimitSourcePolicy::CAR_FIRST)].toStdString().c_str()),
+    tr(SpeedLimitSourcePolicyTexts[static_cast<int>(SpeedLimitSourcePolicy::MAP_FIRST)].toStdString().c_str()),
+    tr(SpeedLimitSourcePolicyTexts[static_cast<int>(SpeedLimitSourcePolicy::COMBINED)].toStdString().c_str())
   };
   speed_limit_policy = new ButtonParamControlSP(
     "SpeedLimitPolicy",

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/longitudinal/speed_limit/speed_limit_settings.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/longitudinal/speed_limit/speed_limit_settings.cc
@@ -25,10 +25,10 @@ SpeedLimitSettings::SpeedLimitSettings(QWidget *parent) : QStackedWidget(parent)
   speedLimitPolicyScreen = new SpeedLimitPolicy(this);
 
   std::vector<QString> speed_limit_mode_texts{
-    SpeedLimitModeTexts[static_cast<int>(SpeedLimitMode::OFF)],
-    SpeedLimitModeTexts[static_cast<int>(SpeedLimitMode::INFORMATION)],
-    SpeedLimitModeTexts[static_cast<int>(SpeedLimitMode::WARNING)],
-    SpeedLimitModeTexts[static_cast<int>(SpeedLimitMode::ASSIST)],
+    tr(SpeedLimitModeTexts[static_cast<int>(SpeedLimitMode::OFF)].toStdString().c_str()),
+    tr(SpeedLimitModeTexts[static_cast<int>(SpeedLimitMode::INFORMATION)].toStdString().c_str()),
+    tr(SpeedLimitModeTexts[static_cast<int>(SpeedLimitMode::WARNING)].toStdString().c_str()),
+    tr(SpeedLimitModeTexts[static_cast<int>(SpeedLimitMode::ASSIST)].toStdString().c_str())
   };
   speed_limit_mode_settings = new ButtonParamControlSP(
     "SpeedLimitMode",
@@ -64,9 +64,9 @@ SpeedLimitSettings::SpeedLimitSettings(QWidget *parent) : QStackedWidget(parent)
   QVBoxLayout *offsetLayout = new QVBoxLayout(offsetFrame);
 
   std::vector<QString> speed_limit_offset_texts{
-    SpeedLimitOffsetTypeTexts[static_cast<int>(SpeedLimitOffsetType::NONE)],
-    SpeedLimitOffsetTypeTexts[static_cast<int>(SpeedLimitOffsetType::FIXED)],
-    SpeedLimitOffsetTypeTexts[static_cast<int>(SpeedLimitOffsetType::PERCENT)]
+    tr(SpeedLimitOffsetTypeTexts[static_cast<int>(SpeedLimitOffsetType::NONE)].toStdString().c_str()),
+    tr(SpeedLimitOffsetTypeTexts[static_cast<int>(SpeedLimitOffsetType::FIXED)].toStdString().c_str()),
+    tr(SpeedLimitOffsetTypeTexts[static_cast<int>(SpeedLimitOffsetType::PERCENT)].toStdString().c_str())
   };
   speed_limit_offset_settings = new ButtonParamControlSP(
     "SpeedLimitOffsetType",

--- a/selfdrive/ui/translations/main_ko.ts
+++ b/selfdrive/ui/translations/main_ko.ts
@@ -1778,62 +1778,6 @@ Warning: You are on a metered connection!</source>
         <source>sunnypilot</source>
         <translation>sunnypilot</translation>
     </message>
-    <message>
-        <source>None</source>
-        <translation>없음</translation>
-    </message>
-    <message>
-        <source>Fixed</source>
-        <translation>고정</translation>
-    </message>
-    <message>
-        <source>Percent</source>
-        <translation>비율</translation>
-    </message>
-    <message>
-        <source>Car
-Only</source>
-        <translation>차량만</translation>
-    </message>
-    <message>
-        <source>Map
-Only</source>
-        <translation>지도만</translation>
-    </message>
-    <message>
-        <source>Car
-First</source>
-        <translation>차량
-우선</translation>
-    </message>
-    <message>
-        <source>Map
-First</source>
-        <translation>지도
-우선</translation>
-    </message>
-    <message>
-        <source>Combined
-Data</source>
-        <translation>결합
-데이터</translation>
-    </message>
-    <message>
-        <source>Off</source>
-        <translation>끄기</translation>
-    </message>
-    <message>
-        <source>Information</source>
-        <translation>정보</translation>
-    </message>
-    <message>
-        <source>Warning</source>
-        <translation>경고</translation>
-    </message>
-    <message>
-        <source>Assist</source>
-        <translation>보조</translation>
-    </message>
 </context>
 <context>
     <name>SettingsWindow</name>
@@ -2198,6 +2142,34 @@ Data</source>
         <source>⦿ Combined: Use combined Speed Limit data from Car &amp; OpenStreetMaps</source>
         <translation>⦿ 결합: 차량 및 OpenStreetMaps의 속도 제한 결합 데이터 사용</translation>
     </message>
+    <message>
+        <source>Car
+Only</source>
+        <translation>차량만</translation>
+    </message>
+    <message>
+        <source>Map
+Only</source>
+        <translation>지도만</translation>
+    </message>
+    <message>
+        <source>Car
+First</source>
+        <translation>차량
+우선</translation>
+    </message>
+    <message>
+        <source>Map
+First</source>
+        <translation>지도
+우선</translation>
+    </message>
+    <message>
+        <source>Combined
+Data</source>
+        <translation>결합
+데이터</translation>
+    </message>
 </context>
 <context>
     <name>SpeedLimitSettings</name>
@@ -2244,6 +2216,34 @@ Data</source>
     <message>
         <source>⦿ Assist: Adjusts the vehicle&apos;s cruise speed based on the current road&apos;s speed limit when operating the +/- buttons.</source>
         <translation>⦿ 보조: +/- 버튼을 조작할 때 현재 도로의 제한 속도를 기준으로 차량의 크루즈 속도를 조정합니다.</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation>없음</translation>
+    </message>
+    <message>
+        <source>Fixed</source>
+        <translation>고정</translation>
+    </message>
+    <message>
+        <source>Percent</source>
+        <translation>비율</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <translation>끄기</translation>
+    </message>
+    <message>
+        <source>Information</source>
+        <translation>정보</translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation>경고</translation>
+    </message>
+    <message>
+        <source>Assist</source>
+        <translation>보조</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
<img width="2167" height="1077" alt="image" src="https://github.com/user-attachments/assets/bf319056-c9a6-45bd-9c1e-5af19a01e3dd" />

<img width="2167" height="1077" alt="image" src="https://github.com/user-attachments/assets/72ba1680-b609-483e-9abc-315d5b280ee0" />

## Summary by Sourcery

Fix SLA translations by relocating missing Korean translation entries, updating translation macros, and wrapping UI strings in tr() calls for runtime lookup

Bug Fixes:
- Restore missing Korean translations for speed limit modes, offsets, and source policies in the SettingsWindow and SpeedLimitSettings UI

Enhancements:
- Move generic translation entries in main_ko.ts into their proper contexts
- Replace QObject::tr() with QT_TRANSLATE_NOOP() in helpers to define texts with explicit translation contexts
- Wrap speed limit option strings in tr() calls in settings and policy constructors to enable translation at runtime