### PR TITLE
sunnylink: block more params

### DIFF
--- a/common/params_keys.h
+++ b/common/params_keys.h
@@ -203,6 +203,7 @@ inline static std::unordered_map<std::string, ParamKeyAttributes> keys = {
     {"SunnylinkdPid", {PERSISTENT, INT}},
     {"SunnylinkEnabled", {PERSISTENT, BOOL, "1"}},
     {"SunnylinkTempFault", {CLEAR_ON_MANAGER_START | CLEAR_ON_OFFROAD_TRANSITION, BOOL, "0"}},
+    {"SunnylinkAllowSensitiveWrite", {PERSISTENT, BOOL, "0"}},
 
     // Backup Manager params
     {"BackupManager_CreateBackup", {PERSISTENT, BOOL}},


### PR DESCRIPTION
**Description**

Inspired by https://github.com/sunnypilot/sunnypilot/pull/1591 I extended remote parameter protection to block additional security-sensitive parameters. This has minor impact on backup/restore convenience in exchange for security hardening and privacy piece of mind.

Additionally I blocked any remote modifications while OP is engaged for safety reasons. - If needed, some low impact params can be whitelisted in the future.
Todo: toggle state gets out of sync if modified while driving, so that's something that could be improved on the front end side. 

**Verification**

I tested safety implication of pushing toggles while driving using https://www.sunnylink.ai/dashboard.  

- Before the change pushing Offroad On toggle would disengage suddenly and play siren (after a delay and for a fraction of a second - probably panda bug), not giving the driver much time to react. 

- After the change, pushing Offroad On toggle didn't have any effect - as expected.  
