### PR TITLE
hardware: don't kernel panic when a heat-soaked display stops acking frames

### DIFF
--- a/launch_chffrplus.sh
+++ b/launch_chffrplus.sh
@@ -9,6 +9,15 @@ function agnos_init {
   sudo rm -f /data/etc/NetworkManager/system-connections/*.nmmeta
   rm -f /data/scons_cache/config.lock
 
+  # The SDE display driver panics the kernel when a command-mode panel misses two
+  # consecutive pingpong-done IRQs (sde_encoder_phys_cmd.c, SDE_DBG_DUMP("panic")),
+  # which heat-soaked EA8074 panels do ~20-45s into boot - so a recoverable panel
+  # fault becomes a reboot loop. Disarming panic_on_err keeps the register dump and
+  # the PANEL_DEAD/ctl-reset recovery path; it only skips the panic() call.
+  # See commaai/openpilot#34971 and commaai/agnos-kernel-sdm845#85.
+  # Done here rather than in hardwared: this runs before any openpilot DRM client.
+  echo 0 | sudo tee /sys/kernel/debug/dri/0/debug/panic > /dev/null || true
+
   # set success flag for current boot slot
   sudo abctl --set_success
 

--- a/openpilot/system/hardware/hardwared.py
+++ b/openpilot/system/hardware/hardwared.py
@@ -10,7 +10,7 @@ from collections import OrderedDict, namedtuple
 import openpilot.cereal.messaging as messaging
 from openpilot.cereal import log
 from openpilot.cereal.services import SERVICE_LIST
-from openpilot.common.utils import strip_deprecated_keys
+from openpilot.common.utils import strip_deprecated_keys, sudo_read
 from openpilot.common.filter_simple import FirstOrderFilter
 from openpilot.common.params import Params
 from openpilot.common.realtime import DT_HW
@@ -188,6 +188,13 @@ def hardware_thread(end_event, hw_queue) -> None:
   last_uptime_ts: float = time.monotonic()
 
   HARDWARE.initialize_hardware()
+
+  if TICI:
+    # panic-on-display-error is disarmed in launch_chffrplus.sh. journald is only_onroad,
+    # so nothing else records the state during the offroad boot window where a heat-soaked
+    # panel faults - log the readback so that boot is diagnosable after the fact.
+    cloudlog.event("hardwared.sde_panic_on_err", value=sudo_read("/sys/kernel/debug/dri/0/debug/panic"))
+
   thermal_config = HARDWARE.get_thermal_config()
 
   fan_controller = FanController(int(1./DT_HW))


### PR DESCRIPTION

**Description**

Fixes #1891.

On a comma 3X, a heat-soaked display panel makes the kernel panic and reboot the device,
offroad, ~20–45 s into boot — which on a hot day becomes a boot loop that only ends when the
device cools.

It's a deliberate panic in the display driver, not a thermal trip. In
`commaai/agnos-kernel-sdm845`, `_sde_encoder_phys_cmd_handle_ppdone_timeout()`
(`drivers/gpu/drm/msm/sde/sde_encoder_phys_cmd.c`) calls `SDE_DBG_DUMP("panic")` once a
command-mode panel has missed two consecutive pingpong-done IRQs (`PP_TIMEOUT_MAX_TRIALS`),
and `_sde_dump_array()` in `sde_dbg.c` then does:

```c
if (do_panic && sde_dbg_base.panic_on_err)
        panic(name);
```

`panic_on_err` defaults to `1` (`#define DEFAULT_PANIC 1`, `sde_dbg.h`) and is exposed as
`/sys/kernel/debug/dri/0/debug/panic`.

This clears that knob in `agnos_init()`. It is a debug dump policy, not protection:
`_sde_dump_array()` still writes the full register/dbgbus dump *before* the panic check,
`SDE_ENCODER_FRAME_EVENT_PANEL_DEAD` is still delivered, and the encoder still gets
`SDE_ENC_ERR_NEEDS_HW_RESET` and recovers on the next kickoff. Only the `panic()` is skipped,
so a recoverable panel fault stays recoverable.

comma has seen this before — commaai/openpilot#34971, mitigated by a panel-jitter DT change
in commaai/agnos-kernel-sdm845#85, then commaai/openpilot#36191 closed as
*"limited to ~5 users, so we just got them back."* The mitigation reduces the fault rate but
doesn't remove it; this device is on current AGNOS and still faults above ~68 °C board.

Two notes for review:

- **Why `agnos_init()` and not `Tici.initialize_hardware()`**, which is the natural home and
  already writes two `msm_vidc` debugfs knobs: `hardwared` starts from `manager_thread()`,
  after `manager_init()` and registration, which is later than the 20.6 s earliest panic
  observed here. `agnos_init()` runs before `build.py` and before `manager.py`, i.e. before
  any openpilot DRM client exists.
- **Why not `sudo_write()`** from `openpilot/common/utils.py`: its `PermissionError` fallback
  runs `sudo chmod a+w <path>`, which would leave a root-owned debugfs knob world-writable.
  `sudo tee` avoids that.

The second hunk logs the readback once at `hardwared` start. `journald` is `only_onroad`, so
nothing currently records kernel state during the offroad boot window where this fault fires;
without it there's no way to tell a device that was protected from one that silently wasn't.

Deliberately out of scope: display brightness limiting and thermal-gate changes. Separate
concerns, separate PRs.

**Verification**

- Bench: `ruff check` clean, `bash -n` clean on the launch script, `pytest openpilot/system/hardware/tests` unaffected. No cereal schema change.
- Device: after reboot, `sudo cat /sys/kernel/debug/dri/0/debug/panic` reads `0`, and swaglog carries `hardwared.sde_panic_on_err` with `value: "0"`.
- Field, one comma 3X, ~9 days across the failure window:
  - **Before** (panic armed, 2026-07-13): 6 consecutive boots, none surviving past 19 s, two
    distinct ramoops both ending in
    `Kernel panic - not syncing: _sde_encoder_phys_cmd_handle_ppdone_timeout`, each exactly
    230 ms after the first `kickoff timed out` line.
  - **After** (panic disarmed, 2026-07-14 → 07-22): 32 boots, 243–33 521 s each, **0 reboots,
    0 panic dumps** — while the panel fault kept recurring on 4 of those boots, including one
    at 82.4 °C board (hotter than the crash-loop conditions) that logged faults starting at
    46 s uptime, inside the old panic window, and then ran 22 minutes unbroken.
  - Display faults separate cleanly on board temperature: every boot ≥ 68.3 °C faulted, every
    boot ≤ 67.5 °C did not, no overlap.

Full data, figures and the controls (including the brightness-guard confound and what would
falsify the claim) are in #1891.
