### PR TITLE
Don't re-announce a speed limit that is already set

### DIFF
--- a/openpilot/sunnypilot/selfdrive/controls/lib/speed_limit/speed_limit_assist.py
+++ b/openpilot/sunnypilot/selfdrive/controls/lib/speed_limit/speed_limit_assist.py
@@ -121,6 +121,9 @@ class SpeedLimitAssist:
     return bool(self.v_cruise_cluster_conv < CONFIRM_SPEED_THRESHOLD[self.is_metric])
 
   def update_active_event(self, events_sp: EventsSP) -> None:
+    if self.target_set_speed_confirmed:
+      return
+
     if self.v_cruise_cluster_below_confirm_speed_threshold:
       events_sp.add(EventNameSP.speedLimitChanged)
     else:
@@ -373,11 +376,8 @@ class SpeedLimitAssist:
 
       # only notify if we acquire a valid speed limit
       # do not check has_speed_limit here
-      elif self._speed_limit != self.speed_limit_prev:
-        if self.speed_limit_prev <= 0:
-          self.update_active_event(events_sp)
-        elif self.speed_limit_prev > 0 and self._speed_limit > 0:
-          self.update_active_event(events_sp)
+      elif self._speed_limit != self.speed_limit_prev and self._speed_limit > 0:
+        self.update_active_event(events_sp)
 
   def update(self, long_enabled: bool, long_override: bool, v_ego: float, a_ego: float, v_cruise_cluster: float, speed_limit: float,
              speed_limit_final_last: float, has_speed_limit: bool, distance: float, events_sp: EventsSP) -> None:


### PR DESCRIPTION
`update_active_event()` announces on every change to a nonzero limit without
ever comparing it against the current set speed. Any source that drops out and
comes back re-reports the same value and announces it again; so does a genuine
limit change that happens to land on the speed already set.

Across 689 qlogs, 1335 announcements fired with the set speed already equal to
the limit. 564 of them fired while no source was live at all, running on the
retained `speedLimitFinalLast` — the problem is not specific to any one source.

One 60 s segment, set speed held at 100 and the limit resolving to 100
throughout:

```
  0.00s  src=map   limit= 100 final_last= 100 state=inactive
  8.49s  src=none  limit=   0 final_last= 100 state=disabled
 13.49s  src=map   limit= 100 final_last= 100 state=active     <- announce
 33.49s  src=none  limit=   0 final_last= 100 state=active
 44.49s  src=map   limit= 100 final_last= 100 state=active     <- announce
```

The alert was up for 136 of the segment's frames. This affects every device —
the announcement is not gated on hardware.

Returning early when `target_set_speed_confirmed` silences that segment
completely, while a genuine 100 -> 80 change still announces once.

The two nested branches under the `elif` both called the same function and
their union is just "new limit > 0", so they collapse into the condition. That
part is a no-op.
