### PR TITLE
Refine v_cruise_equal to use a tolerance check

### DIFF
--- a/sunnypilot/selfdrive/car/intelligent_cruise_button_management/controller.py
+++ b/sunnypilot/selfdrive/car/intelligent_cruise_button_management/controller.py
@@ -47,7 +47,7 @@ class IntelligentCruiseButtonManagement:
 
   @property
   def v_cruise_equal(self) -> bool:
-    return self.v_target == self.v_cruise_cluster
+    return abs(self.v_target - self.v_cruise_cluster) < 0.1
 
   def update_calculations(self, CS: car.CarState, LP_SP: custom.LongitudinalPlanSP) -> None:
     speed_conv = CV.MS_TO_KPH if self.is_metric else CV.MS_TO_MPH


### PR DESCRIPTION
I believe this change fixes a bug that affects icbm on nissan platforms where the set speed oscillates up and down by a couple mph instead of stopping at the target speed. Below are images from cabana and plot juggler that demonstrate the issue.

<img width="752" height="277" alt="image" src="https://github.com/user-attachments/assets/fc104ffe-3208-46d8-922c-feb129a7ebde" />

<img width="1344" height="603" alt="image" src="https://github.com/user-attachments/assets/8268ba59-dfd4-46f4-af03-ca7c6289c249" />
