### PR TITLE
LiveLocationKalman: skip tests on unsupported msgq

### DIFF
--- a/sunnypilot/selfdrive/locationd/tests/test_locationd.py
+++ b/sunnypilot/selfdrive/locationd/tests/test_locationd.py
@@ -14,7 +14,7 @@ from openpilot.system.manager.process_config import managed_processes
 
 
 if platform.system() == 'Darwin':
-  pytest.skip("Skipping locationd test on macOS because msgq doesn't work.", allow_module_level=True)
+  pytest.skip("Skipping locationd test on macOS due to unsupported msgq.", allow_module_level=True)
 
 
 class TestLocationdProc:


### PR DESCRIPTION
msgq is fun

## Summary by Sourcery

Tests:
- Add a module-level pytest.skip for Darwin to bypass failing msgq tests on macOS