### PR TITLE
tools: script for video concatenation

### DIFF
--- a/sunnypilot/tools/pull_footage.py
+++ b/sunnypilot/tools/pull_footage.py
@@ -1,4 +1,10 @@
 #!/usr/bin/env python3
+"""
+Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+"""
 import argparse
 import os
 import shutil


### PR DESCRIPTION
This provides an easy to use video concatenation script. 

This can be ran after setting up openpilot on computer. 

Run the file, give optional ssh arguments by either doing comma@, sunny-, or comma-
And route and it’ll pull the fcam from device.

Or don’t do those and simply just put in the route and the file will use commas server to download the footage range or all, fcam preferred but there’s fallbacks to whatever is available on their server and stitch it together into a full “movie” and save it as mp4

Example commands: `./sunnypilot/tools/pull_footage.py comma-4e1c2f3718946cc1 0000007a--768170bf57/0`
for ssh direct from device. For accessing commas server directly, simply `./sunnypilot/tools/pull_footage.py 4e1c2f3718946cc1/0000007a--768170bf57/` or use slicing `./sunnypilot/tools/pull_footage.py 4e1c2f3718946cc1/0000007a--768170bf57/1:8` for exact segment range.


<br>Commas server access with no cam uploaded (qcam):

https://github.com/user-attachments/assets/14b48d6e-ec7c-4be0-8e94-3d9280483138  


Using comma-* wild card with route command segment 0:

https://github.com/user-attachments/assets/297d9b7e-70bf-4830-83b4-ac65a018aad2



