### PR TITLE
Improve TSS2 longitudinal tuning defaults

### DIFF
--- a/opendbc_repo/opendbc/car/toyota/carcontroller.py
+++ b/opendbc_repo/opendbc/car/toyota/carcontroller.py
@@ -39,8 +39,8 @@ MAX_USER_TORQUE = 500
 
 def get_long_tune(CP, params):
   if CP.carFingerprint in TSS2_CAR:
-    kiBP = [2., 5.]
-    kiV = [0.5, 0.25]
+    kiBP = [0., 3., 5., 10., 25., 36.]
+    kiV = [0.46, 0.46, 0.31, 0.27, 0.245, 0.24]
   else:
     kiBP = [0., 5., 35.]
     kiV = [3.6, 2.4, 1.5]

--- a/opendbc_repo/opendbc/car/toyota/interface.py
+++ b/opendbc_repo/opendbc/car/toyota/interface.py
@@ -121,7 +121,7 @@ class CarInterface(CarInterfaceBase):
 
       ret.vEgoStopping = 0.25
       ret.vEgoStarting = 0.25
-      ret.stoppingDecelRate = 0.3  # reach stopping target smoothly
+      ret.stoppingDecelRate = 0.005  # reach stopping target smoothly
 
       # Hybrids have much quicker longitudinal actuator response
       if ret.flags & ToyotaFlags.HYBRID.value:


### PR DESCRIPTION
Description

The current TSS2 longitudinal tuning uses a simple 2-point integral gain curve and an aggressive stoppingDecelRate of 0.3, which causes jerky, abrupt stops — especially noticeable at traffic lights.

This PR improves the defaults for all TSS2 cars:

- Replace 2-point integral gain curve with 6-point speed-dependent curve
- Reduce stoppingDecelRate from 0.3 to 0.005 for smoother stops, eliminating the last-second lurch when coming to a stop


Verification

These were all tested on existing `tn` branches. Updating for C4 users. Tested on a 2021 RAV4 Prime (TSS2 hybrid) over several weeks of daily driving. Verified smooth braking and stopping behavior at traffic lights, stop signs, and in stop-and-go traffic. No regressions observed in acceleration or following distance behavior.



