### PR TITLE
feat(subaru): add LKAS button support for pre-global MADS

### DIFF
--- a/opendbc_repo/opendbc/dbc/generator/subaru/subaru_forester_2017.dbc
+++ b/opendbc_repo/opendbc/dbc/generator/subaru/subaru_forester_2017.dbc
@@ -7,6 +7,7 @@ BO_ 355 ES_DashStatus: 8 XXX
  SG_ Cruise_Set_Speed : 24|8@1+ (1,0) [0|255] "" XXX
  SG_ COUNTER : 40|3@1+ (1,0) [0|7] "" XXX
  SG_ Brake : 43|1@1+ (1,0) [0|1] "" XXX
+ SG_ LKAS_State : 38|1@1+ (1,0) [0|1] "" XXX
  SG_ Car_Follow : 54|1@1+ (1,0) [0|1] "" XXX
  SG_ Far_Distance : 56|4@1+ (5,0) [0|75] "m" XXX
 

--- a/opendbc_repo/opendbc/sunnypilot/car/subaru/mads.py
+++ b/opendbc_repo/opendbc/sunnypilot/car/subaru/mads.py
@@ -18,6 +18,8 @@ ButtonType = structs.CarState.ButtonEvent.Type
 class MadsCarState(MadsCarStateBase):
   def __init__(self, CP: structs.CarParams, CP_SP: structs.CarParamsSP):
     super().__init__(CP, CP_SP)
+    self._prev_lkas_raw = None
+    self._initial_applied = False
 
   @staticmethod
   def create_lkas_button_events(cur_btn: int, prev_btn: int,
@@ -42,7 +44,33 @@ class MadsCarState(MadsCarStateBase):
     cp_cam = can_parsers[Bus.cam]
 
     self.prev_lkas_button = self.lkas_button
-    if not self.CP.flags & SubaruFlags.PREGLOBAL:
+    if self.CP.flags & SubaruFlags.PREGLOBAL:
+      # Pre-global Subarus don't have ES_LKAS_State. The LKAS button
+      # state is in ES_DashStatus byte4 bit6 as a latching toggle (0/1).
+      lkas_state = int(cp_cam.vl["ES_DashStatus"]["LKAS_State"])
+      if self._prev_lkas_raw is None:
+        # First read: record state, wait for cruise to be available
+        self._prev_lkas_raw = lkas_state
+        self.lkas_button = 0
+      elif not self._initial_applied:
+        # Track LKAS changes during boot (user may press button early)
+        self._prev_lkas_raw = lkas_state
+        if ret.cruiseState.available:
+          # Cruise is ready. Apply current LKAS state to auto-enable
+          # MADS if LKAS was left on, matching the dash indicator.
+          self.lkas_button = lkas_state
+          self._initial_applied = True
+        else:
+          self.lkas_button = 0
+      else:
+        # Normal operation: convert latching toggle to pulse so
+        # create_lkas_button_events sees 0->1->0 per press.
+        if lkas_state != self._prev_lkas_raw:
+          self.lkas_button = 1
+        else:
+          self.lkas_button = 0
+        self._prev_lkas_raw = lkas_state
+    else:
       self.lkas_button = cp_cam.vl["ES_LKAS_State"]["LKAS_Dash_State"]
 
     ret.buttonEvents = self.create_lkas_button_events(self.lkas_button, self.prev_lkas_button, {1: ButtonType.lkas})


### PR DESCRIPTION
**Description**

Pre-global Subarus don't have ES_LKAS_State, so the LKAS button was never wired into MADS. This meant MADS lateral control could not be toggled via the physical LKAS button on the steering wheel.

The LKAS button state is available in ES_DashStatus byte4 bit6 as a latching toggle (0=off, 1=on). Unlike the momentary signal on global Subarus, this persists across ignition cycles.

This PR adds an LKAS_State signal to the pre-global Forester DBC and read it in the MADS carstate. The latching toggle is converted to a pulse so create_lkas_button_events generates one event per physical press.

On boot, the initial LKAS state is applied once cruiseState becomes available, auto-enabling MADS if the driver left LKAS on when the car was last turned off.

Tested on 2018 Subaru Forester (pre-global) with sunnypilot 2026.001.000.

**Verification**

- [x] Boot with LKAS ON → MADS auto-enables
- [x] Boot with LKAS OFF → MADS stays disabled
- [x] Press LKAS while MADS active → MADS disables
- [x] Press LKAS while MADS inactive → MADS enables
- [x] LKAS dash indicator stays in sync with MADS state

**Route**

Route: COMING SOON (have to do a real drive rather than testing while parked)