### PR TITLE
speed_limit: fix GPS fix-age clock-domain bug (unreachable map adaptation)

### DIFF
--- a/openpilot/sunnypilot/selfdrive/controls/lib/speed_limit/speed_limit_resolver.py
+++ b/openpilot/sunnypilot/selfdrive/controls/lib/speed_limit/speed_limit_resolver.py
@@ -119,12 +119,23 @@ class SpeedLimitResolver:
     self._reset_limit_sources(SpeedLimitSource.map)
     self._process_map_data(sm)
 
+  def _gps_fix_age(self, sm: messaging.SubMaster) -> float:
+    # Time since the last GPS message, in the monotonic domain. The message's own
+    # unixTimestampMillis is wall-clock epoch (ms) and must not be mixed with
+    # time.monotonic(); recv_time is the consumer-side monotonic receipt time and
+    # stays large (data treated as stale) until the first fix arrives.
+    recv_time = getattr(sm, 'recv_time', None)
+    if recv_time is None:
+      # The longitudinal maneuver harness (selfdrive/test/longitudinal_maneuvers/plant.py)
+      # passes a plain dict instead of a SubMaster, so there is no receipt time to read.
+      # It synthesizes a fresh message every step, so treat the data as current.
+      return 0.
+    return time.monotonic() - recv_time[self._gps_location_service]
+
   def _process_map_data(self, sm: messaging.SubMaster) -> None:
-    gps_data = sm[self._gps_location_service]
     map_data = sm['liveMapDataSP']
 
-    gps_fix_age = time.monotonic() - gps_data.unixTimestampMillis * 1e-3
-    if gps_fix_age > LIMIT_MAX_MAP_DATA_AGE:
+    if self._gps_fix_age(sm) > LIMIT_MAX_MAP_DATA_AGE:
       return
 
     speed_limit = map_data.speedLimit if map_data.speedLimitValid else 0.
@@ -133,16 +144,14 @@ class SpeedLimitResolver:
     self._calculate_map_data_limits(sm, speed_limit, next_speed_limit)
 
   def _calculate_map_data_limits(self, sm: messaging.SubMaster, speed_limit: float, next_speed_limit: float) -> None:
-    gps_data = sm[self._gps_location_service]
     map_data = sm['liveMapDataSP']
 
-    distance_since_fix = self.v_ego * (time.monotonic() - gps_data.unixTimestampMillis * 1e-3)
+    distance_since_fix = self.v_ego * self._gps_fix_age(sm)
     distance_to_speed_limit_ahead = max(0., map_data.speedLimitAheadDistance - distance_since_fix)
 
     self.limit_solutions[SpeedLimitSource.map] = speed_limit
     self.distance_solutions[SpeedLimitSource.map] = 0.
 
-    # FIXME-SP: this is not working as expected
     if 0. < next_speed_limit < self.v_ego:
       adapt_time = (next_speed_limit - self.v_ego) / LIMIT_ADAPT_ACC
       adapt_distance = self.v_ego * adapt_time + 0.5 * LIMIT_ADAPT_ACC * adapt_time ** 2

--- a/openpilot/sunnypilot/selfdrive/controls/lib/speed_limit/tests/test_speed_limit_resolver.py
+++ b/openpilot/sunnypilot/selfdrive/controls/lib/speed_limit/tests/test_speed_limit_resolver.py
@@ -55,6 +55,10 @@ def setup_sm_mock(mocker: MockerFixture):
     'carStateSP': car_state_sp,
     'gpsLocation': gps_data,
   }[key]
+  # GPS freshness is measured from the monotonic receipt time; a recent value keeps
+  # the map data considered fresh.
+  now = time.monotonic()
+  sm_mock.recv_time = {'gpsLocation': now, 'gpsLocationExternal': now}
   return sm_mock
 
 
@@ -138,7 +142,30 @@ class TestSpeedLimitResolverValidation:
     resolver = resolver_class()
     resolver.policy = policy
     sm_mock = mocker.MagicMock()
-    sm_mock['gpsLocation'].unixTimestampMillis = (time.monotonic() - 2 * LIMIT_MAX_MAP_DATA_AGE) * 1e3
+    stale = time.monotonic() - 2 * LIMIT_MAX_MAP_DATA_AGE
+    sm_mock.recv_time = {'gpsLocation': stale, 'gpsLocationExternal': stale}
     resolver._get_from_map_data(sm_mock)
     assert resolver.limit_solutions[SpeedLimitSource.map] == 0.
     assert resolver.distance_solutions[SpeedLimitSource.map] == 0.
+
+  @pytest.mark.parametrize("policy", [Policy.map_data_only])
+  def test_upcoming_lower_limit_triggers_adaptation(self, resolver_class, policy, mocker: MockerFixture):
+    # Regression test for the clock-domain bug that made this branch unreachable:
+    # with a fresh GPS fix, an upcoming lower limit within the adapt distance must be applied.
+    resolver = resolver_class()
+    resolver.policy = policy
+    resolver.v_ego = 20.
+    live_map_data = create_mock({
+      'speedLimit': 30., 'speedLimitValid': True,
+      'speedLimitAhead': 10., 'speedLimitAheadValid': True,
+      'speedLimitAheadDistance': 100.,
+    }, mocker)
+    sm_mock = mocker.MagicMock()
+    sm_mock.__getitem__.side_effect = lambda key: {'liveMapDataSP': live_map_data}[key]
+    now = time.monotonic()
+    sm_mock.recv_time = {'gpsLocation': now, 'gpsLocationExternal': now}
+
+    resolver._get_from_map_data(sm_mock)
+
+    assert resolver.limit_solutions[SpeedLimitSource.map] == 10.
+    assert resolver.distance_solutions[SpeedLimitSource.map] == pytest.approx(100., abs=1.)


### PR DESCRIPTION
**Description**

`SpeedLimitResolver` computed GPS fix age by subtracting the GPS message's wall-clock `unixTimestampMillis` (epoch, ~1.7e12 ms) from `time.monotonic()` (uptime seconds):

```python
gps_fix_age = time.monotonic() - gps_data.unixTimestampMillis * 1e-3
```

The result is always hugely negative, which breaks two things:

1. **The staleness guard can never fire**, so stale map data is always accepted:

   ```python
   if gps_fix_age > LIMIT_MAX_MAP_DATA_AGE:   # never True
       return
   ```

2. **`distance_since_fix` is always negative**, so `distance_to_speed_limit_ahead` stays inflated and the upcoming-lower-speed-limit adaptation branch is unreachable — which is the cause behind the existing `FIXME-SP: this is not working as expected` sitting on that very branch.

Measured on a build (`LIMIT_MAX_MAP_DATA_AGE = 10.0`, `v_ego = 15 m/s`, ahead = 200 m):

```
buggy gps_fix_age        = -1,784,937,636 s     (~ -56 years)
staleness guard fires?   = False                 <- stale data never rejected
distance_since_fix       = -26,774,064,536 m     (physically impossible)
distance_to_limit_ahead  = 26,774,064,736 m      (inflated from 200)
```

This looks like a blind `time.time` -> `time.monotonic` swap to satisfy the ruff ban on `time.time`, which silently changed clock domains.

**Fix:** measure GPS age in the monotonic domain via `sm.recv_time[gps_service]` (consumer-side receipt time), which also stays large until the first fix arrives, so a cold start is still correctly treated as stale. Both call sites now share one `_gps_fix_age()` helper, and the stale `FIXME-SP` comment is removed.

**Verification**

Unit tests, on Ubuntu 24.04 / Python 3.12.3, against a tree containing current master plus only this commit:

```
test_speed_limit_resolver.py             : 24 passed before -> 25 passed after
whole speed_limit/ directory             : 45 passed  (includes test_speed_limit_assist.py)
sunnypilot/selfdrive/controls/lib/tests  : 56 passed
```

This adds `test_upcoming_lower_limit_triggers_adaptation` covering the previously unreachable branch, and updates existing tests that had masked the bug by feeding monotonic-valued timestamps into `unixTimestampMillis`.

I also decoded a 24-minute drive from my own car (comma 3X; `liveMapDataSP` at ~1 Hz, 1411 messages, 1389 with `speedLimitValid`) and recomputed the unpatched expression against the logged GPS messages:

```
buggy gps_fix_age      = -1,784,859,278 s   (constant across the drive)
staleness guard fired  = 0 / 1399 GPS messages (0.0%)
```

So on a real drive the guard never rejected map data once — it cannot, by construction. The dead adaptation branch also had real work available:

```
frames with speedLimitAheadDistance > 0                       : 310
of those, upcoming limit < current speed (adaptation-eligible): 150
```

At ~1 Hz that is roughly 150 seconds of that drive where an upcoming lower limit was known and the adaptation branch should have been engaging but could not. Map limits changed only 7 times across the drive, each value held for minutes, so a stale value has a long window in which to persist undetected.

To be straight about the limits of my verification:

- The numeric demonstration and the unit tests above are the evidence.
- I have **not** road-tested the adaptation behaviour in Speed Limit Assist mode. My car is a Subaru, which needs alpha longitudinal for Assist, and I don't run that. The resolver itself runs in `plannerd` on every car regardless of mode, so the bug isn't platform-specific — but someone on a factory-longitudinal car should confirm the on-road behaviour before this is relied on.
- Note this makes a previously dead code path live: the car will now begin slowing for an upcoming lower limit rather than at it. That's the intended behaviour, but it is a behaviour change on a live driving feature and deserves a deliberate test drive.

**Not included here**

`LongitudinalPlannerSP.__init__` assigns `self.resolver = SpeedLimitResolver()` twice (lines 27 and 30) — harmless, but one is dead. I left it out to keep this PR single-purpose; happy to open a separate one if you'd like it cleaned up.
