### PR TITLE
Subaru AVH — user toggle + wiring

### DIFF
--- a/common/params_keys.h
+++ b/common/params_keys.h
@@ -220,6 +220,7 @@ inline static std::unordered_map<std::string, ParamKeyAttributes> keys = {
     {"HyundaiLongitudinalTuning", {PERSISTENT | BACKUP, INT, "0"}},
     {"SubaruStopAndGo", {PERSISTENT | BACKUP, BOOL, "0"}},
     {"SubaruStopAndGoManualParkingBrake", {PERSISTENT | BACKUP, BOOL, "0"}},
+    {"SubaruAutoVehicleHold", {PERSISTENT | BACKUP, BOOL, "0"}},
     {"TeslaCoopSteering", {PERSISTENT | BACKUP, BOOL, "0"}},
     {"ToyotaEnforceStockLongitudinal", {PERSISTENT | BACKUP, BOOL, "0"}},
     {"ToyotaStopAndGoHack", {PERSISTENT | BACKUP, BOOL, "0"}},

--- a/selfdrive/ui/sunnypilot/layouts/settings/vehicle/brands/subaru.py
+++ b/selfdrive/ui/sunnypilot/layouts/settings/vehicle/brands/subaru.py
@@ -15,13 +15,17 @@ class SubaruSettings(BrandSettings):
   def __init__(self):
     super().__init__()
     self.has_stop_and_go = False
+    self.has_brake_hold = False
 
     self.stop_and_go_toggle = toggle_item_sp(tr("Stop and Go (Beta)"), "", param="SubaruStopAndGo", callback=self._on_toggle_changed)
 
     self.stop_and_go_manual_parking_brake_toggle = toggle_item_sp(tr("Stop and Go for Manual Parking Brake (Beta)"), "",
                                                                   param="SubaruStopAndGoManualParkingBrake", callback=self._on_toggle_changed)
 
-    self.items = [self.stop_and_go_toggle, self.stop_and_go_manual_parking_brake_toggle]
+    self.avh_toggle = toggle_item_sp(tr("Automatic Vehicle Hold (AVH) (Beta)"), "",
+                                     param="SubaruAutoVehicleHold", callback=self._on_toggle_changed)
+
+    self.items = [self.stop_and_go_toggle, self.stop_and_go_manual_parking_brake_toggle, self.avh_toggle]
 
   def _on_toggle_changed(self, _):
     self.update_settings()
@@ -33,14 +37,24 @@ class SubaruSettings(BrandSettings):
       return tr("Enable \"Always Offroad\" in Device panel, or turn vehicle off to toggle.")
     return ""
 
+  def avh_disabled_msg(self):
+    if not self.has_brake_hold:
+      return tr("This feature is currently not available on this platform.")
+    elif not ui_state.is_offroad():
+      return tr("Enable \"Always Offroad\" in Device panel, or turn vehicle off to toggle.")
+    return ""
+
   def update_settings(self):
+    brake_hold_mask = SubaruFlags.GLOBAL_GEN2 | SubaruFlags.PREGLOBAL | SubaruFlags.LKAS_ANGLE | SubaruFlags.HYBRID
     bundle = ui_state.params.get("CarPlatformBundle")
     if bundle:
       platform = bundle.get("platform")
       config = CAR[platform].config
       self.has_stop_and_go = not (config.flags & (SubaruFlags.GLOBAL_GEN2 | SubaruFlags.HYBRID))
+      self.has_brake_hold = not (config.flags & brake_hold_mask)
     elif ui_state.CP is not None:
       self.has_stop_and_go = not (ui_state.CP.flags & (SubaruFlags.GLOBAL_GEN2 | SubaruFlags.HYBRID))
+      self.has_brake_hold = not (ui_state.CP.flags & brake_hold_mask)
 
     disabled_msg = self.stop_and_go_disabled_msg()
     descriptions = [
@@ -52,3 +66,9 @@ class SubaruSettings(BrandSettings):
     for toggle, desc in zip([self.stop_and_go_toggle, self.stop_and_go_manual_parking_brake_toggle], descriptions, strict=True):
       toggle.action_item.set_enabled(self.has_stop_and_go and ui_state.is_offroad())
       toggle.set_description(f"<b>{disabled_msg}</b><br><br>{desc}" if disabled_msg else desc)
+
+    avh_disabled_msg = self.avh_disabled_msg()
+    avh_desc = tr("Holds the brakes at a complete stop while MADS is engaged, and releases when you press the accelerator. " +
+                  "Subaru Global (non-Gen2, non-hybrid) only.")
+    self.avh_toggle.action_item.set_enabled(self.has_brake_hold and ui_state.is_offroad())
+    self.avh_toggle.set_description(f"<b>{avh_disabled_msg}</b><br><br>{avh_desc}" if avh_disabled_msg else avh_desc)

--- a/sunnypilot/selfdrive/car/interfaces.py
+++ b/sunnypilot/selfdrive/car/interfaces.py
@@ -121,6 +121,7 @@ def initialize_params(params) -> list[dict[str, Any]]:
   keys.extend([
     "SubaruStopAndGo",
     "SubaruStopAndGoManualParkingBrake",
+    "SubaruAutoVehicleHold",
   ])
 
   # tesla

--- a/sunnypilot/sunnylink/capabilities.py
+++ b/sunnypilot/sunnylink/capabilities.py
@@ -40,6 +40,7 @@ CAPABILITY_FIELDS = (
   "stock_longitudinal",
   "device_type",
   "subaru_has_sng",
+  "subaru_has_brake_hold",
   "hyundai_alpha_long_available",
 )
 
@@ -62,6 +63,7 @@ CAPABILITY_LABELS: dict[str, str] = {
   "stock_longitudinal": "stock longitudinal",
   "device_type": "Device type",
   "subaru_has_sng": "Subaru Stop-and-Go available",
+  "subaru_has_brake_hold": "Subaru Automatic Vehicle Hold available",
   "hyundai_alpha_long_available": "Hyundai Alpha Longitudinal available",
 }
 
@@ -150,6 +152,9 @@ def generate_capabilities(params: Params | None = None) -> dict:
       flags = SUBARU_CAR[bundle_platform].config.flags
       caps["subaru_has_sng"] = not bool(flags & (SubaruFlags.GLOBAL_GEN2 | SubaruFlags.HYBRID))
       caps["has_stop_and_go"] = caps["subaru_has_sng"]
+      # AVH (brake hold) eligibility mirrors CP.alphaLongitudinalAvailable.
+      caps["subaru_has_brake_hold"] = not bool(flags & (SubaruFlags.GLOBAL_GEN2 | SubaruFlags.PREGLOBAL |
+                                                        SubaruFlags.LKAS_ANGLE | SubaruFlags.HYBRID))
     except KeyError:
       cloudlog.exception(f"capabilities: unknown subaru platform {bundle_platform!r}")
 

--- a/sunnypilot/sunnylink/params_metadata.json
+++ b/sunnypilot/sunnylink/params_metadata.json
@@ -1239,6 +1239,10 @@
     "title": "[TIZI/TICI only] Standstill Timer",
     "description": "Show a timer on the HUD when the car is at a standstill."
   },
+  "SubaruAutoVehicleHold": {
+    "title": "Subaru Automatic Vehicle Hold (AVH)",
+    "description": "Holds the brakes at a complete stop while MADS is engaged, and releases when you press the accelerator. Subaru Global (non-Gen2, non-hybrid) only."
+  },
   "SubaruStopAndGo": {
     "title": "Subaru Stop and Go",
     "description": ""

--- a/sunnypilot/sunnylink/settings_ui.json
+++ b/sunnypilot/sunnylink/settings_ui.json
@@ -2145,6 +2145,22 @@
               "equals": true
             }
           ]
+        },
+        {
+          "key": "SubaruAutoVehicleHold",
+          "widget": "toggle",
+          "title": "Automatic Vehicle Hold (AVH) (Beta)",
+          "description": "Holds the brakes at a complete stop while MADS is engaged, and releases when you press the accelerator. Subaru Global (non-Gen2, non-hybrid) only.",
+          "enablement": [
+            {
+              "type": "offroad_only"
+            },
+            {
+              "type": "capability",
+              "field": "subaru_has_brake_hold",
+              "equals": true
+            }
+          ]
         }
       ]
     },

--- a/sunnypilot/sunnylink/settings_ui_src/pages/vehicle.yaml
+++ b/sunnypilot/sunnylink/settings_ui_src/pages/vehicle.yaml
@@ -47,6 +47,15 @@ sections:
     - type: capability
       field: has_stop_and_go
       equals: true
+  - key: SubaruAutoVehicleHold
+    widget: toggle
+    title: Automatic Vehicle Hold (AVH) (Beta)
+    description: Holds the brakes at a complete stop while MADS is engaged, and releases when you press the accelerator. Subaru Global (non-Gen2, non-hybrid) only.
+    enablement:
+    - $ref: '#/macros/offroad'
+    - type: capability
+      field: subaru_has_brake_hold
+      equals: true
 - id: tesla
   title: Tesla Settings
   description: ''

--- a/sunnypilot/sunnylink/tests/test_capabilities.py
+++ b/sunnypilot/sunnylink/tests/test_capabilities.py
@@ -63,6 +63,18 @@ class TestProtocolVersion:
     )
 
 
+class _FakeParams:
+  """Minimal Params stand-in: only CarPlatformBundle is populated."""
+  def __init__(self, bundle):
+    self._bundle = bundle
+
+  def get(self, key):
+    return self._bundle if key == "CarPlatformBundle" else None
+
+  def get_bool(self, key):
+    return False
+
+
 class TestOpaquePerBrandFlags:
   def test_subaru_has_sng_field_present(self):
     assert "subaru_has_sng" in CAPABILITY_FIELDS
@@ -75,6 +87,20 @@ class TestOpaquePerBrandFlags:
 
   def test_hyundai_alpha_long_available_default_false(self, caps):
     assert caps["hyundai_alpha_long_available"] is False
+
+  def test_subaru_has_brake_hold_field_present(self):
+    assert "subaru_has_brake_hold" in CAPABILITY_FIELDS
+
+  def test_subaru_has_brake_hold_default_false(self, caps):
+    assert caps["subaru_has_brake_hold"] is False
+
+  def test_subaru_has_brake_hold_true_for_eligible_platform(self):
+    caps = generate_capabilities(_FakeParams({"brand": "subaru", "platform": "SUBARU_IMPREZA_2020"}))
+    assert caps["subaru_has_brake_hold"] is True
+
+  def test_subaru_has_brake_hold_false_for_gen2_platform(self):
+    caps = generate_capabilities(_FakeParams({"brand": "subaru", "platform": "SUBARU_OUTBACK"}))
+    assert caps["subaru_has_brake_hold"] is False
 
 
 class TestCapabilitiesShape:

--- a/sunnypilot/sunnylink/tests/test_settings_schema.py
+++ b/sunnypilot/sunnylink/tests/test_settings_schema.py
@@ -292,6 +292,14 @@ class TestKnownVehicleSettings:
     assert "SubaruStopAndGo" in keys
     assert "SubaruStopAndGoManualParkingBrake" in keys
 
+  def test_subaru_has_auto_vehicle_hold(self, schema):
+    items = _brand_items(schema["vehicle_settings"].get("subaru"))
+    avh = next((i for i in items if i["key"] == "SubaruAutoVehicleHold"), None)
+    assert avh is not None, "SubaruAutoVehicleHold toggle missing from subaru settings"
+    assert avh["widget"] == "toggle"
+    cap_refs = {r.get("field") for r in avh.get("enablement", []) if r.get("type") == "capability"}
+    assert "subaru_has_brake_hold" in cap_refs
+
 
 class TestItemCompleteness:
   def _collect_all_items(self, schema):


### PR DESCRIPTION
### Subaru AVH — user toggle + wiring

Parent-repo companion to the opendbc Subaru AVH PR (sunnypilot/opendbc#477). Adds the `SubaruAutoVehicleHold` param, the vehicle-settings UI toggle, sunnylink capability/metadata/schema entries (with tests), car-interface wiring, and the opendbc submodule bump.

**Draft:** the submodule pointer currently references the opendbc PR's `pr/subaru-avh` head. It will be re-pointed to `sunnypilot/opendbc` master and this PR marked ready once the opendbc PR merges.