### PR TITLE
Add 'file' package to Ubuntu dependencies script

### DIFF
--- a/tools/install_ubuntu_dependencies.sh
+++ b/tools/install_ubuntu_dependencies.sh
@@ -32,6 +32,7 @@ function install_ubuntu_common_requirements() {
     libcurl4-openssl-dev \
     git \
     git-lfs \
+    file \
     ffmpeg \
     libavformat-dev \
     libavcodec-dev \


### PR DESCRIPTION
**Description**

The op.sh setup script fails with this message when running in a Ubuntu 24.04.3 LTS x86_64 container.

Checking for git lfs files...
./tools/op.sh: line 106: file: command not found
 ↳ [✗] git lfs files not found! Run 'git lfs pull'

missing package: https://packages.ubuntu.com/noble/file


**Verification**

Ran op.sh setup script again and saw no errors in the output.

 ↳ [✔] Dependencies installed successfully in 4 seconds.
Getting git submodules...
 ↳ [✔] Submodules installed successfully in 0 seconds.
Pulling git lfs files...
 ↳ [✔] Files pulled successfully in 0 seconds.
Checking for openpilot directory...
 ↳ [✔] openpilot found.
Checking for git...
 ↳ [✔] git found.
Checking for git lfs files...
 ↳ [✔] git lfs files found.
Checking for git submodules...
 ↳ [✔] git submodules found.
Checking for compatible os version...
 ↳ [✔] Ubuntu noble detected.
Checking for venv...
 ↳ [✔] venv detected.
Checking for compatible python version...
 ↳ [✔] Python 3.12.3 detected.

## Summary by Sourcery

Bug Fixes:
- Install the 'file' package in install_ubuntu_dependencies.sh to satisfy the script’s dependency check for the 'file' command