### PR TITLE
[MICI] ui: always-on driving personality indicator

### DIFF
--- a/openpilot/common/params_keys.h
+++ b/openpilot/common/params_keys.h
@@ -183,6 +183,7 @@ inline static std::unordered_map<std::string, ParamKeyAttributes> keys = {
     {"ScreenSaverEnabled", {PERSISTENT | BACKUP, BOOL, "1"}},
     {"ScreenSaverTimeout", {PERSISTENT | BACKUP, INT, "300"}},
     {"ShowAdvancedControls", {PERSISTENT | BACKUP, BOOL, "0"}},
+    {"ShowDrivingPersonality", {PERSISTENT | BACKUP, BOOL, "0"}},
     {"ShowTurnSignals", {PERSISTENT | BACKUP, BOOL, "0"}},
     {"StandstillTimer", {PERSISTENT | BACKUP, BOOL, "0"}},
     {"TrueVEgoUI", {PERSISTENT | BACKUP, BOOL, "0"}},

--- a/openpilot/selfdrive/ui/sunnypilot/mici/onroad/hud_renderer.py
+++ b/openpilot/selfdrive/ui/sunnypilot/mici/onroad/hud_renderer.py
@@ -8,20 +8,24 @@ import pyray as rl
 
 from openpilot.selfdrive.ui.mici.onroad.hud_renderer import HudRenderer
 from openpilot.selfdrive.ui.sunnypilot.onroad.blind_spot_indicators import BlindSpotIndicators
+from openpilot.selfdrive.ui.sunnypilot.onroad.personality_indicator import PersonalityIndicator
 
 
 class HudRendererSP(HudRenderer):
   def __init__(self):
     super().__init__()
     self.blind_spot_indicators = BlindSpotIndicators()
+    self.personality_indicator = PersonalityIndicator()
 
   def _update_state(self) -> None:
     super()._update_state()
     self.blind_spot_indicators.update()
+    self.personality_indicator.update()
 
   def _render(self, rect: rl.Rectangle) -> None:
     super()._render(rect)
     self.blind_spot_indicators.render(rect)
+    self.personality_indicator.render(rect, can_draw=self._can_draw_top_icons)
 
   def _has_blind_spot_detected(self) -> bool:
 

--- a/openpilot/selfdrive/ui/sunnypilot/onroad/personality_indicator.py
+++ b/openpilot/selfdrive/ui/sunnypilot/onroad/personality_indicator.py
@@ -1,0 +1,56 @@
+"""
+Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+"""
+import pyray as rl
+
+from openpilot.selfdrive.ui.ui_state import ui_state
+from openpilot.system.ui.lib.application import gui_app
+from openpilot.common.filter_simple import FirstOrderFilter
+
+
+class PersonalityIndicator:
+  """Always-visible driving personality chip: one filled bar for aggressive,
+  two for standard, three for relaxed - the factory follow-distance idiom.
+
+  Personality comes live from selfdriveState, so wheel-button and settings
+  changes reflect within a frame with no extra param polling."""
+
+  WIDTH, HEIGHT = 78, 40
+  BAR_W, BAR_H, BAR_GAP = 14, 24, 7
+  MARGIN_X, MARGIN_Y = 10, 14
+
+  def __init__(self):
+    self._personality: int = -1
+    self._flash_filter = FirstOrderFilter(0.0, 0.3, 1 / gui_app.target_fps)
+
+  def update(self) -> None:
+    personality = int(ui_state.sm['selfdriveState'].personality.raw)
+    if personality != self._personality:
+      if self._personality >= 0:
+        self._flash_filter.x = 1.0  # brief highlight so a change is noticeable
+      self._personality = personality
+
+  def render(self, rect: rl.Rectangle, can_draw: bool = True) -> None:
+    # personality only exists with openpilot longitudinal control, and alerts
+    # own the screen (can_draw is the same yield the set speed uses)
+    if not ui_state.show_driving_personality or not ui_state.has_longitudinal_control:
+      return
+    if not can_draw or self._personality < 0:
+      return
+
+    filled = self._personality + 1  # aggressive=0 -> 1 bar ... relaxed=2 -> 3 bars
+    x = rect.x + rect.width - self.MARGIN_X - self.WIDTH
+    y = rect.y + self.MARGIN_Y
+    flash = self._flash_filter.update(0.0)
+    bg = rl.Color(255, 255, 255, int(255 * (0.14 + 0.45 * flash)))
+    rl.draw_rectangle_rounded(rl.Rectangle(x, y, self.WIDTH, self.HEIGHT), 0.5, 8, bg)
+
+    bar_x = x + (self.WIDTH - 3 * self.BAR_W - 2 * self.BAR_GAP) / 2
+    bar_y = y + (self.HEIGHT - self.BAR_H) / 2
+    for i in range(3):
+      bar = rl.Rectangle(bar_x + i * (self.BAR_W + self.BAR_GAP), bar_y, self.BAR_W, self.BAR_H)
+      color = rl.Color(0, 145, 255, 235) if i < filled else rl.Color(255, 255, 255, 55)
+      rl.draw_rectangle_rounded(bar, 0.35, 6, color)

--- a/openpilot/selfdrive/ui/sunnypilot/ui_state.py
+++ b/openpilot/selfdrive/ui/sunnypilot/ui_state.py
@@ -46,6 +46,7 @@ class UIStateSP:
     self.active_bundle = None
     self.model_runner_tinygrad: bool = False
     self.blindspot: bool = False
+    self.show_driving_personality: bool = False
     self.chevron_metrics = None
     self.custom_interactive_timeout: int = 0
     self.developer_ui = None
@@ -160,6 +161,7 @@ class UIStateSP:
     # chestnut just the same, so ChestnutState has to see it as available too.
     self.chestnut_compiled = self.chestnut_compiled or self.model_runner_tinygrad
     self.blindspot = self.params.get_bool("BlindSpot")
+    self.show_driving_personality = self.params.get_bool("ShowDrivingPersonality")
     self.chevron_metrics = self.params.get("ChevronInfo")
     self.custom_interactive_timeout = self.params.get("InteractivityTimeout", return_default=True)
     self.developer_ui = self.params.get("DevUIInfo")

--- a/openpilot/sunnypilot/sunnylink/settings_ui.json
+++ b/openpilot/sunnypilot/sunnylink/settings_ui.json
@@ -417,7 +417,7 @@
                   "min": 0.1,
                   "max": 5.0,
                   "step": 0.1,
-                  "unit": "m/s\u00c2\u00b2",
+                  "unit": "m/s\u00b2",
                   "enablement": [
                     {
                       "type": "param",

--- a/openpilot/sunnypilot/sunnylink/settings_ui.json
+++ b/openpilot/sunnypilot/sunnylink/settings_ui.json
@@ -417,7 +417,7 @@
                   "min": 0.1,
                   "max": 5.0,
                   "step": 0.1,
-                  "unit": "m/s\u00b2",
+                  "unit": "m/s\u00c2\u00b2",
                   "enablement": [
                     {
                       "type": "param",
@@ -1388,6 +1388,26 @@
               "widget": "toggle",
               "title": "Display Turn Signals",
               "description": "When enabled, visual turn indicators are drawn on the HUD."
+            },
+            {
+              "key": "ShowDrivingPersonality",
+              "widget": "toggle",
+              "title": "Display Driving Personality",
+              "description": "Show the current driving personality on the driving screen as follow-distance bars - one bar for Aggressive, two for Standard, three for Relaxed. Updates live when the personality is changed from settings or the steering wheel distance button.",
+              "visibility": [
+                {
+                  "type": "capability",
+                  "field": "device_type",
+                  "equals": "mici"
+                }
+              ],
+              "enablement": [
+                {
+                  "type": "capability",
+                  "field": "has_longitudinal_control",
+                  "equals": true
+                }
+              ]
             },
             {
               "key": "RoadNameToggle",

--- a/openpilot/sunnypilot/sunnylink/settings_ui_src/pages/visuals.yaml
+++ b/openpilot/sunnypilot/sunnylink/settings_ui_src/pages/visuals.yaml
@@ -24,6 +24,16 @@ sections:
     widget: toggle
     title: Display Turn Signals
     description: When enabled, visual turn indicators are drawn on the HUD.
+  - key: ShowDrivingPersonality
+    widget: toggle
+    title: Display Driving Personality
+    description: Show the current driving personality on the driving screen as follow-distance bars - one bar for Aggressive,
+      two for Standard, three for Relaxed. Updates live when the personality is changed from settings or the steering wheel
+      distance button.
+    visibility:
+    - {type: capability, field: device_type, equals: mici}
+    enablement:
+    - $ref: '#/macros/longitudinal'
   - key: RoadNameToggle
     widget: toggle
     title: Display Road Name


### PR DESCRIPTION
### Summary of Changes

Adds an always-visible driving personality indicator to the mici driving screen, as requested
by @sunnyhaibin.

1. New `PersonalityIndicator` component (modeled on `BlindSpotIndicators`): three
   follow-distance bars in the top-right of the driving screen — one filled bar for
   Aggressive, two for Standard, three for Relaxed — with a brief highlight when the
   personality changes.
2. Personality is read live from `selfdriveState`, so changes from the steering-wheel
   distance button or settings reflect within a frame; no control-stack changes needed.
3. Gated behind a new `ShowDrivingPersonality` toggle (default off), `PERSISTENT | BACKUP`
   so it participates in sunnylink backup/restore; sunnylink web settings entry added under
   Visuals → HUD Elements (mici-only visibility, enabled with longitudinal control).
4. The indicator yields to alerts via the existing `can_draw_top_icons` flag and hides when
   openpilot longitudinal control is unavailable. All logic lives in the sunnypilot overlay
   (`HudRendererSP` gets a 4-line hook); no base openpilot files are touched.

The component is deliberately shareable — big-UI (tizi/tici) support is a small follow-up
(`HudRendererSP` hook + a settings row) that I've left out because I can only verify in-vehicle
on a comma four.

### Verification

- The indicator itself (same geometry, colors, live `selfdriveState` personality source,
  change flash, and alert yield) has been running for ~2 weeks on my comma four (Prius Prime,
  daily driver) as a fork implementation in the base renderer — that's the version this PR
  restructures into the sunnypilot overlay with the toggle added.
- This exact tree: python compiles and lints clean; `compile_settings_ui.py --check` passes on
  the regenerated `settings_ui.json`.
- I have not flashed this PR branch to my device (it runs my daily-driver fork). Happy to
  iterate on anything review or in-vehicle testing turns up.

### Notes

- Happy to add an on-device settings row for mici if preferred — I followed the existing
  convention where SP visual toggles reach mici users via the sunnylink web settings
  (BlindSpot, RainbowMode, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
