### PR TITLE
tools: add retry mechanism for API requests

### DIFF
--- a/tools/lib/api.py
+++ b/tools/lib/api.py
@@ -1,5 +1,6 @@
 import os
 import requests
+from requests.adapters import HTTPAdapter, Retry
 API_HOST = os.getenv('API_HOST', 'https://api.commadotai.com')
 
 # TODO: this should be merged into common.api
@@ -10,6 +11,9 @@ class CommaApi:
     self.session.headers['User-agent'] = 'OpenpilotTools'
     if token:
       self.session.headers['Authorization'] = 'JWT ' + token
+
+    retries = Retry(total=5, backoff_factor=1, status_forcelist=[500, 502, 503, 504])
+    self.session.mount('https://', HTTPAdapter(max_retries=retries))
 
   def request(self, method, endpoint, **kwargs):
     with self.session.request(method, API_HOST + '/' + endpoint, **kwargs) as resp:


### PR DESCRIPTION
Temporary fix for spotty failures with fetching routes from comma's Azure bucket.

**Duplicate of**
- https://github.com/commaai/openpilot/pull/36617

If the above PR or a different fix is merged in upstream, revert this PR to avoid conflicts.