### PR TITLE
manager: catch SIGTERM/SIGHUP in github_runner.sh wrapper

### DIFF
--- a/system/manager/github_runner.sh
+++ b/system/manager/github_runner.sh
@@ -27,8 +27,12 @@ fi
 # Store the script argument in a descriptive variable
 ACTION=$1
 
-# Trap EXIT signal (Ctrl+C) and stop the service
-trap 'control_service stop ; exit' SIGINT SIGKILL EXIT
+# Stop the systemd service on any orderly termination so the actions-runner
+# process does not get orphaned when the manager tears this wrapper down.
+# SIGKILL is intentionally omitted: it cannot be caught (kernel-forced).
+# openpilot's manager sends SIGINT first, then escalates to SIGTERM after a
+# timeout; catching both keeps the shutdown deterministic.
+trap 'control_service stop ; exit' SIGINT SIGTERM SIGHUP EXIT
 
 # Enter the main loop
 while true; do

--- a/system/manager/github_runner.sh
+++ b/system/manager/github_runner.sh
@@ -32,7 +32,8 @@ ACTION=$1
 # SIGKILL is intentionally omitted: it cannot be caught (kernel-forced).
 # openpilot's manager sends SIGINT first, then escalates to SIGTERM after a
 # timeout; catching both keeps the shutdown deterministic.
-trap 'control_service stop ; exit' SIGINT SIGTERM SIGHUP EXIT
+trap 'control_service stop' EXIT
+trap 'exit' SIGINT SIGTERM SIGHUP
 
 # Enter the main loop
 while true; do


### PR DESCRIPTION
### Problem

The [github_runner.sh](https://github.com/sunnypilot/sunnypilot/blob/master/system/manager/github_runner.sh) wrapper's `trap` listens for `SIGINT / SIGKILL / EXIT`. Two issues:

1. **`SIGKILL` cannot be trapped** — it is kernel-forced, so listing it is misleading and does nothing.
2. **`SIGTERM` is missing**. openpilot's manager sends `SIGINT` first and then escalates to `SIGTERM` after a timeout (see `system/manager/process.py`). When `SIGTERM` lands the shell dies without the trap running, so `systemctl stop actions.runner.sunnypilot.<host>` is never invoked and the actions-runner systemd service keeps running (dotnet `Runner.Listener` + `Runner.Worker`) after the manager thinks the wrapper is gone.

### Impact observed

Left over into a drive, the stray runner competes with `plannerd` / `modeld` for CPU. On a comma3X we observed intermittent `commIssue / softDisable → "TAKE CONTROL IMMEDIATELY"` events during driving. rlog showed every upstream publisher healthy (max gap ~50 ms, `valid=100%`) but `plannerd` published `longitudinalPlan / driverAssistance / longitudinalPlanSP` with `valid=False` in a ~5 s burst — a classic dotnet-GC / JIT contention window rather than an actual publisher failure. Disabling `EnableGithubRunner` and confirming no dotnet/Runner processes cleared the symptom.

### Fix

Catch `SIGTERM` and `SIGHUP` in addition to `SIGINT` + `EXIT`, and drop `SIGKILL` from the list. Now any orderly termination signal the manager or systemd might send runs the stop hook, so the actions-runner service is torn down deterministically before the wrapper exits.

### Test plan

- Static: `shellcheck system/manager/github_runner.sh` clean.
- Behavior: on a device with `EnableGithubRunner=1`, driving → manager stops `github_runner_start` → verify (via `systemctl status actions.runner.sunnypilot.<host>`) the runner service is `inactive` while onroad. Before this change SIGTERM would leave it `active`.

### Notes

- Behavior of the loop and the `start` path is unchanged.
- No car / safety code touched.