### PR TITLE
fix: Sunnylink settings panel stale display and offroad write enforcement

### DIFF
--- a/sunnypilot/sunnylink/athena/sunnylinkd.py
+++ b/sunnypilot/sunnylink/athena/sunnylinkd.py
@@ -57,6 +57,58 @@ BLOCKED_PARAMS = {
   "ParamsVersion",         # Device-managed version counter
 }
 
+_SETTINGS_UI_PATH = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "settings_ui.json")
+
+
+def _extract_rule_params(schema: dict, rule_type: str) -> frozenset[str]:
+  result: set[str] = set()
+
+  def has_rule(rules: list) -> bool:
+    for r in rules:
+      if not isinstance(r, dict):
+        continue
+      if r.get('type') == rule_type:
+        return True
+      for v in r.values():
+        if isinstance(v, list) and has_rule(v):
+          return True
+    return False
+
+  def scan(items: list) -> None:
+    for item in items:
+      if not isinstance(item, dict):
+        continue
+      key = item.get('key')
+      if key and has_rule(item.get('enablement') or []):
+        result.add(key)
+      scan(item.get('sub_items') or [])
+
+  def scan_sections(sections: list) -> None:
+    for section in sections:
+      if not isinstance(section, dict):
+        continue
+      scan(section.get('items') or [])
+      for sp in section.get('sub_panels') or []:
+        if isinstance(sp, dict):
+          scan(sp.get('items') or [])
+
+  for panel in schema.get('panels') or []:
+    if isinstance(panel, dict):
+      scan_sections(panel.get('sections') or [])
+  for brand_data in (schema.get('vehicle_settings') or {}).values():
+    if isinstance(brand_data, dict):
+      scan_sections(brand_data.get('sections') or [])
+
+  return frozenset(result)
+
+
+try:
+  with open(_SETTINGS_UI_PATH) as _f:
+    OFFROAD_ONLY_PARAMS: frozenset[str] = _extract_rule_params(json.load(_f), 'offroad_only')
+except Exception:
+  cloudlog.exception("sunnylinkd: failed to load settings_ui.json for offroad enforcement")
+  OFFROAD_ONLY_PARAMS = frozenset()
+
 
 def handle_long_poll(ws: WebSocket, exit_event: threading.Event | None) -> None:
   cloudlog.info("sunnylinkd.handle_long_poll started")
@@ -233,23 +285,30 @@ def getParams(params_keys: list[str], compression: bool = False) -> str | dict[s
 
 @dispatcher.add_method
 def saveParams(params_to_update: dict[str, str], compression: bool = False) -> None:
+  is_onroad = params.get_bool("IsOnroad")
+  wrote_any = False
+
   for key, value in params_to_update.items():
-    # disallow modifications to blocked parameters
     if key in BLOCKED_PARAMS:
-      cloudlog.warning(f"sunnylinkd.saveParams.blocked: Attempted to modify blocked parameter '{key}'")
+      cloudlog.warning(f"sunnylinkd.saveParams.blocked: '{key}'")
+      continue
+
+    if is_onroad and key in OFFROAD_ONLY_PARAMS:
+      cloudlog.warning(f"sunnylinkd.saveParams.offroad_only: '{key}' rejected (device is onroad)")
       continue
 
     try:
       save_param_from_base64_encoded_string(key, value, compression)
+      wrote_any = True
     except Exception as e:
       cloudlog.error(f"sunnylinkd.saveParams.exception {e}")
 
-  # Increment version counter for frontend change detection
-  try:
-    current = int(params.get("ParamsVersion") or "0")
-    params.put("ParamsVersion", str(current + 1), block=True)
-  except Exception:
-    pass
+  if wrote_any:
+    try:
+      current = int(params.get("ParamsVersion") or "0")
+      params.put("ParamsVersion", str(current + 1), block=True)
+    except Exception:
+      pass
 
 
 def startLocalProxy(global_end_event: threading.Event, remote_ws_uri: str, local_port: int) -> dict[str, int]:

--- a/sunnypilot/sunnylink/docs/README.md
+++ b/sunnypilot/sunnylink/docs/README.md
@@ -166,7 +166,7 @@ The tables below describe the **compiled** `settings_ui.json` schema — what th
 
 | Use this | When | Why |
 |---|---|---|
-| `offroad_only` | Param can only be safely changed when the car is parked. Most user-facing toggles. | Strictest. Frontend shows "device is driving" badge and disables the row. |
+| `offroad_only` | Param can only be safely changed when the car is parked. Most user-facing toggles. | Strictest. Frontend shows "device is driving" badge and disables the row. Sunnylink remote writes are also blocked on the device when onroad (enforced by `sunnylinkd.py` at the remote write path, derived from `settings_ui.json` at startup). |
 | `not_engaged` | Param can be changed while the car is started but only when sunnypilot/MADS is **not** actively driving. | Less strict than offroad. Matches Raylib `engaged = started AND (selfdriveState.enabled OR mads.enabled)`. Use for items the device must apply mid-drive (e.g. test maneuvers, longitudinal stock-vs-OP toggle). |
 | `param`-based | Behavior depends on another setting's value (parent toggle, mode selector, etc.). | Composes with `not`/`any`/`all` for arbitrary logic. |
 | `capability`-based | Behavior depends on the connected car or device (brand, longitudinal, hardware). | Resolved on the device from `CarParams` / hardware. See [`capabilities.py`](../capabilities.py) for the full field list. |
@@ -574,7 +574,7 @@ The device defines these labels in `capabilities.py:CAPABILITY_LABELS`. Examples
 
 ### Centralized param enforcement
 
-The device-side UI enforces capability constraints in `selfdrive/ui/sunnypilot/ui_state.py:_enforce_constraints()`, which removes incompatible params based on car capabilities. This is the single source of truth for such constraints.
+The device-side UI enforces capability constraints in `selfdrive/ui/sunnypilot/ui_state.py:_enforce_constraints()`, which removes incompatible params based on car capabilities.
 
 Settings layouts should not duplicate these params.remove() calls. Instead, rely on schema rules and centralized enforcement to prevent duplicate logic and ensure consistency.
 
@@ -583,3 +583,5 @@ Example constraints in `_enforce_constraints()`:
 - No CarParams: remove all car-dependent params
 - No longitudinal: remove `ExperimentalMode`
 - No ICBM: remove `IntelligentCruiseButtonManagement`
+
+`sunnylinkd.py` also enforces `offroad_only` rules at the Sunnylink remote write path: it loads `settings_ui.json` at startup and builds `OFFROAD_ONLY_PARAMS` from all items that carry an `offroad_only` enablement rule. Any `saveParams()` call received while the device is onroad silently drops writes to those params. New `offroad_only` settings are automatically covered when the schema is recompiled and committed — no code change needed.

--- a/system/ui/sunnypilot/widgets/list_view.py
+++ b/system/ui/sunnypilot/widgets/list_view.py
@@ -181,6 +181,12 @@ class MultipleButtonActionSP(MultipleButtonAction):
 
       rl.draw_text_ex(self._font, text, rl.Vector2(text_x, text_y), 40, 0, current_text_color)
 
+  def show_event(self):
+    if self.param_key:
+      self.selected_button = int(self.params.get(self.param_key, return_default=True))
+      self._anim_x = None
+    super().show_event()
+
   def _handle_mouse_release(self, mouse_pos: MousePos):
     # Override parent method to check individual button enabled state
     if not self.enabled:

--- a/system/ui/sunnypilot/widgets/toggle.py
+++ b/system/ui/sunnypilot/widgets/toggle.py
@@ -27,6 +27,13 @@ class ToggleSP(Toggle):
   def set_rect(self, rect: rl.Rectangle):
     self._rect = rl.Rectangle(rect.x, rect.y, style.TOGGLE_WIDTH, style.TOGGLE_HEIGHT)
 
+  def show_event(self):
+    if self.param_key:
+      self._state = self.params.get_bool(self.param_key)
+      self._progress = 1.0 if self._state else 0.0
+      self._target = self._progress
+    super().show_event()
+
   def _handle_mouse_release(self, mouse_pos: MousePos):
     super()._handle_mouse_release(mouse_pos)
     if self._enabled and self.param_key:


### PR DESCRIPTION
## Purpose

Two related bugs in the Sunnylink remote settings path:

1. **Settings panel shows stale value after a remote change** — multiple-button and toggle widgets did not re-read their param when a settings panel was re-opened. If Sunnylink wrote a new value remotely, the panel continued to show the old value until the UI process restarted.

2. **Sunnylink could write offroad-only params while onroad** — settings marked `offroad_only` in the schema (greyed out on-device while driving) had no enforcement on the remote write path. `sunnylinkd.saveParams()` accepted those writes regardless of drive state.

Both fixes affect all supported vehicles.

Originally proposed/discussed: https://community.sunnypilot.ai/t/changes-via-sunnylink-require-device-reboot-to-be-effective/5400

## Changes

- `system/ui/sunnypilot/widgets/list_view.py` — `MultipleButtonActionSP.show_event()` re-reads its param on panel open
- `system/ui/sunnypilot/widgets/toggle.py` — `ToggleSP.show_event()` re-reads its param on panel open
- `sunnypilot/sunnylink/athena/sunnylinkd.py` — `saveParams()` loads `offroad_only` params from `settings_ui.json` at startup and silently drops writes to those params while `IsOnroad` is true; `ParamsVersion` is only incremented when at least one write succeeds
- `sunnypilot/sunnylink/docs/README.md` — documents the new enforcement behaviour

## Verification

- Changed a multiple-button setting via Sunnylink web app while device was parked; reopened the settings panel on-device — new value displayed immediately without restarting the UI.
- Attempted to push an offroad-only setting via Sunnylink while driving — param value did not change; rejection logged by `sunnylinkd`.
- Pushed the same offroad-only setting while parked — write succeeded normally.
- Normal on-device toggle and multiple-button interaction unaffected.