### PR TITLE
[MICI] ui: need superclass `_render` in `HudRendererSP`

### DIFF
--- a/selfdrive/ui/sunnypilot/mici/onroad/hud_renderer.py
+++ b/selfdrive/ui/sunnypilot/mici/onroad/hud_renderer.py
@@ -20,7 +20,9 @@ class HudRendererSP(HudRenderer):
     self.blind_spot_indicators.update()
 
   def _render(self, rect: rl.Rectangle) -> None:
+    super()._render(rect)
     self.blind_spot_indicators.render(rect)
 
   def _has_blind_spot_detected(self) -> bool:
+
     return self.blind_spot_indicators.detected


### PR DESCRIPTION
Introduced in https://github.com/sunnypilot/sunnypilot/pull/1727, removing the superclass `_render` caused some UI elements to not draw.

| Before | After |
| --- | --- |
| <img width="564" height="306" alt="image" src="https://github.com/user-attachments/assets/ce05cf4b-c149-42d9-a432-788ad5a83088" /> | <img width="564" height="306" alt="image" src="https://github.com/user-attachments/assets/b10b4df3-0e03-4f5d-8cfc-b9d253e3bdf8" /> |