### PR TITLE
Sunnylink: block parameter changes when engaged

### DIFF
--- a/sunnypilot/sunnylink/athena/sunnylinkd.py
+++ b/sunnypilot/sunnylink/athena/sunnylinkd.py
@@ -253,10 +253,17 @@ def getParams(params_keys: list[str], compression: bool = False) -> str | dict[s
 
 @dispatcher.add_method
 def saveParams(params_to_update: dict[str, str], compression: bool = False) -> None:
+  is_engaged = params.get_bool("IsEngaged")
+
   for key, value in params_to_update.items():
     # disallow modifications to blocked parameters
     if key in BLOCKED_PARAMS:
       cloudlog.warning(f"sunnylinkd.saveParams.blocked: Attempted to modify blocked parameter '{key}'")
+      continue
+
+    # Block all params while engaged
+    if is_engaged:
+      cloudlog.warning(f"sunnylinkd.saveParams.blocked_engaged: Attempted to modify '{key}' while engaged")
       continue
 
     try:

--- a/sunnypilot/sunnylink/athena/tests/test_sunnylinkd.py
+++ b/sunnypilot/sunnylink/athena/tests/test_sunnylinkd.py
@@ -4,22 +4,25 @@ Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
 This file is part of sunnypilot and is licensed under the MIT License.
 See the LICENSE.md file in the root directory for more details.
 """
+import pytest
+
 from openpilot.sunnypilot.sunnylink.athena import sunnylinkd
 
 
 class TestSunnylinkdMethods:
-  def setup_method(self):
+  @pytest.fixture(autouse=True)
+  def setup(self, mocker):
     self.saved_params = []
-
-    self.original_save = sunnylinkd.save_param_from_base64_encoded_string
 
     def mock_save_param(key, value, compression=False):
       self.saved_params.append((key, value, compression))
 
-    sunnylinkd.save_param_from_base64_encoded_string = mock_save_param
+    mocker.patch.object(sunnylinkd, 'save_param_from_base64_encoded_string', mock_save_param)
 
-  def teardown_method(self):
-    sunnylinkd.save_param_from_base64_encoded_string = self.original_save
+    # Mock params with IsEngaged=False by default
+    self.mock_params = mocker.MagicMock()
+    self.mock_params.get_bool.return_value = False
+    mocker.patch.object(sunnylinkd, 'params', self.mock_params)
 
   def test_saveParams_blocked(self):
     blocked_params = {
@@ -57,3 +60,42 @@ class TestSunnylinkdMethods:
     assert len(self.saved_params) == 1
     assert self.saved_params[0][0] == "SpeedLimitOffset"
     assert self.saved_params[0][1] == "10"
+
+  def test_saveParams_all_blocked_when_engaged(self):
+    """All params are blocked while engaged"""
+    self.mock_params.get_bool.side_effect = lambda key: key == "IsEngaged"
+
+    sunnylinkd.saveParams({
+      "Mads": "1",
+      "AlphaLongitudinalEnabled": "1",
+    })
+
+    assert len(self.saved_params) == 0
+
+  def test_saveParams_safety_critical_blocked_when_engaged(self):
+    """Safety-critical params are blocked while engaged"""
+    self.mock_params.get_bool.side_effect = lambda key: key == "IsEngaged"
+
+    sunnylinkd.saveParams({
+      "DoReboot": "1",
+      "DoShutdown": "1",
+      "DoUninstall": "1",
+      "ForcePowerDown": "1",
+      "OffroadMode": "1",
+    })
+
+    assert len(self.saved_params) == 0
+
+  def test_saveParams_allowed_when_not_engaged(self):
+    """Safety-critical params are allowed when not engaged"""
+    sunnylinkd.saveParams({
+      "DoReboot": "1",
+      "DoShutdown": "1",
+      "DoUninstall": "1",
+      "ForcePowerDown": "1",
+      "OffroadMode": "1",
+      "Mads": "1",
+      "AlphaLongitudinalEnabled": "1",
+    })
+
+    assert len(self.saved_params) == 7


### PR DESCRIPTION
Blocks any remote modifications while OP is engaged for safety reasons. 
Adds test for those that can result in instant loss of steering. 

Old ref: https://github.com/sunnypilot/sunnypilot/pull/1593#issue-3750214564