### PR TITLE
Revert "sunnylink: shorter timeout for websocket reconnect"

### DIFF
--- a/common/api/__init__.py
+++ b/common/api/__init__.py
@@ -18,8 +18,8 @@ class Api:
     return self.service.get_token(payload_extra, expiry_hours)
 
 
-def api_get(endpoint, method='GET', timeout=None, access_token=None, session=None, json=None, **params):
-  return CommaConnectApi(None).api_get(endpoint, method, timeout, access_token, session, json, **params)
+def api_get(endpoint, method='GET', timeout=None, access_token=None, session=None, **params):
+  return CommaConnectApi(None).api_get(endpoint, method, timeout, access_token, session, **params)
 
 
 def get_key_pair() -> tuple[str, str, str] | tuple[None, None, None]:


### PR DESCRIPTION
Reverts sunnypilot/sunnypilot#1681

* Need to bypass ssl cert validation when locally developing for testing 
* the 30 second timeout means it has to go 30 seconds without a ping or pong, not that it waits 30 seconds between reconnects 