### PR TITLE
chrysler: add 2024 RAM 2500 firmware versions to staging

### DIFF
--- a/opendbc_repo/opendbc/sunnypilot/car/chrysler/fingerprints_ext.py
+++ b/opendbc_repo/opendbc/sunnypilot/car/chrysler/fingerprints_ext.py
@@ -24,4 +24,22 @@ FW_VERSIONS_EXT = {
       b'68502996AC',
     ],
   },
+
+  CAR.RAM_HD_5TH_GEN: {
+    # Added: 2024 RAM 2500 (VIN: 3C6UR4HJ9RG206624)
+    # fuzzyFingerprint was True due to these missing entries.
+    # combinationMeter: 68628472AC is a new variant (existing DB has 68628474AB)
+    # engine: 68617375AB  is a new 2024 firmware (note trailing space)
+    # transmission: 68617338AA — RAM HD now reports a transmission ECU on 0x7e1
+    #   (this ECU was not present in earlier model years / not previously in the DB)
+    (Ecu.combinationMeter, 0x742, None): [
+      b'68628472AC',
+    ],
+    (Ecu.engine, 0x7e0, None): [
+      b'68617375AB ',
+    ],
+    (Ecu.transmission, 0x7e1, None): [
+      b'68617338AA',
+    ],
+  },
 }


### PR DESCRIPTION
<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

