### PR TITLE
ui: fix cellular toggles

### DIFF
--- a/system/ui/sunnypilot/widgets/list_view.py
+++ b/system/ui/sunnypilot/widgets/list_view.py
@@ -363,7 +363,7 @@ def simple_button_item_sp(button_text: str | Callable[[], str], callback: Callab
 def toggle_item_sp(title: str | Callable[[], str], description: str | Callable[[], str] | None = None, initial_state: bool = False,
                    callback: Callable | None = None, icon: str = "", enabled: bool | Callable[[], bool] = True, param: str | None = None) -> ListItemSP:
   action = ToggleActionSP(initial_state=initial_state, enabled=enabled, callback=callback, param=param)
-  return ListItemSP(title=title, description=description, action_item=action, icon=icon, callback=callback)
+  return ListItemSP(title=title, description=description, action_item=action, icon=icon)
 
 
 def multiple_button_item_sp(title: str | Callable[[], str], description: str | Callable[[], str], buttons: list[str | Callable[[], str]],

--- a/system/ui/sunnypilot/widgets/toggle.py
+++ b/system/ui/sunnypilot/widgets/toggle.py
@@ -57,3 +57,7 @@ class ToggleSP(Toggle):
     knob_y = self._rect.y + style.TOGGLE_BG_HEIGHT / 2
 
     rl.draw_circle(int(knob_x), int(knob_y), KNOB_RADIUS, knob_color)
+
+    clicked = self._clicked
+    self._clicked = False
+    return clicked


### PR DESCRIPTION
**Description**

Fixed the toggles for Cellular Roaming and Cellular Metering

The underlying problem behind this is that sunnypilot overrides the original openpilot `Toggle` using the `ToggleSP` class but in the `_render` function it does not have some click handling code present in the original:

https://github.com/sunnypilot/sunnypilot/blob/fdd43f49e0893b41f36077b998a547b3c16ef66f/system/ui/widgets/toggle.py#L75-L78

In the surrounding `ListViewSP` class, it relies on the `render` function returning true to execute the callbacks, which it now will with this fix:

https://github.com/sunnypilot/sunnypilot/blob/fdd43f49e0893b41f36077b998a547b3c16ef66f/system/ui/sunnypilot/widgets/list_view.py#L324-L327

The second fix, in `toggle_item_sp` prevents a double call on the callback. In the very line above, we can see the callback being passed into `ToggleActionSP` but then it is also passed into `ListItemSP`. Having both will cause it to fire twice when the toggle is changed. This is similar to the upstream openpilot `toggle_item`:

https://github.com/sunnypilot/sunnypilot/blob/fdd43f49e0893b41f36077b998a547b3c16ef66f/system/ui/widgets/list_view.py#L440-L443

Full disclosure: Claude Code was used to assist debugging and fixing this issue, but all code is reviewed and tested by me

**Verification**

Tested on device by checking params using SSH commands. Additionally rebooted to ensure persistence.

```
comma@comma-8341c93c:/data/openpilot$ cd /data/openpilot && /usr/local/venv/bin/python3 -c "
from openpilot.common.params import Params
p = Params()
print(p.get_bool('GsmRoaming'))
print(p.get_bool('GsmMetered'))
"

True
False
```

```
comma@comma-8341c93c:/data/openpilot$ nmcli -t con show lte | grep -iE "gsm\.home-only|connection\.metered|GENERAL\.UNSAVED"
connection.metered:no
gsm.home-only:no
```

Before this patch, changing these toggles in the UI had no effect and the values did not change here and the network manager also did not enable roaming or configure metering.

I also verified that tethering works correctly, I am not sure if it was broken before but it's toggle works similarly to the others so I wanted to check that also.