### PR TITLE
longitudinal: add Increased Stop Distance

### DIFF
--- a/common/params_keys.h
+++ b/common/params_keys.h
@@ -226,6 +226,7 @@ inline static std::unordered_map<std::string, ParamKeyAttributes> keys = {
     {"ToyotaStopAndGoHack", {PERSISTENT | BACKUP, BOOL, "0"}},
 
     {"DynamicExperimentalControl", {PERSISTENT | BACKUP, BOOL, "0"}},
+    {"IncreasedStoppedDistance", {PERSISTENT | BACKUP, INT, "0"}},
     {"BlindSpot", {PERSISTENT | BACKUP, BOOL, "0"}},
 
     // sunnypilot model params

--- a/selfdrive/controls/lib/longitudinal_planner.py
+++ b/selfdrive/controls/lib/longitudinal_planner.py
@@ -159,6 +159,7 @@ class LongitudinalPlanner(LongitudinalPlannerSP):
                                                                         action_t=action_t, vEgoStopping=self.CP.vEgoStopping)
     output_a_target_e2e = sm['modelV2'].action.desiredAcceleration
     output_should_stop_e2e = sm['modelV2'].action.shouldStop
+    output_a_target_e2e, output_should_stop_e2e = self.apply_e2e_stop_distance(sm, v_ego, output_a_target_e2e, output_should_stop_e2e)
 
     if self.is_e2e(sm):
       output_a_target = min(output_a_target_e2e, output_a_target_mpc)

--- a/selfdrive/controls/radard.py
+++ b/selfdrive/controls/radard.py
@@ -15,6 +15,7 @@ from openpilot.common.simple_kalman import KF1D
 from opendbc.car import structs
 from opendbc.car.hyundai.values import HyundaiFlags
 from opendbc.sunnypilot.car.hyundai.values import HyundaiFlagsSP
+from openpilot.sunnypilot.selfdrive.controls.lib.increased_stop_distance import IncreasedStopDistance
 
 
 # Default lead acceleration decay set to 50% at 1s
@@ -217,9 +218,12 @@ class RadarD:
 
     self.ready = False
 
+    self.increased_stop_distance = IncreasedStopDistance()
+
   def update(self, sm: messaging.SubMaster, rr: car.RadarData):
     self.ready = sm.seen['modelV2']
     self.current_time = 1e-9*max(sm.logMonoTime.values())
+    self.increased_stop_distance.update()
 
     if sm.recv_frame['carState'] != self.last_v_ego_frame:
       self.v_ego = sm['carState'].vEgo
@@ -266,10 +270,12 @@ class RadarD:
         else:
           self.lead_prob_filters[i].update(lead_prob)
 
-      self.radar_state.leadOne = get_lead(self.v_ego, self.ready, self.tracks, leads_v3[0], model_v_ego, self.lead_prob_filters[0].x,
-                                          self.CP, self.CP_SP, low_speed_override=True)
-      self.radar_state.leadTwo = get_lead(self.v_ego, self.ready, self.tracks, leads_v3[1], model_v_ego, self.lead_prob_filters[1].x,
-                                          self.CP, self.CP_SP, low_speed_override=False)
+      lead_one = get_lead(self.v_ego, self.ready, self.tracks, leads_v3[0], model_v_ego, self.lead_prob_filters[0].x,
+                          self.CP, self.CP_SP, low_speed_override=True)
+      lead_two = get_lead(self.v_ego, self.ready, self.tracks, leads_v3[1], model_v_ego, self.lead_prob_filters[1].x,
+                          self.CP, self.CP_SP, low_speed_override=False)
+      self.radar_state.leadOne = self.increased_stop_distance.apply_lead(lead_one)
+      self.radar_state.leadTwo = self.increased_stop_distance.apply_lead(lead_two)
 
   def publish(self, pm: messaging.PubMaster):
     assert self.radar_state is not None

--- a/selfdrive/ui/sunnypilot/layouts/settings/cruise.py
+++ b/selfdrive/ui/sunnypilot/layouts/settings/cruise.py
@@ -87,9 +87,18 @@ class CruiseLayout(Widget):
       description=tr("Enable toggle to allow the model to determine when to use sunnypilot ACC or sunnypilot End to End Longitudinal."),
       param="DynamicExperimentalControl")
 
+    self.increased_stopped_distance_item = option_item_sp(
+      title=tr("Increased Stopped Distance"),
+      param="IncreasedStoppedDistance",
+      min_value=0, max_value=5, value_change_step=1,
+      description=tr("Increase the distance sunnypilot stops behind a stopped lead vehicle or at a red light, in meters."),
+      label_callback=lambda value: f"{value} m",
+      inline=True)
+
     items = [
       self.icbm_toggle,
       self.dec_toggle,
+      self.increased_stopped_distance_item,
       self.scc_v_toggle,
       self.scc_m_toggle,
       self.custom_acc_toggle,
@@ -145,6 +154,7 @@ class CruiseLayout(Widget):
       if has_long or has_icbm:
         self.custom_acc_toggle.action_item.set_enabled(((has_long and not ui_state.CP.pcmCruise) or has_icbm) and ui_state.is_offroad())
         self.dec_toggle.action_item.set_enabled(has_long)
+        self.increased_stopped_distance_item.action_item.set_enabled(has_long)
         self.scc_v_toggle.action_item.set_enabled(True)
         self.scc_m_toggle.action_item.set_enabled(True)
       else:
@@ -152,8 +162,10 @@ class CruiseLayout(Widget):
         ui_state.params.remove("DynamicExperimentalControl")
         ui_state.params.remove("SmartCruiseControlVision")
         ui_state.params.remove("SmartCruiseControlMap")
+        ui_state.params.remove("IncreasedStoppedDistance")
         self.custom_acc_toggle.action_item.set_enabled(False)
         self.dec_toggle.action_item.set_enabled(False)
+        self.increased_stopped_distance_item.action_item.set_enabled(False)
         self.scc_v_toggle.action_item.set_enabled(False)
         self.scc_m_toggle.action_item.set_enabled(False)
 

--- a/sunnypilot/selfdrive/car/interfaces.py
+++ b/sunnypilot/selfdrive/car/interfaces.py
@@ -88,6 +88,7 @@ def _cleanup_unsupported_params(CP: structs.CarParams, CP_SP: structs.CarParamsS
     params.remove("CustomAccIncrementsEnabled")
     params.remove("SmartCruiseControlVision")
     params.remove("SmartCruiseControlMap")
+    params.remove("IncreasedStoppedDistance")
 
   set_speed_limit_assist_availability(CP, CP_SP, params)
 

--- a/sunnypilot/selfdrive/controls/lib/increased_stop_distance.py
+++ b/sunnypilot/selfdrive/controls/lib/increased_stop_distance.py
@@ -1,0 +1,92 @@
+"""
+Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+
+Increased Stop Distance: stop further behind a stopped lead vehicle, and
+further from stops the model plans to hold (red lights).
+
+Two mechanisms share the IncreasedStoppedDistance param (meters):
+
+- Lead stops (radard): the reported lead distance is reduced by the offset,
+  faded back out as the lead gets up to speed so normal following distance
+  is unaffected. Works in both chill and end-to-end mode.
+
+- Model-held stops (planner, end-to-end mode): when the model's trajectory
+  ends at ~zero velocity (it plans to remain stopped, e.g. a red light),
+  brake toward a point short of its predicted stop point, and hold there
+  instead of creeping forward. Only ever adds braking, never reduces it.
+  Stops the model plans to proceed through shortly (stop signs) are left
+  untouched: forcing an early stop makes the model treat the stop as
+  completed and roll through the sign itself (confirmed in road testing).
+"""
+import numpy as np
+
+from opendbc.car.interfaces import ACCEL_MIN
+from openpilot.common.params import Params
+from openpilot.common.realtime import DT_MDL
+from openpilot.selfdrive.modeld.constants import ModelConstants
+from openpilot.sunnypilot import PARAMS_UPDATE_PERIOD
+
+# Fade the offset back out as the lead gets up to speed
+STOPPED_DISTANCE_FADE_BP = [0., 3.]  # m/s, lead speed
+MIN_ADJUSTED_D_REL = 1.0  # m
+
+E2E_STOP_PLAN_VEL_THRESHOLD = 1.0  # m/s, model plan ending below this implies a held stop
+E2E_STOP_MIN_BRAKING = -0.1  # m/s^2, only deepen braking the model has already started
+E2E_STOP_MIN_DIST = 2.0  # m, never target a stop point closer than this
+E2E_STOP_HOLD_MAX_V = 0.5  # m/s, below this the car is considered stopped
+E2E_STOP_HOLD_BUFFER = 2.0  # m, hold until the model's stop point moves beyond offset + buffer
+
+
+class IncreasedStopDistance:
+  def __init__(self):
+    self.params = Params()
+    self.frame = 0
+    self.distance = 0.
+    self.read_params()
+
+  def read_params(self) -> None:
+    self.distance = float(self.params.get("IncreasedStoppedDistance", return_default=True))
+
+  def update(self) -> None:
+    if self.frame % int(PARAMS_UPDATE_PERIOD / DT_MDL) == 0:
+      self.read_params()
+    self.frame += 1
+
+  def apply_lead(self, lead_dict: dict) -> dict:
+    if self.distance <= 0. or not lead_dict.get('status', False):
+      return lead_dict
+
+    offset = self.distance * float(np.interp(lead_dict['vLead'], STOPPED_DISTANCE_FADE_BP, [1., 0.]))
+    lead_dict['dRel'] = min(lead_dict['dRel'], max(lead_dict['dRel'] - offset, MIN_ADJUSTED_D_REL))
+    return lead_dict
+
+  def adjust_e2e_stop(self, a_target: float, should_stop: bool, v_ego: float, model_msg) -> tuple[float, bool]:
+    if self.distance <= 0.:
+      return a_target, should_stop
+
+    x = model_msg.position.x
+    v = model_msg.velocity.x
+    if len(x) != ModelConstants.IDX_N or len(v) != ModelConstants.IDX_N:
+      return a_target, should_stop
+
+    # only stops the model plans to hold (red lights) can be shifted
+    if float(v[-1]) > E2E_STOP_PLAN_VEL_THRESHOLD:
+      return a_target, should_stop
+
+    stop_distance = float(x[-1])
+
+    if v_ego < E2E_STOP_HOLD_MAX_V:
+      # stopped short of the model's stop point: hold instead of creeping up to it
+      if stop_distance <= self.distance + E2E_STOP_HOLD_BUFFER:
+        should_stop = True
+    elif a_target < E2E_STOP_MIN_BRAKING:
+      # deepen braking that has already started, targeting a stop short of the model's stop point
+      adjusted_distance = max(stop_distance - self.distance, E2E_STOP_MIN_DIST)
+      a_required = max(-(v_ego ** 2) / (2 * adjusted_distance), ACCEL_MIN)
+      if a_required < a_target:
+        a_target = float(a_required)
+
+    return a_target, should_stop

--- a/sunnypilot/selfdrive/controls/lib/longitudinal_planner.py
+++ b/sunnypilot/selfdrive/controls/lib/longitudinal_planner.py
@@ -11,6 +11,7 @@ from openpilot.common.constants import CV
 from openpilot.selfdrive.car.cruise import V_CRUISE_MAX
 from openpilot.sunnypilot.selfdrive.controls.lib.dec.dec import DynamicExperimentalController
 from openpilot.sunnypilot.selfdrive.controls.lib.e2e_alerts_helper import E2EAlertsHelper
+from openpilot.sunnypilot.selfdrive.controls.lib.increased_stop_distance import IncreasedStopDistance
 from openpilot.sunnypilot.selfdrive.controls.lib.smart_cruise_control.smart_cruise_control import SmartCruiseControl
 from openpilot.sunnypilot.selfdrive.controls.lib.speed_limit.speed_limit_assist import SpeedLimitAssist
 from openpilot.sunnypilot.selfdrive.controls.lib.speed_limit.speed_limit_resolver import SpeedLimitResolver
@@ -26,6 +27,7 @@ class LongitudinalPlannerSP:
     self.events_sp = EventsSP()
     self.resolver = SpeedLimitResolver()
     self.dec = DynamicExperimentalController(CP, mpc)
+    self.increased_stop_distance = IncreasedStopDistance()
     self.scc = SmartCruiseControl()
     self.resolver = SpeedLimitResolver()
     self.sla = SpeedLimitAssist(CP, CP_SP)
@@ -76,7 +78,13 @@ class LongitudinalPlannerSP:
   def update(self, sm: messaging.SubMaster) -> None:
     self.events_sp.clear()
     self.dec.update(sm)
+    self.increased_stop_distance.update()
     self.e2e_alerts_helper.update(sm, self.events_sp)
+
+  def apply_e2e_stop_distance(self, sm: messaging.SubMaster, v_ego: float, a_target: float, should_stop: bool) -> tuple[float, bool]:
+    if not self.is_e2e(sm):
+      return a_target, should_stop
+    return self.increased_stop_distance.adjust_e2e_stop(a_target, should_stop, v_ego, sm['modelV2'])
 
   def publish_longitudinal_plan_sp(self, sm: messaging.SubMaster, pm: messaging.PubMaster) -> None:
     plan_sp_send = messaging.new_message('longitudinalPlanSP')

--- a/sunnypilot/sunnylink/settings_ui.json
+++ b/sunnypilot/sunnylink/settings_ui.json
@@ -648,6 +648,36 @@
           ]
         },
         {
+          "id": "increased_stop_distance",
+          "title": "",
+          "description": "",
+          "items": [
+            {
+              "key": "IncreasedStoppedDistance",
+              "widget": "option",
+              "title": "Increased Stopped Distance",
+              "description": "Increase the distance sunnypilot stops behind a stopped lead vehicle or at a red light, in meters.",
+              "min": 0,
+              "max": 5,
+              "step": 1,
+              "visibility": [
+                {
+                  "type": "capability",
+                  "field": "has_longitudinal_control",
+                  "equals": true
+                }
+              ],
+              "enablement": [
+                {
+                  "type": "capability",
+                  "field": "has_longitudinal_control",
+                  "equals": true
+                }
+              ]
+            }
+          ]
+        },
+        {
           "id": "custom_acc_increments",
           "title": "Custom ACC Speed Intervals",
           "description": "",

--- a/sunnypilot/sunnylink/settings_ui_src/pages/cruise.yaml
+++ b/sunnypilot/sunnylink/settings_ui_src/pages/cruise.yaml
@@ -57,6 +57,21 @@ sections:
         type: capability
         field: has_longitudinal_control
         equals: true
+- id: increased_stop_distance
+  title: ''
+  description: ''
+  items:
+  - key: IncreasedStoppedDistance
+    widget: option
+    title: Increased Stopped Distance
+    description: Increase the distance sunnypilot stops behind a stopped lead vehicle or at a red light, in meters.
+    min: 0
+    max: 5
+    step: 1
+    visibility:
+    - $ref: '#/macros/longitudinal'
+    enablement:
+    - $ref: '#/macros/longitudinal'
 - id: custom_acc_increments
   title: Custom ACC Speed Intervals
   description: ''


### PR DESCRIPTION
**Description**

Adds an Increased Stop Distance setting (0-5 m, Settings -> Cruise, also exposed via sunnylink): stop further behind a stopped lead vehicle, and further from stops the model plans to hold (red lights). Gated on sunnypilot longitudinal control.

One param drives two mechanisms:
- **Lead stops** (radard): the reported lead distance is reduced by the offset, faded back out as the lead gets up to speed - normal following distance is unaffected. Works in chill and experimental mode, with radar or vision leads.
- **Model-held stops** (planner, experimental mode): when the model's trajectory ends at ~zero velocity, braking is bounded toward a point short of its predicted stop, with a hold preventing creep back to the original stop point. Only ever *adds* braking - it cannot reduce braking authority or cause an overshoot.

Stop signs are deliberately excluded: road testing showed that forcing an early stop before a stop-then-proceed plan makes the model treat the stop as completed and roll through the sign (the offset gets consumed by replanning rather than shifting the stop). Red lights don't have this feedback loop because the model plans to remain stopped regardless. Details are documented in the module docstring.

**Verification**

Road tested on a 2021 Hyundai Palisade (sunnypilot longitudinal, radar tracks active) across multiple drives: lead-stop offset verified in chill and experimental mode at settings 0-5 m; red-light offset verified in experimental mode; stop-sign behavior verified unchanged. The stop-sign exclusion itself was validated empirically - two earlier iterations that attempted to shift stop-sign stops were reverted after consistent roll-through behavior in testing.

Route: https://connect.comma.ai/ff9dba54b42b3afa/0000002f--00273b485e

🤖 Generated with [Claude Code](https://claude.com/claude-code)