### PR TITLE
ui: adjust Sponsor and Pairing button behaviors in sunnylink panel

### DIFF
--- a/selfdrive/ui/sunnypilot/layouts/settings/sunnylink.py
+++ b/selfdrive/ui/sunnypilot/layouts/settings/sunnylink.py
@@ -328,12 +328,11 @@ class SunnylinkLayout(Widget):
     tier_name = ui_state.sunnylink_state.get_sponsor_tier().name.capitalize() or tr("Not Sponsor")
     self._sponsor_btn.action_item.set_text(sponsor_btn_text)
     self._sponsor_btn.action_item.set_value(tier_name, ui_state.sunnylink_state.get_sponsor_tier_color())
-    self._sponsor_btn.action_item.set_enabled(self._sunnylink_enabled and not ui_state.sunnylink_state.is_sponsor())
+    self._sponsor_btn.action_item.set_enabled(self._sunnylink_enabled)
 
     pair_btn_text = tr("Paired") if ui_state.sunnylink_state.is_paired() else tr("Not Paired")
     self._pair_btn.action_item.set_text(pair_btn_text)
-    self._pair_btn.set_visible(lambda: self._sunnylink_enabled and not ui_state.sunnylink_state.is_paired())
-    self._pair_btn.action_item.set_enabled(self._sunnylink_enabled and not ui_state.sunnylink_state.is_paired())
+    self._pair_btn.action_item.set_enabled(self._sunnylink_enabled)
 
   def _render(self, rect):
     self._scroller.render(rect)

--- a/system/ui/sunnypilot/widgets/sunnylink_pairing_dialog.py
+++ b/system/ui/sunnypilot/widgets/sunnylink_pairing_dialog.py
@@ -25,6 +25,7 @@ class SunnylinkPairingDialog(PairingDialog):
   def __init__(self, sponsor_pairing: bool = False):
     PairingDialog.__init__(self)
     self._sponsor_pairing = sponsor_pairing
+    self._is_paired_prev = ui_state.sunnylink_state.is_paired()
 
   def _get_pairing_url(self) -> str:
     qr_string = "https://github.com/sponsors/sunnyhaibin"
@@ -42,7 +43,8 @@ class SunnylinkPairingDialog(PairingDialog):
     return qr_string
 
   def _update_state(self):
-    if ui_state.sunnylink_state.is_paired():
+    is_paired = ui_state.sunnylink_state.is_paired()
+    if not self._is_paired_prev and is_paired:
       gui_app.set_modal_overlay(None)
 
   def _render(self, rect: rl.Rectangle) -> int:


### PR DESCRIPTION
**Description**
- always allow sunnylink pairing, since a device may be paired multiple times.
- always keep the Sponsor and Pairing buttons enabled, so users can open the QR code dialogs at any time.
- fix an issue where the pairing dialog would immediately auto-close when opened on a device that was already paired.
