### PR TITLE
Reapply "ui: Global Brightness Override (#1579)"

### DIFF
--- a/selfdrive/ui/sunnypilot/ui_state.py
+++ b/selfdrive/ui/sunnypilot/ui_state.py
@@ -90,9 +90,9 @@ class DeviceSP:
       self._params.put_bool("OffroadMode", True)
 
   @staticmethod
-  def update_custom_global_brightness(brightness_override: int) -> float:
+  def update_max_global_brightness(brightness_override: int) -> float:
     """
-    Updates the custom global brightness by constraining the value to a predefined range.
+    Updates the max global brightness by constraining the value to a predefined range.
 
     The method takes an integer `brightness` value, adjusts it to ensure it is within the
     range of 30 to 100, inclusive, and returns the adjusted value as a float.

--- a/selfdrive/ui/ui_state.py
+++ b/selfdrive/ui/ui_state.py
@@ -263,7 +263,7 @@ class Device(DeviceSP):
     brightness = round(self._brightness_filter.update(clipped_brightness))
 
     if gui_app.sunnypilot_ui() and ui_state.global_brightness_override != 0:
-      brightness = DeviceSP.update_custom_global_brightness(ui_state.global_brightness_override)
+      brightness = DeviceSP.update_max_global_brightness(ui_state.global_brightness_override)
 
     if not self._awake:
       brightness = 0


### PR DESCRIPTION
Reapplies the global brightness override. 

This PR should address https://community.sunnypilot.ai/t/c4-booting-to-black-screen/2251/7

On MICI, a brightness below 5 is completely invisible. 