### PR TITLE
sunnylink: Remove unused API endpoint

### DIFF
--- a/sunnypilot/sunnylink/api.py
+++ b/sunnypilot/sunnylink/api.py
@@ -30,10 +30,6 @@ class SunnylinkApi(BaseApi):
 
     return super().api_get(endpoint, method, timeout, access_token, session, json, **kwargs)
 
-  def resume_queued(self, timeout=10, **kwargs):
-    sunnylinkId, commaId = self._resolve_dongle_ids()
-    return self.api_get(f"ws/{sunnylinkId}/resume_queued", "POST", timeout, access_token=self.get_token(), **kwargs)
-
   def get_token(self, payload_extra=None, expiry_hours=1):
     # Add your additional data here
     additional_data = {}

--- a/sunnypilot/sunnylink/athena/sunnylinkd.py
+++ b/sunnypilot/sunnylink/athena/sunnylinkd.py
@@ -64,7 +64,6 @@ def handle_long_poll(ws: WebSocket, exit_event: threading.Event | None) -> None:
               threading.Thread(target=ws_recv, args=(ws, end_event), name='ws_recv'),
               threading.Thread(target=ws_send, args=(ws, end_event), name='ws_send'),
               threading.Thread(target=ws_ping, args=(ws, end_event), name='ws_ping'),
-              threading.Thread(target=ws_queue, args=(end_event,), name='ws_queue'),
               threading.Thread(target=upload_handler, args=(end_event,), name='upload_handler'),
               threading.Thread(target=sunny_log_handler, args=(end_event, comma_prime_cellular_end_event), name='log_handler'),
               threading.Thread(target=stat_handler, args=(end_event, Paths.stats_sp_root(), True), name='stat_handler'),
@@ -145,37 +144,6 @@ def ws_ping(ws: WebSocket, end_event: threading.Event) -> None:
       cloudlog.exception("sunnylinkd.ws_ping.exception")
       end_event.set()
   cloudlog.debug("sunnylinkd.ws_ping.end_event is set, exiting ws_ping thread")
-
-
-def ws_queue(end_event: threading.Event) -> None:
-  sunnylink_dongle_id = params.get("SunnylinkDongleId")
-  sunnylink_api = SunnylinkApi(sunnylink_dongle_id)
-  resume_requested = False
-  tries = 0
-
-  while not end_event.is_set() and not resume_requested:
-    try:
-      if not resume_requested:
-        cloudlog.debug("sunnylinkd.ws_queue.resume_queued")
-        sunnylink_api.resume_queued(timeout=29)
-        resume_requested = True
-        tries = 0
-    except Exception as e:
-      if isinstance(e, (ConnectionError, TimeoutError)):
-        cloudlog.warning(f"sunnylinkd.ws_queue.resume_queued.{type(e).__name__}")
-      else:
-        cloudlog.exception("sunnylinkd.ws_queue.resume_queued.exception")
-
-      resume_requested = False
-      tries += 1
-      time.sleep(backoff(tries))
-
-  if end_event.is_set():
-    cloudlog.debug("end_event is set, exiting ws_queue thread")
-  elif resume_requested:
-    cloudlog.debug(f"Resume requested to server after {tries} tries")
-  else:
-    cloudlog.error(f"Reached end of ws_queue while end_event is not set and resume_requested is {resume_requested}")
 
 
 def sunny_log_handler(end_event: threading.Event, comma_prime_cellular_end_event: threading.Event) -> None:


### PR DESCRIPTION
This pull request removes the `ws_queue` functionality from the Sunnylink Athena service, simplifying the threading model and related API code. The main impact is the elimination of the resume queue logic, which previously attempted to resume queued tasks with retries.

**Removal of resume queue logic:**

* The `ws_queue` thread and its associated function have been removed from the Athena service, so the system no longer attempts to resume queued operations in a background thread. (`sunnypilot/sunnylink/athena/sunnylinkd.py`) [[1]](diffhunk://#diff-40ad7bc50889c2d969b56606b55c2eccf4de1253185eba99a149ba10c70d01beL67) [[2]](diffhunk://#diff-40ad7bc50889c2d969b56606b55c2eccf4de1253185eba99a149ba10c70d01beL150-L180)
* The `resume_queued` method has been deleted from the `SunnylinkApi` class, as it is no longer needed. (`sunnypilot/sunnylink/api.py`)
