### PR TITLE
Accidentally created pull request

### DIFF
--- a/opendbc_repo/opendbc/car/rivian/carstate.py
+++ b/opendbc_repo/opendbc/car/rivian/carstate.py
@@ -51,7 +51,7 @@ class CarState(CarStateBase, CarStateExt):
     # Cruise state
     speed = min(int(cp_adas.vl["ACM_tsrCmd"]["ACM_tsrSpdDisClsMain"]), 85)
     self.last_speed = speed if speed != 0 else self.last_speed
-    ret.cruiseState.enabled = cp_cam.vl["ACM_Status"]["ACM_FeatureStatus"] == 1
+    ret.cruiseState.enabled = cp_cam.vl["ACM_Status"]["ACM_FeatureStatus"] == 2
     # TODO: find cruise set speed on CAN
     ret.cruiseState.speed = self.last_speed * CV.MPH_TO_MS  # detected speed limit
     if not self.CP.openpilotLongitudinalControl:

--- a/opendbc_repo/opendbc/car/rivian/interface.py
+++ b/opendbc_repo/opendbc/car/rivian/interface.py
@@ -20,9 +20,9 @@ class CarInterface(CarInterfaceBase):
 
     ret.steerActuatorDelay = 0.15
     ret.steerLimitTimer = 0.4
-    CarInterfaceBase.configure_torque_tune(candidate, ret.lateralTuning)
 
-    ret.steerControlType = structs.CarParams.SteerControlType.torque
+    # Use angle-based steering (Driver+)
+    ret.steerControlType = structs.CarParams.SteerControlType.angle
     ret.radarUnavailable = True
 
     # TODO: pending finding/handling missing set speed and fixing up radar parser

--- a/opendbc_repo/opendbc/car/rivian/riviancan.py
+++ b/opendbc_repo/opendbc/car/rivian/riviancan.py
@@ -67,7 +67,7 @@ def create_longitudinal(packer, frame, accel, enabled):
     "ACM_longitudinalRequest_Counter": frame % 15,
     "ACM_AccelerationRequest": accel,
     "ACM_PrndRequest": 0,
-    "ACM_longInterfaceEnable": 1 if enabled else 0,
+    "ACM_longInterfaceEnable": 1 if enabled else 0,  # 0=INIT when not engaged, 1=ENABLE when engaged
     "ACM_VehicleHoldRequest": 0,
   }
 
@@ -76,7 +76,7 @@ def create_longitudinal(packer, frame, accel, enabled):
   return packer.make_can_msg("ACM_longitudinalRequest", 0, values)
 
 
-def create_adas_status(packer, vdm_adas_status, interface_status):
+def create_adas_status(packer, vdm_adas_status, interface_status, enabled):
   values = {s: vdm_adas_status[s] for s in (
     "VDM_AdasStatus_Checksum",
     "VDM_AdasStatus_Counter",
@@ -91,9 +91,82 @@ def create_adas_status(packer, vdm_adas_status, interface_status):
     "VDM_UserAdasRequest",
   )}
 
+  # Override interface_status if provided (for cancel logic), otherwise use enabled state
   if interface_status is not None:
     values["VDM_AdasInterfaceStatus"] = interface_status
+  else:
+    # 0=Unavailable when not engaged, 1=Available when engaged
+    values["VDM_AdasInterfaceStatus"] = 1 if enabled else 0
+
+  # 0=Human when not engaged, 1=Adas when engaged
+  values["VDM_AdasDriverModeStatus"] = 1 if enabled else 0
+
+  # 0 when not engaged, 129 when engaged
+  values["VDM_AdasUnkown1"] = 129 if enabled else 0
+
+  # 0 when not engaged, 4 when engaged
+  values["VDM_UserAdasRequest"] = 4 if enabled else 0
 
   data = packer.make_can_msg("VDM_AdasSts", 2, values)[1]
   values["VDM_AdasStatus_Checksum"] = checksum(data[1:], 0x1D, 0xD1)
   return packer.make_can_msg("VDM_AdasSts", 2, values)
+
+
+def create_epas_status(packer, frame, enabled):
+  # EPAS_Ecu2EacSts values: 0=Inhibited, 1=Available, 2=Active, 3=Fault, 7=Sna
+  values = {
+    "EPASS_Ecu2Status_Counter": frame % 15,
+    "EPAS_Ecu2EacSts": 7 if enabled else 1,  # 7=Sna when engaged, 1=Available when not
+    "EPAS_Ecu2PowerMode": 1,  # 1=Normal
+    "EPASS_Ecu2Role": 0,
+    "EPASS_Ecu2State": 0,
+  }
+
+  data = packer.make_can_msg("EPASS_Status", 0, values)[1]
+  values["EPASS_Ecu2Status_Checksum"] = checksum(data[1:], 0x1D, 0x00)  # TODO: verify XOR value
+  return packer.make_can_msg("EPASS_Status", 0, values)
+
+
+def create_steering_control(packer, frame, apply_angle, enabled):
+  # ACM_EacEnabled values: 0=None, 1=Enabled, 2=Reserved
+  values = {
+    "ACM_SteeringControl_Counter": frame % 15,
+    "ACM_EacEnabled": 1 if enabled else 0,  # 0=None when not engaged, 1=Enabled when engaged
+    "ACM_HapticRequired": 0,
+    "ACM_SteeringAngleRequest": apply_angle,  # Steering angle in degrees
+  }
+
+  data = packer.make_can_msg("ACM_SteeringControl", 0, values)[1]
+  values["ACM_SteeringControl_Checksum"] = checksum(data[1:], 0x1D, 0x00)  # TODO: verify XOR value
+  return packer.make_can_msg("ACM_SteeringControl", 0, values)
+
+
+def create_longitudinal_interface(packer, frame, enabled):
+  # Send longitudinal interface enable on bus 0
+  values = {
+    "ACM_longitudinalRequest_Counter": frame % 15,
+    "ACM_AccelerationRequest": 0,
+    "ACM_PrndRequest": 0,
+    "ACM_longInterfaceEnable": 1 if enabled else 0,  # 0=INIT when not engaged, 1=ENABLE when engaged
+    "ACM_VehicleHoldRequest": 0,
+  }
+
+  data = packer.make_can_msg("ACM_longitudinalRequest", 0, values)[1]
+  values["ACM_longitudinalRequest_Checksum"] = checksum(data[1:], 0x1D, 0x12)
+  return packer.make_can_msg("ACM_longitudinalRequest", 0, values)
+
+
+def create_epas_adas_status(packer, frame, enabled):
+  # EPAS_EacStatus values: 0=Inhibited, 1=Available, 2=Active, 3=Standby, 4=Fault, 5=Sna
+  values = {
+    "EPAS_AdasStatus_Counter": frame % 15,
+    "EPAS_EacStatus": 2 if enabled else 1,  # 1=Available when not engaged, 2=Active when engaged
+    "EPAS_EacErrorCode": 0,  # 0=No error
+    "EPAS_SteeringAngleSpeed": 0,
+    "EPAS_InternalSas": 0,
+    "EPAS_InternalSasQ": 0,
+  }
+
+  data = packer.make_can_msg("EPAS_AdasStatus", 0, values)[1]
+  values["EPAS_AdasStatus_Checksum"] = checksum(data[1:], 0x1D, 0x00)  # TODO: verify XOR value
+  return packer.make_can_msg("EPAS_AdasStatus", 0, values)


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

## Summary by Sourcery

Enable Driver+ angle-based steering on Rivian by replacing torque-based control with angle commands, adding EPAS and ADAS status messaging, and updating safety hooks, CarController, and interface accordingly

New Features:
- Implement Driver+ angle-based steering control for Rivian using ACM_SteeringControl messages
- Add CAN message constructors for EPAS status (EPASS_Status), EPAS ADAS status (EPAS_AdasStatus), steering control, and longitudinal interface enable

Enhancements:
- Extend ADAS status generation to include interface status, driver mode, and engagement flags
- Update Rivian safety hooks to validate angle commands against new angle-based steering limits and adjust transmit whitelist
- Switch CarInterface and CarController to use steerControlType.angle and adapt CarState cruise detection to the new feature status field