### PR TITLE
Rivian: remove stalk-down hold requirement for ACC set speed update

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,8 @@
   url = https://github.com/sunnyhaibin/panda.git
 [submodule "opendbc"]
   path = opendbc_repo
-  url = https://github.com/sunnypilot/opendbc.git
+  url = https://github.com/Geomglot/opendbc.git
+  branch = rivian-down1-fix
 [submodule "msgq"]
   path = msgq_repo
   url = https://github.com/commaai/msgq.git


### PR DESCRIPTION
  **Description**

  This fixes Rivian ACC set-speed handling so a stalk-down action updates the set speed immediately instead of requiring an approximately 0.5 second hold
  first.

  The previous behavior added delay that did not match stock Rivian behavior and could briefly leave the comma display and the Rivian cluster showing
  different set speeds.

  This PR updates the `opendbc` submodule wiring to the `Geomglot/opendbc` `rivian-down1-fix` branch and points the submodule to the published fix commit.

  Relevant `opendbc` changes:
  - remove the `stalk_down_counter` hold requirement in Rivian `carstate_ext.py`
  - keep Rivian stalk-down set-speed behavior aligned with observed vehicle behavior
  - include a follow-up comment cleanup in the same submodule branch

  **Verification**

  Verified by:
  - confirming the PR diff is limited to `.gitmodules` and the `opendbc_repo` submodule pointer
  - validating the `opendbc` submodule points to the intended published `rivian-down1-fix` commit
  - on-road testing in a Rivian confirming stalk-down no longer requires a hold before set speed updates