### PR TITLE
ui: Update default model name after eGPU hot-plug

### DIFF
--- a/openpilot/common/hardware/usb.py
+++ b/openpilot/common/hardware/usb.py
@@ -9,6 +9,10 @@ TYPEC_CC_ORIENTATION_PATH = Path("/sys/class/power_supply/usb/typec_cc_orientati
 PRIMARY_USB_CONTROLLER = "a600000.ssusb"
 
 
+def is_chestnut_ready(vendor_id: int, product_id: int, product: str) -> bool:
+  return (vendor_id, product_id) in CHESTNUT_USB_IDS and product == f"custom {CHESTNUT_FW_VERSION}-CLEAN"
+
+
 def get_usb_topology() -> set[str]:
   try:
     return set(os.listdir(USB_DEVICES_PATH))

--- a/openpilot/selfdrive/modeld/helpers.py
+++ b/openpilot/selfdrive/modeld/helpers.py
@@ -7,7 +7,7 @@ import tempfile
 from pathlib import Path
 
 from openpilot.common.file_chunker import get_manifest_path
-from openpilot.common.hardware.usb import CHESTNUT_FW_VERSION, CHESTNUT_USB_IDS, USB_DEVICES_PATH
+from openpilot.common.hardware.usb import USB_DEVICES_PATH, is_chestnut_ready
 
 MODELS_DIR = Path(__file__).resolve().parent / 'models'
 TG_INPUT_DEVICES_PATH = MODELS_DIR / 'tg_input_devices.json'
@@ -50,7 +50,7 @@ def usbgpu_present() -> bool:
     try:
       usb_id = (int((d / "idVendor").read_text(), 16), int((d / "idProduct").read_text(), 16))
       product = (d / "product").read_text().strip()
-      if usb_id in CHESTNUT_USB_IDS and product == f"custom {CHESTNUT_FW_VERSION}-CLEAN":
+      if is_chestnut_ready(*usb_id, product):
         return True
     except Exception:
       pass

--- a/openpilot/sunnypilot/models/default_model.py
+++ b/openpilot/sunnypilot/models/default_model.py
@@ -3,13 +3,15 @@ import os
 import hashlib
 
 from openpilot.common.basedir import BASEDIR
+from openpilot.common.hardware.usb import is_chestnut_ready
 from openpilot.selfdrive.ui.ui_state import ui_state
 from openpilot.sunnypilot import get_file_hash
 from openpilot.sunnypilot.models.model_name import DEFAULT_MODEL, DEFAULT_BIG_MODEL
 
 
 def get_default_model() -> str:
-  show_big_model = (ui_state.usbgpu and ui_state.usbgpu_compiled
+  usb_devices = ui_state.sm["deviceState"].usbState.devices
+  show_big_model = (any(is_chestnut_ready(d.vendorId, d.productId, d.product) for d in usb_devices)
                     and (ui_state.usbgpu_active or ui_state.usbgpu_loading or ui_state.is_offroad()))
 
   return DEFAULT_BIG_MODEL if show_big_model else DEFAULT_MODEL

--- a/openpilot/sunnypilot/models/default_model.py
+++ b/openpilot/sunnypilot/models/default_model.py
@@ -10,9 +10,11 @@ from openpilot.sunnypilot.models.model_name import DEFAULT_MODEL, DEFAULT_BIG_MO
 
 
 def get_default_model() -> str:
-  usb_devices = ui_state.sm["deviceState"].usbState.devices
-  show_big_model = (any(is_chestnut_ready(d.vendorId, d.productId, d.product) for d in usb_devices)
-                    and (ui_state.usbgpu_active or ui_state.usbgpu_loading or ui_state.is_offroad()))
+  is_offroad = ui_state.is_offroad()
+  usbgpu_ready = (any(is_chestnut_ready(d.vendorId, d.productId, d.product) for d in ui_state.sm["deviceState"].usbState.devices)
+                  if is_offroad else ui_state.usbgpu)
+  show_big_model = (usbgpu_ready and ui_state.usbgpu_compiled
+                    and (ui_state.usbgpu_active or ui_state.usbgpu_loading or is_offroad))
 
   return DEFAULT_BIG_MODEL if show_big_model else DEFAULT_MODEL
 


### PR DESCRIPTION
## Summary
The default model name did not update in the UI when Chestnut was hot plugged while offroad.

Use the shared Chestnut readiness check so the model catalog and default model label respond consistently to offroad eGPU hot plug.

## Verification
- Ran unit tests
- Verified behavior on tizi UI
    - Connect Chestnut: model catalog and default model label update to display big models
    - Disconnect Chestnut: model catalog and default model label update to display small models