### PR TITLE
fix(sunnylink): convert lane turn speed for metric display

### DIFF
--- a/openpilot/sunnypilot/sunnylink/docs/README.md
+++ b/openpilot/sunnypilot/sunnylink/docs/README.md
@@ -131,6 +131,7 @@ The tables below describe the **compiled** `settings_ui.json` schema — what th
 | `options` | For selectors | Array of `{"value": 0, "label": "Off"}` objects (see per-option enablement below) |
 | `min`, `max`, `step` | For sliders | Numeric range constraints |
 | `unit` | No | Unit label. Static: `"seconds"`. Dynamic: `{"metric": "km/h", "imperial": "mph"}` (resolved by IsMetric) |
+| `value_transform` | No | Per-unit display transform for parameters stored in one canonical unit |
 | `visibility` | No | Rules for show/hide. Settings are never hidden, always dimmed with UNAVAILABLE badge when rules fail |
 | `enablement` | No | Rules for enabled/disabled (all must pass). Dimmed with badge when rules fail |
 | `blocked` | No | `true` for device-only settings that cannot be modified remotely. Frontend shows as read-only |
@@ -266,6 +267,22 @@ For an item that is intentionally minimal inline (no inline body, only the modal
 ```
 
 Frontend resolves the unit string based on the device's `IsMetric` param. Static units (e.g. `seconds`, `m/s²`) stay plain strings.
+
+If a parameter is always stored in one canonical unit, declare how Sunnylink should transform its numeric value for each display system:
+
+```yaml
+- key: LaneTurnValue
+  widget: option
+  min: 0
+  max: 20
+  step: 1
+  unit: {metric: km/h, imperial: mph}
+  value_transform:
+    metric: {scale: 1.609344, precision: 0, step: 1}
+    imperial: {scale: 1, precision: 0, step: 1}
+```
+
+Sunnylink multiplies stored values and bounds by `scale`, rounds them to `precision`, and uses the optional display-space `step`. Choose a step on the same decimal grid as the declared precision (for example, `step: 0.1` with `precision: 1`) so every rounded value is valid for the native range input. Writes divide the displayed value by the active scale so storage semantics remain unchanged. Do not add this field to parameters whose stored unit already follows `IsMetric`.
 
 ### Add a dynamic title suffix
 

--- a/openpilot/sunnypilot/sunnylink/settings_ui.json
+++ b/openpilot/sunnypilot/sunnylink/settings_ui.json
@@ -2052,6 +2052,18 @@
                 "metric": "km/h",
                 "imperial": "mph"
               },
+              "value_transform": {
+                "metric": {
+                  "scale": 1.609344,
+                  "precision": 0,
+                  "step": 1
+                },
+                "imperial": {
+                  "scale": 1,
+                  "precision": 0,
+                  "step": 1
+                }
+              },
               "enablement": [
                 {
                   "type": "param",

--- a/openpilot/sunnypilot/sunnylink/settings_ui.schema.json
+++ b/openpilot/sunnypilot/sunnylink/settings_ui.schema.json
@@ -239,6 +239,9 @@
           ],
           "description": "Unit label for numeric values. Use a string for static units or an object with metric/imperial variants for units that depend on the IsMetric param."
         },
+        "value_transform": {
+          "$ref": "#/$defs/ValueTransformByUnit"
+        },
         "value_map": {
           "type": "object",
           "description": "Maps stored values to display labels.",
@@ -335,6 +338,43 @@
           "items": {
             "$ref": "#/$defs/SchemaItem"
           }
+        }
+      }
+    },
+    "ValueTransformByUnit": {
+      "type": "object",
+      "description": "Transforms a canonical stored numeric value for the selected unit system. Display values equal stored values multiplied by scale and rounded to precision; writes apply the inverse scale.",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "metric": {
+          "$ref": "#/$defs/ValueTransform"
+        },
+        "imperial": {
+          "$ref": "#/$defs/ValueTransform"
+        }
+      }
+    },
+    "ValueTransform": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["scale", "precision"],
+      "properties": {
+        "scale": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Multiplier from the canonical stored value to the display value."
+        },
+        "precision": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 10,
+          "description": "Number of decimal places shown after applying scale."
+        },
+        "step": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Optional display-space slider step override. It must use the same decimal grid as precision so rounded values remain valid range values."
         }
       }
     },

--- a/openpilot/sunnypilot/sunnylink/settings_ui_src/_schemas/page.schema.json
+++ b/openpilot/sunnypilot/sunnylink/settings_ui_src/_schemas/page.schema.json
@@ -88,6 +88,7 @@
             }
           ]
         },
+        "value_transform": {"$ref": "#/$defs/ValueTransformByUnit"},
         "needs_onroad_cycle": {"type": "boolean"},
         "requires_attestation": {"type": "boolean"},
         "blocked": {"type": "boolean"},
@@ -107,6 +108,30 @@
         "visibility": {"type": "array", "items": {"$ref": "rule.schema.json"}},
         "enablement": {"type": "array", "items": {"$ref": "rule.schema.json"}},
         "sub_items": {"type": "array", "items": {"$ref": "#/$defs/Item"}}
+      }
+    },
+    "ValueTransformByUnit": {
+      "type": "object",
+      "description": "Converts canonical stored numeric values for display according to IsMetric.",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "metric": {"$ref": "#/$defs/ValueTransform"},
+        "imperial": {"$ref": "#/$defs/ValueTransform"}
+      }
+    },
+    "ValueTransform": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["scale", "precision"],
+      "properties": {
+        "scale": {"type": "number", "exclusiveMinimum": 0},
+        "precision": {"type": "integer", "minimum": 0, "maximum": 10},
+        "step": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Display-space step; keep it on the decimal grid declared by precision."
+        }
       }
     }
   }

--- a/openpilot/sunnypilot/sunnylink/settings_ui_src/pages/models.yaml
+++ b/openpilot/sunnypilot/sunnylink/settings_ui_src/pages/models.yaml
@@ -27,6 +27,9 @@ sections:
     unit:
       metric: km/h
       imperial: mph
+    value_transform:
+      metric: {scale: 1.609344, precision: 0, step: 1}
+      imperial: {scale: 1, precision: 0, step: 1}
     enablement:
     - type: param
       key: LaneTurnDesire

--- a/openpilot/sunnypilot/sunnylink/tests/test_settings_changes.py
+++ b/openpilot/sunnypilot/sunnylink/tests/test_settings_changes.py
@@ -207,6 +207,20 @@ class TestSpuriousOffroadGatesDropped(OpenpilotTestCase):
     assert "offroad_only" not in _flatten_rule_types(item.get("enablement"))
 
 
+class TestLaneTurnValueUnits(OpenpilotTestCase):
+  def test_metric_display_preserves_mph_storage(self, schema):
+    item = _find_item(schema, "LaneTurnValue")
+    assert item is not None
+    assert item["max"] == 20
+    assert item["unit"] == {"metric": "km/h", "imperial": "mph"}
+    assert item["value_transform"] == {
+      "metric": {"scale": 1.609344, "precision": 0, "step": 1},
+      "imperial": {"scale": 1, "precision": 0, "step": 1},
+    }
+    metric = item["value_transform"]["metric"]
+    assert round(item["max"] * metric["scale"], metric["precision"]) == 32
+
+
 class TestNotEngagedReplacement(OpenpilotTestCase):
   @parameterized.expand([
     "AlphaLongitudinalEnabled",

--- a/openpilot/sunnypilot/sunnylink/tools/compile_settings_ui.py
+++ b/openpilot/sunnypilot/sunnylink/tools/compile_settings_ui.py
@@ -118,6 +118,7 @@ _ITEM_KEY_ORDER = [
   "max",
   "step",
   "unit",
+  "value_transform",
   "options",
   "visibility",
   "enablement",


### PR DESCRIPTION
## Summary

- add an optional per-unit display transform to the Sunnylink settings schema
- declare `LaneTurnValue` as canonical mph with integer metric and imperial display transforms
- keep the stored 0–20 mph range and vehicle-side runtime semantics unchanged
- document and validate the transform contract, including display precision and step-grid requirements

## Why

`LaneTurnValue` is always stored and interpreted as mph. Sunnylink previously changed its label to km/h under `IsMetric` without converting the value or range, so metric users still saw 0–20 instead of 0–32.

The companion frontend implementation is sunnypilot/sunnylink-frontend#101. It converts values only for display, inverse-converts deliberate writes, and prevents rounded boundary no-ops from changing the canonical setting. The frontend change is backward compatible and can be merged/deployed before this schema metadata.

Fixes #1888.

## Testing

- Sunnylink compile/settings/schema tests — 59 passed
- lane-turn desire runtime tests — 19 passed
- settings compiler `--check`
- settings validator — 10 checks passed
- full SCons build on macOS
- full lint suite except the existing macOS/LFS shebang false positive for `openpilot/common/hardware/comma/updater`; all other checks passed

Assisted by OpenAI Codex; the commit includes the required disclosure.
