### PR TITLE
Fix display of values when using use_float_scaling

### DIFF
--- a/system/ui/sunnypilot/widgets/option_control.py
+++ b/system/ui/sunnypilot/widgets/option_control.py
@@ -44,7 +44,8 @@ class OptionControlSP(ItemAction):
           self.current_value = int(key)
           break
     else:
-      self.current_value = int(self.params.get(self.param_key, return_default=True))
+      value = self.params.get(self.param_key, return_default=True)
+      self.current_value = int(float(value) * 100.0) if self.use_float_scaling else int(value)
 
     # Initialize font and button styles
     self._font = gui_app.font(FontWeight.MEDIUM)


### PR DESCRIPTION
The Lateral Acceleration and Friction are being displayed improperly in the Torque Params settings on the comma 3x due to use_float_scaling which divides by 100. This just multiplies the value by 100 again so it displays the correct decimal place in the UI.

This issue has also reported by gusdaz22 in the sunnypilot community forum - https://community.sunnypilot.ai/t/custom-torque-params-issues/3128

Default values before:

<img width="1852" height="978" alt="Screenshot from 2026-02-20 21-38-12" src="https://github.com/user-attachments/assets/bdd7b403-9d9e-4236-8955-7eb209dd3e04" />

Default values after:

<img width="1852" height="978" alt="Screenshot from 2026-02-20 21-58-54" src="https://github.com/user-attachments/assets/26b72f18-2ea9-4966-b82f-2f713012d25a" />

Two decimal places:

<img width="1852" height="978" alt="Screenshot from 2026-02-21 06-27-52" src="https://github.com/user-attachments/assets/de194e64-5954-4dec-ac9c-e09706c6ccc0" />

