### PR TITLE
Fix the direction of the speed limit confirmation prompt

### DIFF
--- a/openpilot/sunnypilot/selfdrive/selfdrived/events.py
+++ b/openpilot/sunnypilot/selfdrive/selfdrived/events.py
@@ -11,6 +11,7 @@ from openpilot.common.constants import CV
 from openpilot.sunnypilot.selfdrive.selfdrived.events_base import EventsBase, Priority, ET, Alert, \
   NoEntryAlert, ImmediateDisableAlert, EngagementAlert, NormalPermanentAlert, AlertCallbackType, wrong_car_mode_alert
 from openpilot.sunnypilot.selfdrive.controls.lib.speed_limit import PCM_LONG_REQUIRED_MAX_SET_SPEED, CONFIRM_SPEED_THRESHOLD
+from openpilot.sunnypilot.selfdrive.controls.lib.speed_limit.helpers import compare_cluster_target
 from openpilot.common.hardware import HARDWARE
 
 AlertSize = log.SelfdriveState.AlertSize
@@ -42,7 +43,6 @@ def speed_limit_pre_active_alert(CP: car.CarParams, CS: car.CarState, sm: messag
   speed_conv = CV.MS_TO_KPH if metric else CV.MS_TO_MPH
   v_cruise_cluster = CS.vCruiseCluster
   set_speed = sm['controlsState'].deprecated.vCruise if v_cruise_cluster == 0.0 else v_cruise_cluster
-  set_speed_conv = round(set_speed * speed_conv)
 
   speed_limit_final_last = sm['longitudinalPlanSP'].speedLimit.resolver.speedLimitFinalLast
   speed_limit_final_last_conv = round(speed_limit_final_last * speed_conv)
@@ -59,9 +59,10 @@ def speed_limit_pre_active_alert(CP: car.CarParams, CS: car.CarState, sm: messag
     alert_1_str = f"Speed Limit Assist: set to {pcm_long_required_max_set_speed_conv} {speed_unit} to engage"
   else:
     if IS_MICI:
-      if set_speed_conv < speed_limit_final_last_conv:
+      req_plus, req_minus = compare_cluster_target(set_speed * CV.KPH_TO_MS, speed_limit_final_last, metric)
+      if req_plus:
         alert_1_str = "Press + to confirm speed limit"
-      elif set_speed_conv > speed_limit_final_last_conv:
+      elif req_minus:
         alert_1_str = "Press - to confirm speed limit"
     else:
       alert_size = AlertSize.none


### PR DESCRIPTION
`speed_limit_pre_active_alert()` scales `CS.vCruiseCluster` by `MS_TO_KPH`, but
`card.py` already publishes that field in km/h:

```python
CS.vCruiseCluster = float(self.v_cruise_helper.v_cruise_cluster_kph)
```

`speedLimitFinalLast` is in m/s, so only one of the two operands needed
converting. The set speed ends up 3.6x too large and the +/- crossover moves
from `set == limit` to `set == limit / 3.6`.

`update_speed_limit_assist_pre_active_confirmed()` decides which button
actually confirms via `compare_cluster_target()`, which converts correctly, so
the prompt and the button disagree: below the limit the alert asks for `-`, but
only `+` confirms. Pressing `-` decrements the set speed,
`v_cruise_cluster_changed` fires, and the state machine drops to `inactive` —
under `CONFIRM_SPEED_THRESHOLD` the assist never engages.

This uses the same helper for the text, so the two cannot disagree.

Note this only surfaces on mici. The whole comparison sits inside `if IS_MICI:`
and every other device takes the `else` branch, which renders no prompt at all.

### Evidence

689 qlogs from a MQB Evo car on openpilot longitudinal, non-PCM. Two of the
observed cases were reversed:

| set | limit | samples | shown | correct |
|----:|------:|--------:|:-----:|:-------:|
| 60 | 70 | 108 | - | + |
| 55 | 100 | 67 | - | + |

`+` shows only when `set * 3.6 < limit`, which is why the one correct `+` in
the whole dataset is at set 20 / limit 100.

Replaying every logged (set, limit) pair through the patched function: all 16
distinct rows match the correct direction, the two reversed ones flip, and the
previously-correct ones are unchanged.
