### PR TITLE
models: only write chunk manifests when the chunks exist locally

### DIFF
--- a/openpilot/sunnypilot/models/fetcher.py
+++ b/openpilot/sunnypilot/models/fetcher.py
@@ -12,6 +12,7 @@ from requests.exceptions import (SSLError, RequestException, HTTPError)
 from openpilot.common.params import Params
 from openpilot.common.swaglog import cloudlog
 from openpilot.common.hardware.hw import Paths
+from openpilot.common.file_chunker import get_chunk_name
 from openpilot.sunnypilot.models.helpers import is_bundle_version_compatible
 from openpilot.cereal import custom
 
@@ -48,7 +49,13 @@ class ModelParser:
         manifest_path = os.path.join(model_dir, f"{artifact.fileName}.chunkmanifest")
         num_chunks = str(len(artifact.chunks))
 
-        if not os.path.exists(manifest_path) or open(manifest_path).read().strip() != num_chunks:
+        # a manifest describes chunk files on disk (file_chunker writes one only after
+        # writing the chunks): writing it for artifacts that were never downloaded lets
+        # it shadow a whole-file model in open_file_chunked(), and lets two catalog
+        # entries that share a file_name with different chunk counts rewrite it on
+        # every parse
+        first_chunk = os.path.join(model_dir, get_chunk_name(artifact.fileName, 0, len(artifact.chunks)))
+        if os.path.exists(first_chunk) and (not os.path.exists(manifest_path) or open(manifest_path).read().strip() != num_chunks):
           with open(manifest_path, "w") as f:
             f.write(num_chunks)
           cloudlog.info(f"Wrote chunk manifest for {artifact.fileName}: {num_chunks} chunks")


### PR DESCRIPTION
**Description**

`ModelParser._parse_artifact` writes `{fileName}.chunkmanifest` for every chunked artifact on every catalog parse, whether or not the artifact was ever downloaded. The write-if-changed guard (from #1887) can't prevent rewrites when two catalog entries share a `file_name` with *different* chunk counts — and the live `driving_models_v21.json` has exactly that pair:

- Planplus Model (November 28, 2025) — `driving_pm_tinygrad.pkl`, **5** chunks
- Pop Model (March 20, 2026) — `driving_pm_tinygrad.pkl`, **4** chunks

Every parse flips that manifest between `5` and `4`, emitting a `cloudlog.info` line each time. Measured on a comma four: ~2 writes/sec whenever the fetcher polls, ~93% of all swaglog bytes, log retention crushed to ~2 hours, and continuous flash writes while parked.

It's also a correctness hazard, not just log volume: `file_chunker.open_file_chunked()` prefers the manifest over an assembled file, so a manifest written for a never-downloaded artifact can shadow a whole-file model, and the alternating content can describe the wrong chunk set at the moment a model is opened.

The fix gates the write on the artifact's own first chunk (`chunk01ofNN`) existing locally — a manifest describes chunk files on disk, which is the invariant `file_chunker.chunk_file()` already maintains (it writes the manifest only after writing the chunks). Keying the existence check on the artifact's own chunk count also makes the manifest converge to whichever variant is actually downloaded when file names collide.

Side note for sunnypilot-models: two bundles sharing one `file_name` collide in `Paths.model_root()` regardless of this fix (chunks, manifest, and assembled file are all keyed by name) — probably worth de-duplicating in the catalog as well. Happy to file that separately if useful.

**Verification**

Running on a comma four (mici) since 2026-08-28 with an equivalent patch:

- Before: ~360 `Wrote chunk manifest` lines by minute 3 of an offroad boot, alternating `driving_pm_tinygrad.pkl: 5` / `: 4`.
- After: 0 manifest writes offroad; manifests still present and correct for downloaded artifacts; chunked model loads verified on both the qcom and USBGPU bundle slots across multiple reboots.
- The spurious-manifest state is easy to confirm on any device: `ls /data/media/0/models/*.chunkmanifest` shows manifests for artifacts that have no chunks on disk.

Per docs/AI_POLICY.md: developed with Claude's assistance (disclosed in the commit trailer); I've reviewed, understand, and field-tested the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
