### PR TITLE
ci: disable macos builds

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -107,6 +107,7 @@ jobs:
 
   build_mac:
     name: build macOS
+    if: false  # temp disable since gcc-arm-embedded install is getting stuck due to checksum mismatch
     runs-on: ${{ ((github.repository == 'commaai/openpilot') && ((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.full_name == 'commaai/openpilot'))) && 'namespace-profile-macos-8x14' || 'macos-latest' }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
**Root Cause and Fix from Homebrew**
- https://github.com/Homebrew/homebrew-cask/issues/238908
- https://github.com/Homebrew/homebrew-cask/pull/238913

```
Installing gcc-arm-embedded
==> Downloading https://developer.arm.com/-/media/Files/downloads/gnu/14.3.rel1/binrel/arm-gnu-toolchain-14.3.rel1-darwin-arm64-arm-none-eabi.pkg
Installing gcc-arm-embedded has failed!
Error: SHA-256 mismatch
Expected: b93712026cec9f98a5d98dfec84e8096d32be3759642381e1982c4a5d2aa020b
  Actual: 321383e1c371330c73a6d2b1fdd726a1a75c3719cbf2f39b10c459f28ba4cec8
    File: /Users/runner/Library/Caches/Homebrew/downloads/461ad9ebd826303625f0789c57e0e4eaac2e170bb6bade40f8aee7d9581813a4--arm-gnu-toolchain-14.3.rel1-darwin-arm64-arm-none-eabi.pkg
To retry an incomplete download, remove the file above.

Installing portaudio
Using gcc@13
`brew bundle` failed! 1 Brewfile dependency failed to install
Error: Process completed with exit code 1.
```