### PR TITLE
controls: fix angle handling in lateral control initialization. (controlsd error on angle cars)

### DIFF
--- a/sunnypilot/selfdrive/controls/controlsd_ext.py
+++ b/sunnypilot/selfdrive/controls/controlsd_ext.py
@@ -35,6 +35,10 @@ class ControlsExt(ModelStateBase):
     self.pm_services_ext = ['carControlSP']
 
   def initialize_lateral_control(self, lac, CI, dt):
+    # Only the torque controller has a v0 variant; angle/pid cars must keep their stock LaC
+    if self.CP.lateralTuning.which() != 'torque':
+      return lac
+
     enforce_torque_control = self.params.get_bool("EnforceTorqueControl")
     torque_versions = self.params.get("TorqueControlTune")
     if not enforce_torque_control:

--- a/sunnypilot/selfdrive/controls/controlsd_ext.py
+++ b/sunnypilot/selfdrive/controls/controlsd_ext.py
@@ -36,7 +36,7 @@ class ControlsExt(ModelStateBase):
 
   def initialize_lateral_control(self, lac, CI, dt):
     # Only the torque controller has a v0 variant; angle/pid cars must keep their stock LaC
-    if self.CP.lateralTuning.which() != 'torque':
+    if self.CP.steerControlType == structs.CarParams.SteerControlType.angle or self.CP.lateralTuning.which() != 'torque':
       return lac
 
     enforce_torque_control = self.params.get_bool("EnforceTorqueControl")


### PR DESCRIPTION
**Description**

A recent update gives an error on angle steering cars.

**Verification**

I tested it in my Peugeot e-208 with angle steering. Bug is fixed.