### PR TITLE
sunnylink: centralize key pair handling in sunnylink registration

### DIFF
--- a/sunnypilot/sunnylink/api.py
+++ b/sunnypilot/sunnylink/api.py
@@ -3,7 +3,6 @@ import os
 import random
 import time
 from datetime import datetime, timedelta
-from pathlib import Path
 
 import jwt
 from openpilot.common.api.base import BaseApi


### PR DESCRIPTION
- Replaced manual key reading with `BaseApi.get_key_pair` for consistency.
- Simplifies code and improves maintainability of key management.
