### PR TITLE
Sunnylink: opt-out by default

### DIFF
--- a/common/params_keys.h
+++ b/common/params_keys.h
@@ -201,7 +201,7 @@ inline static std::unordered_map<std::string, ParamKeyAttributes> keys = {
     {"SunnylinkCache_Users", {PERSISTENT, STRING}},
     {"SunnylinkDongleId", {PERSISTENT, STRING}},
     {"SunnylinkdPid", {PERSISTENT, INT}},
-    {"SunnylinkEnabled", {PERSISTENT, BOOL, "1"}},
+    {"SunnylinkEnabled", {PERSISTENT, BOOL, "0"}},
     {"SunnylinkTempFault", {CLEAR_ON_MANAGER_START | CLEAR_ON_OFFROAD_TRANSITION, BOOL, "0"}},
 
     // Backup Manager params

--- a/selfdrive/ui/sunnypilot/layouts/settings/sunnylink.py
+++ b/selfdrive/ui/sunnypilot/layouts/settings/sunnylink.py
@@ -303,12 +303,10 @@ class SunnylinkLayout(Widget):
 
   def _sunnylink_toggle_callback(self, state: bool):
     if state:
-      description = tr(
-        "Welcome back!! We're excited to see you've enabled sunnylink again!")
+      description = tr("Thanks for enabling sunnylink!")
       color = rl.Color(0, 255, 0, 255)  # Green
     else:
-      description = ("😢 " + tr("Not going to lie, it's sad to see you disabled sunnylink") +
-                     tr(", but we'll be here when you're ready to come back."))
+      description = tr("Sunnylink disabled. You can re-enable anytime.")
       color = rl.Color(255, 165, 0, 255)  # Orange
     self._sunnylink_description.set_text(description)
     self._sunnylink_description.set_color(color)


### PR DESCRIPTION
A minimum version of https://github.com/sunnypilot/sunnypilot/pull/1605

- Gives user a chance to opt-out from Sunnylink. 

<img width="555" alt="image" src="https://github.com/user-attachments/assets/867d0c94-60a7-4926-8007-3b92b11bb4a0" />


<img width="555" alt="image" src="https://github.com/user-attachments/assets/414a1c16-337b-4f1e-9f5c-45db36e71a97" />


<img width="555" alt="image" src="https://github.com/user-attachments/assets/f483c6ef-f583-4a86-9550-271b2f4aaee0" />
