### PR TITLE
models: preserve verified chunks and retry interrupted downloads

### DIFF
--- a/openpilot/sunnypilot/models/manager.py
+++ b/openpilot/sunnypilot/models/manager.py
@@ -154,6 +154,41 @@ class ModelManagerSP:
     del self._download_start_times[artifact.fileName]
 
   async def _process_artifact(self, artifact, destination_path: str) -> None:
+    # retry transient failures, including errors while streaming the body.
+    # Rechecking hashes on each attempt preserves complete chunks without trusting partials.
+    try:
+      for attempt in range(4):
+        try:
+          await self._process_artifact_once(artifact, destination_path)
+          return
+        except (requests.ConnectionError, requests.Timeout, requests.exceptions.ChunkedEncodingError, requests.HTTPError) as e:
+          if isinstance(e, requests.HTTPError) and (e.response is None or e.response.status_code not in (408, 429, 500, 502, 503, 504)):
+            raise
+          if attempt == 3:
+            raise
+          delay = 2 ** (attempt + 1)
+          cloudlog.warning(f"Retrying {artifact.fileName} in {delay}s: {e}")
+          for _ in range(delay * 4):
+            if self._download_interrupted():
+              raise DownloadCancelled("Download cancelled") from e
+            await asyncio.sleep(0.25)
+    except DownloadCancelled:
+      raise
+    except Exception as e:
+      # Keep files for the next attempt; only SHA-verified content is ever reused.
+      cloudlog.error(f"Error downloading {artifact.fileName}: {e}")
+      artifact.downloadProgress.status = custom.ModelManagerSP.DownloadStatus.failed
+      artifact.downloadProgress.eta = 0
+      self._sync_artifact_progress(artifact)
+      if self.selected_bundle:
+        self.selected_bundle.status = custom.ModelManagerSP.DownloadStatus.failed
+      self._report_status()
+      raise
+    finally:
+      self._download_start_times.pop(artifact.fileName, None)
+
+  # one verified attempt, shared by initial downloads and retries.
+  async def _process_artifact_once(self, artifact, destination_path: str) -> None:
     if not artifact.downloadUri.uri:
       return None
     if self._download_interrupted():
@@ -164,78 +199,58 @@ class ModelManagerSP:
     filename = artifact.fileName
     full_path = os.path.join(destination_path, filename)
 
-    try:
-      # progress counts only valid chunks so a resumed download continues the
-      # bar from where verification left it, instead of falling back to zero
-      is_cached = False
-      valid_chunks: set[int] = set()
-      if len(artifact.chunks) > 0:
-        from openpilot.common.file_chunker import get_chunk_name
-        num_chunks = len(artifact.chunks)
-        for i, chunk in enumerate(artifact.chunks):
-          if self._download_interrupted():
-            raise DownloadCancelled("Download cancelled")
-          if await verify_file(get_chunk_name(full_path, i, num_chunks), chunk.sha256):
-            valid_chunks.add(i)
-          artifact.downloadProgress.status = custom.ModelManagerSP.DownloadStatus.verifying
-          artifact.downloadProgress.progress = (len(valid_chunks) / num_chunks) * 100
-          self._sync_artifact_progress(artifact)
-          self._report_status()
-        is_cached = len(valid_chunks) == num_chunks
-      else:
-        if await verify_file(full_path, expected_hash):
-          is_cached = True
-
-      if is_cached:
-        artifact.downloadProgress.status = custom.ModelManagerSP.DownloadStatus.cached
-        artifact.downloadProgress.progress = 100
-        artifact.downloadProgress.eta = 0
+    # progress counts only valid chunks so a resumed download continues the
+    # bar from where verification left it, instead of falling back to zero
+    is_cached = False
+    valid_chunks: set[int] = set()
+    if len(artifact.chunks) > 0:
+      from openpilot.common.file_chunker import get_chunk_name
+      num_chunks = len(artifact.chunks)
+      for i, chunk in enumerate(artifact.chunks):
+        if self._download_interrupted():
+          raise DownloadCancelled("Download cancelled")
+        if await verify_file(get_chunk_name(full_path, i, num_chunks), chunk.sha256):
+          valid_chunks.add(i)
+        artifact.downloadProgress.status = custom.ModelManagerSP.DownloadStatus.verifying
+        artifact.downloadProgress.progress = (len(valid_chunks) / num_chunks) * 100
         self._sync_artifact_progress(artifact)
         self._report_status()
-        return
+      is_cached = len(valid_chunks) == num_chunks
+    else:
+      if await verify_file(full_path, expected_hash):
+        is_cached = True
 
+    if is_cached:
+      # a disconnected final response may leave all chunks but no manifest.
       if len(artifact.chunks) > 0:
-        await self._download_chunked(url, full_path, artifact, skip=valid_chunks)
-        from openpilot.common.file_chunker import get_chunk_name
-        for i, chunk in enumerate(artifact.chunks):
-          chunk_path = get_chunk_name(full_path, i, len(artifact.chunks))
-          if not await verify_file(chunk_path, chunk.sha256):
-            raise ValueError(f"Hash validation failed for chunk {i+1} of {filename}")
-      else:
-        await self._download_file(url, full_path, artifact)
-        if not await verify_file(full_path, expected_hash):
-          raise ValueError(f"Hash validation failed for {filename}")
-
-      artifact.downloadProgress.status = custom.ModelManagerSP.DownloadStatus.downloaded
+        from openpilot.common.file_chunker import get_manifest_path
+        if not os.path.exists(get_manifest_path(full_path)):  # noqa: ASYNC240
+          with open(get_manifest_path(full_path), 'w') as f:  # noqa: ASYNC230
+            f.write(str(len(artifact.chunks)))
+      artifact.downloadProgress.status = custom.ModelManagerSP.DownloadStatus.cached
       artifact.downloadProgress.progress = 100
       artifact.downloadProgress.eta = 0
       self._sync_artifact_progress(artifact)
       self._report_status()
+      return
 
-    except DownloadCancelled:
-      # a cancel keeps whatever is on disk: complete chunks resume the next attempt
-      self._download_start_times.pop(artifact.fileName, None)
-      artifact.downloadProgress.status = custom.ModelManagerSP.DownloadStatus.failed
-      artifact.downloadProgress.eta = 0
-      self._sync_artifact_progress(artifact)
-      if self.selected_bundle:
-        self.selected_bundle.status = custom.ModelManagerSP.DownloadStatus.failed
-      self._report_status()
-      raise
+    if len(artifact.chunks) > 0:
+      await self._download_chunked(url, full_path, artifact, skip=valid_chunks)
+      from openpilot.common.file_chunker import get_chunk_name
+      for i, chunk in enumerate(artifact.chunks):
+        chunk_path = get_chunk_name(full_path, i, len(artifact.chunks))
+        if not await verify_file(chunk_path, chunk.sha256):
+          raise ValueError(f"Hash validation failed for chunk {i+1} of {filename}")
+    else:
+      await self._download_file(url, full_path, artifact)
+      if not await verify_file(full_path, expected_hash):
+        raise ValueError(f"Hash validation failed for {filename}")
 
-    except Exception as e:
-      cloudlog.error(f"Error downloading {filename}: {str(e)}")
-      for f in [full_path] + [p for p in (os.path.join(destination_path, f) for f in os.listdir(destination_path)) if filename in p]:
-        if os.path.isfile(f):  # noqa: ASYNC240
-          os.remove(f)
-      artifact.downloadProgress.status = custom.ModelManagerSP.DownloadStatus.failed
-      artifact.downloadProgress.eta = 0
-      self._sync_artifact_progress(artifact)
-      if self.selected_bundle:
-        self.selected_bundle.status = custom.ModelManagerSP.DownloadStatus.failed
-      self._report_status()
-      self._download_start_times.pop(artifact.fileName, None)
-      raise
+    artifact.downloadProgress.status = custom.ModelManagerSP.DownloadStatus.downloaded
+    artifact.downloadProgress.progress = 100
+    artifact.downloadProgress.eta = 0
+    self._sync_artifact_progress(artifact)
+    self._report_status()
 
   async def _process_model(self, model, destination_path: str) -> None:
     """Processes a single model download including verification"""
@@ -309,11 +324,15 @@ class ModelManagerSP:
       self._download_ref = ref_to_download
       try:
         self.download(model_to_download, Paths.model_root(), source)
+      # cancellation clears the selection; failures remain visible until another request.
+      except DownloadCancelled:
+        self.selected_bundle = None
       except Exception as e:
         cloudlog.exception(e)
+      else:
+        self.selected_bundle = None
       finally:
         self._release_download_ref()
-        self.selected_bundle = None
 
   def main_thread(self) -> None:
     """Main thread for model management"""

--- a/openpilot/sunnypilot/models/tests/test_manager_download.py
+++ b/openpilot/sunnypilot/models/tests/test_manager_download.py
@@ -365,6 +365,12 @@ class TestManagerDownload(ManagerDownloadTestBase):
       assert DownloadHandler.request_paths == [], "cached bundle must not hit the network"
       assert [round(p) for p in self.reported[:3]] == [33, 67, 100]
       assert artifact.downloadProgress.status == custom.ModelManagerSP.DownloadStatus.cached
+      # resuming verified chunks must also restore the loader's manifest.
+      with open(get_manifest_path(base_path)) as f:
+        assert f.read() == str(len(CHUNK_BODIES))
+      os.utime(get_manifest_path(base_path), (1, 1))
+      asyncio.run(self.manager._process_artifact(artifact, self.dest))
+      assert os.stat(get_manifest_path(base_path)).st_mtime == 1, "do not rewrite a manifest a model may be reading"
     self.run_with_server(body)
 
   def _make_params_with_store(self):
@@ -415,6 +421,81 @@ class TestManagerDownload(ManagerDownloadTestBase):
       assert "ModelManager_ActiveBundle" not in store, "chestnut download must not touch the qcom slot"
       assert self.manager.selected_bundle.status == custom.ModelManagerSP.DownloadStatus.downloaded
     self.run_with_server(body)
+
+
+  # exercise retries through real HTTP bodies and the request lifecycle.
+  def test_interrupted_body_retries_without_redownloading_complete_chunks(self):
+    class InterruptedHandler(DownloadHandler):
+      def do_GET(self):
+        if self.path.endswith('.chunk02of03') and self.path not in self.request_paths:
+          type(self).request_paths.append(self.path)
+          self.send_response(200)
+          self.send_header('Content-Length', str(len(CHUNK_BODIES[1])))
+          self.end_headers()
+          self.wfile.write(CHUNK_BODIES[1][:2000])
+          self.close_connection = True
+          return
+        super().do_GET()
+
+    with http_server_context(handler=InterruptedHandler) as (host, port):
+      self.base_url = f'http://{host}:{port}'
+      artifact = self.make_artifact(chunked=True)
+      with mock.patch.object(manager_module.asyncio, 'sleep', new_callable=mock.AsyncMock):
+        asyncio.run(self.manager._process_artifact(artifact, self.dest))
+      paths = InterruptedHandler.request_paths
+      assert sum(p.endswith('.chunk01of03') for p in paths) == 1
+      assert sum(p.endswith('.chunk02of03') for p in paths) == 2
+      assert artifact.downloadProgress.status == custom.ModelManagerSP.DownloadStatus.downloaded
+      for path, expected in zip(self.chunk_paths(os.path.join(self.dest, artifact.fileName)), CHUNK_BODIES, strict=True):
+        with open(path, 'rb') as f:
+          assert f.read() == expected
+
+  def test_transient_failure_keeps_chunks_and_stays_visible(self):
+    self._check_failure_keeps_chunks_and_stays_visible(503, 4)
+
+  def test_permanent_failure_does_not_retry(self):
+    self._check_failure_keeps_chunks_and_stays_visible(404, 1)
+
+  def _check_failure_keeps_chunks_and_stays_visible(self, status, attempts):
+    def body():
+      artifact = self.make_artifact(chunked=True)
+      self._bundle.ref = 'test-ref'
+      self.manager.source_models = {'qcom': [self._bundle]}
+      params, store = self._make_params_with_store()
+      store['ModelManager_DownloadRef'] = 'test-ref'
+      params.remove.side_effect = lambda key: store.__setitem__(key, None)
+      self.manager.params = params
+      failing = '/' + os.path.basename(get_chunk_name(artifact.downloadUri.uri, 1, len(CHUNK_BODIES)))
+      DownloadHandler.fail_paths = {failing: status}
+      with mock.patch.object(manager_module.asyncio, 'sleep', new_callable=mock.AsyncMock), \
+           mock.patch.object(manager_module.Paths, 'model_root', return_value=self.dest):
+        self.manager._process_download_requests()
+        self.manager._process_download_requests()  # idle ticks must retain the failure
+      assert DownloadHandler.request_paths.count(failing) == attempts
+      assert self.manager.selected_bundle.status == custom.ModelManagerSP.DownloadStatus.failed
+      assert store['ModelManager_DownloadRef'] is None
+      assert 'ModelManager_ActiveBundle' not in store
+      path = get_chunk_name(os.path.join(self.dest, artifact.fileName), 0, len(CHUNK_BODIES))
+      with open(path, 'rb') as f:
+        assert f.read() == CHUNK_BODIES[0]
+      assert self.manager._download_start_times == {}
+    self.run_with_server(body)
+
+  def test_cancel_during_backoff_stops_retry(self):
+    def body():
+      artifact = self.make_artifact(chunked=False)
+      DownloadHandler.fail_paths = {'/driving_test_tinygrad.pkl.whole': 503}
+
+      async def cancel(_):
+        self.manager.params.get.return_value = None
+
+      with mock.patch.object(manager_module.asyncio, 'sleep', side_effect=cancel):
+        with self.assertRaises(manager_module.DownloadCancelled):
+          asyncio.run(self.manager._process_artifact(artifact, self.dest))
+      assert len(DownloadHandler.request_paths) == 1
+      self.manager.params.put.assert_not_called()
+    self.run_with_server(body)
+  # End BluePilot
 
 
 class TestManagerImports(OpenpilotTestCase):


### PR DESCRIPTION
When a model transfer times out, `_process_artifact` deletes every chunk for that artifact, including chunks that already downloaded successfully. The request loop then clears the failed selection, so the UI quickly loses the error and the next attempt starts over.

Preserve files on failure and reuse only chunks that pass the existing SHA-256 checks. Retry transient connection/body errors and HTTP 408/429/500/502/503/504 up to four total attempts, with cancellable 2/4/8-second backoff. Permanent errors fail immediately. Keep the failed selection visible until another download, and restore a missing manifest for fully verified cached chunks without rewriting an existing manifest. Activation still happens only after successful verification.

Validation:
- 24 downloader/import tests passed against this upstream manager and test file using a temporary local harness for unavailable compiled dependencies and the surrounding BluePilot compatibility modules. This is not a full native upstream test run.
- Added real HTTP regression coverage for truncated bodies, preserving completed chunks after retries are exhausted, immediate 404 failure, cancellation during backoff, persistent error status, and missing/existing manifests.
- Ruff and `git diff --check` pass.
- The equivalent implementation on BluePilot passed 60 tests on a comma device with its real extensions, plus `scons -j4`. GWM v8 downloaded, verified, and became selected. During a subsequent favorites cache fill, a DNS failure recovered automatically and a mid-transfer read timeout resumed from the verified 50% boundary.

Implementation assisted by OpenAI Codex; adversarial review of the equivalent BluePilot change by Claude Fable 5.1. No driving-control changes or driving-inference validation are included.
