### PR TITLE
ui: recreate search dialog with the latest query

### DIFF
--- a/system/ui/sunnypilot/widgets/tree_dialog.py
+++ b/system/ui/sunnypilot/widgets/tree_dialog.py
@@ -98,12 +98,7 @@ class TreeOptionDialog(MultiOptionDialog):
     # Default title & overridable subtitle for InputDialogSP
     self.search_title = search_title or tr("Enter search query")
     self.search_subtitle = search_subtitle
-    self.search_dialog = InputDialogSP(
-      self.search_title,
-      self.search_subtitle,
-      current_text=self.query,
-      callback=self._on_search_confirm,
-    )
+    self.search_dialog = None
 
     self._build_visible_items()
 
@@ -114,6 +109,12 @@ class TreeOptionDialog(MultiOptionDialog):
     gui_app.set_modal_overlay(self, callback=self.on_exit)
 
   def _on_search_clicked(self):
+    self.search_dialog = InputDialogSP(
+      self.search_title,
+      self.search_subtitle,
+      current_text=self.query,
+      callback=self._on_search_confirm,
+    )
     self.search_dialog.show()
 
   def _toggle_folder(self, folder):


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

