### PR TITLE
[TIZI/TICI] ui: override `set_parent_rect` to dynamically update item height

### DIFF
--- a/system/ui/sunnypilot/widgets/list_view.py
+++ b/system/ui/sunnypilot/widgets/list_view.py
@@ -212,6 +212,12 @@ class ListItemSP(ListItem):
       content_width = int(self._rect.width - style.ITEM_PADDING * 2)
       self._rect.height = self.get_item_height(self._font, content_width)
 
+  def set_parent_rect(self, parent_rect: rl.Rectangle) -> None:
+    super().set_parent_rect(parent_rect)
+    if self.description_visible:
+      content_width = int(self._rect.width - style.ITEM_PADDING * 2)
+      self._rect.height = self.get_item_height(self._font, content_width)
+
   def get_item_height(self, font: rl.Font, max_width: int) -> float:
     height = super().get_item_height(font, max_width)
 


### PR DESCRIPTION
Fixes dynamic descriptions causing duplicated item height.