### PR TITLE
ui: fix malformed dongle ID display on the PC if dongleID is not set

### DIFF
--- a/selfdrive/ui/sunnypilot/layouts/settings/sunnylink.py
+++ b/selfdrive/ui/sunnypilot/layouts/settings/sunnylink.py
@@ -209,8 +209,8 @@ class SunnylinkLayout(Widget):
     return items
 
   @staticmethod
-  def _get_sunnylink_dongle_id() -> str | None:
-    return str(ui_state.params.get("SunnylinkDongleId") or (lambda: tr("N/A")))
+  def _get_sunnylink_dongle_id() -> str:
+    return ui_state.params.get("SunnylinkDongleId") or tr("N/A")
 
   def _handle_pair_btn(self, sponsor_pairing: bool = False):
     sunnylink_dongle_id = self._get_sunnylink_dongle_id()


### PR DESCRIPTION
Fixes this on a PC:
<img width="1100" height="563" alt="image" src="https://github.com/user-attachments/assets/be412b42-3d68-4ab2-be96-fa2ddbdaaeba" />
