### PR TITLE
modeld_v2: fix features_buffer alignment for supercombo models

### DIFF
--- a/openpilot/sunnypilot/modeld_v2/compile_modeld.py
+++ b/openpilot/sunnypilot/modeld_v2/compile_modeld.py
@@ -117,7 +117,8 @@ def generate_queues_and_npy(input_shapes: dict, frame_skip: int, device: str = D
   }
 
   if features_buffer:
-    queues['feat_q'] = Tensor(np.zeros((frame_skip * (features_buffer[1] - 1) + 1, features_buffer[0], features_buffer[2]),
+    feat_q_len = frame_skip * features_buffer[1] if is_supercombo else frame_skip * (features_buffer[1] - 1) + 1
+    queues['feat_q'] = Tensor(np.zeros((feat_q_len, features_buffer[0], features_buffer[2]),
                        dtype=np.float32), device=device).contiguous().realize()
 
   queues.update({key: Tensor(value, device='NPY').realize() for key, value in npy_arrays.items() if key in ('tfm', 'big_tfm')})


### PR DESCRIPTION
When upstream combined the driving model into a single onnx ([a40fa3a0b](https://github.com/commaai/openpilot/commit/a40fa3a0b0cfacb0010b50515bcd64aed3dbdac8)), they changed the feature buffer to be a len 96 ring instead of a 93 ring.
modeld_v2 keeps the 93 ring and so only lags by 1 frame instead of 4, so fused models get a features_buffer shifted 3 frames newer compared to openpilot.

Fixes: #1917

Checked the older supercombo models, they were frame_skip=1 which makes the math equivalent so no regressions there.