### PR TITLE
docs: Update README installation branches and discord links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## 🌞 What is sunnypilot?
 [sunnypilot](https://github.com/sunnyhaibin/sunnypilot) is a fork of comma.ai's openpilot, an open source driver assistance system. sunnypilot offers the user a unique driving experience for over 300+ supported car makes and models with modified behaviors of driving assist engagements. sunnypilot complies with comma.ai's safety rules as accurately as possible.
 
-## 💭 Join our Forum
+## 💭 Join our Community Forum
 Join the official sunnypilot community forum to stay up to date with all the latest features and be a part of shaping the future of sunnypilot!
 * https://community.sunnypilot.ai/
 


### PR DESCRIPTION
**Description**

This PR extends #1241, which is currently in draft state. It updates the recommended installation branches in the README, since the `*-c3-new` branches are no longer the recommended path. It also updates two links referring people to the Discord to the community forum instead. If preferred, the Discord link changes can be moved to a separate PR or removed in favor of changing them further down the line.

**Verification**

No code changes were made, only documentation updates. CI tests ran and passed.

### Linked Discussion
https://community.sunnypilot.ai/t/sunnypilots-readme-should-be-updated-to-reflect-the-current-install-urls/666/4?u=devtekve

## Summary by Sourcery

Update README to use community forum links and revise installation instructions with new branch naming and URLs.

Documentation:
- Replace Discord join section with links and instructions for the community forum
- Update supported car count to 325+ and point to the sunnypilot CARS.md file
- Change installation instructions to recommend release, staging, and dev branches instead of `*-c3-new` and update example URLs and branch table