### PR TITLE
modeld: misleading "Posenet Speed Invalid / Speed Error: nan m/s" and underlying fix

### DIFF
--- a/.github/workflows/build-default-models.yaml
+++ b/.github/workflows/build-default-models.yaml
@@ -35,6 +35,7 @@ jobs:
       onnx_path: ${{ steps.resolve.outputs.onnx_path }}
       hf_defaults_path: ${{ steps.resolve.outputs.hf_defaults_path }}
       tinygrad_ref: ${{ steps.resolve.outputs.tinygrad_ref }}
+      compile_ref: ${{ steps.resolve.outputs.compile_ref }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -65,6 +66,12 @@ jobs:
             exit 1
           fi
 
+          COMPILE_REF=$(python3 openpilot/sunnypilot/models/compile_ref.py)
+          if [ ${#COMPILE_REF} -ne 64 ]; then
+            echo "::error::Failed to resolve compile ref"
+            exit 1
+          fi
+
           SAFE_NAME="${NAME// /-}"
           echo "model_name=${NAME}" >> $GITHUB_OUTPUT
           echo "safe_model_name=${SAFE_NAME}" >> $GITHUB_OUTPUT
@@ -72,6 +79,7 @@ jobs:
           echo "onnx_path=${ONNX_PATH}" >> $GITHUB_OUTPUT
           echo "hf_defaults_path=${HF_DEFAULTS_PATH}" >> $GITHUB_OUTPUT
           echo "tinygrad_ref=${TINYGRAD_REF}" >> $GITHUB_OUTPUT
+          echo "compile_ref=${COMPILE_REF}" >> $GITHUB_OUTPUT
 
   build_small_model:
     needs: resolve
@@ -355,6 +363,7 @@ jobs:
             --onnx-ref "${{ needs.resolve.outputs.onnx_ref }}" \
             --model-name "${{ needs.resolve.outputs.model_name }}" \
             --tinygrad-ref "${{ needs.resolve.outputs.tinygrad_ref }}" \
+            --compile-ref "${{ needs.resolve.outputs.compile_ref }}" \
             --run-number "${{ github.run_number }}"
 
       - name: Download DM artifact
@@ -426,6 +435,7 @@ jobs:
             --onnx-ref "${{ needs.resolve.outputs.onnx_ref }}" \
             --model-name "${{ needs.resolve.outputs.model_name }}" \
             --tinygrad-ref "${{ needs.resolve.outputs.tinygrad_ref }}" \
+            --compile-ref "${{ needs.resolve.outputs.compile_ref }}" \
             --run-number "${{ github.run_number }}"
 
   build_dm_model:

--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -37,10 +37,28 @@ jobs:
       is_stable_branch: ${{ steps.strategy.outputs.is_stable_branch }}
       build: ${{ steps.strategy.outputs.build }}
       include_big_model: ${{ steps.strategy.outputs.include_big_model }}
+      compile_ref: ${{ steps.compile_ref.outputs.compile_ref }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
+      # the tree the build compiles: not this job's checkout on a pull_request_target
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          path: source
+          ref: ${{ env.SOURCE_BRANCH }}
+          repository: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.head.repo.full_name || github.repository }}
+      - name: Resolve compile ref
+        id: compile_ref
+        run: |
+          COMPILE_REF=$(PYTHONPATH=source python3 source/openpilot/sunnypilot/models/compile_ref.py)
+          if [ ${#COMPILE_REF} -ne 64 ]; then
+            echo "::error::Failed to resolve compile ref"
+            exit 1
+          fi
+          echo "compile ref: $COMPILE_REF"
+          echo "compile_ref=${COMPILE_REF}" >> $GITHUB_OUTPUT
       - name: Extract deploy strategy
         id: strategy
         run: |
@@ -239,19 +257,19 @@ jobs:
 
           TINYGRAD_REF=$(gh api "repos/${GH_REPO}/contents/tinygrad_repo?ref=${REF}" --jq '.sha')
           echo "tinygrad ref: $TINYGRAD_REF"
+          COMPILE_REF="${{ needs.prepare_strategy.outputs.compile_ref }}"
 
           JSON_URL="https://huggingface.co/datasets/${HF_REPO}/resolve/main/${HF_DEFAULTS_PATH}/default_models.json"
 
           check_defaults() {
             DEFAULTS=$(curl -fsSL "${JSON_URL}?t=$(date +%s)" 2>/dev/null) || return 1
-            TINYGRAD_MATCH=$(echo "$DEFAULTS" | jq -r --arg ref "$TINYGRAD_REF" '.tinygrad_ref == $ref' 2>/dev/null)
-            [ "$TINYGRAD_MATCH" = "true" ] || return 1
+            echo "$DEFAULTS" | jq -e --arg t "$TINYGRAD_REF" --arg c "$COMPILE_REF" '.tinygrad_ref == $t and .compile_ref == $c' >/dev/null 2>&1 || return 1
             BUNDLE=$(echo "$DEFAULTS" | jq --arg hash "$ONNX_HASH" '.bundles[] | select(.onnx_sha256 == $hash)' 2>/dev/null)
             [ -n "$BUNDLE" ] && [ "$BUNDLE" != "null" ]
           }
 
           if check_defaults; then
-            echo "HF defaults match repo ONNX hash and tinygrad ref"
+            echo "HF defaults match repo ONNX hash, tinygrad ref and compile ref"
             exit 0
           fi
 
@@ -322,19 +340,19 @@ jobs:
 
           TINYGRAD_REF=$(gh api "repos/${GH_REPO}/contents/tinygrad_repo?ref=${REF}" --jq '.sha')
           echo "tinygrad ref: $TINYGRAD_REF"
+          COMPILE_REF="${{ needs.prepare_strategy.outputs.compile_ref }}"
 
           JSON_URL="https://huggingface.co/datasets/${HF_REPO}/resolve/main/${HF_DEFAULTS_PATH}/default_models.json"
 
           check_defaults() {
             DEFAULTS=$(curl -fsSL "${JSON_URL}?t=$(date +%s)" 2>/dev/null) || return 1
-            TINYGRAD_MATCH=$(echo "$DEFAULTS" | jq -r --arg ref "$TINYGRAD_REF" '.tinygrad_ref == $ref' 2>/dev/null)
-            [ "$TINYGRAD_MATCH" = "true" ] || return 1
+            echo "$DEFAULTS" | jq -e --arg t "$TINYGRAD_REF" --arg c "$COMPILE_REF" '.tinygrad_ref == $t and .compile_ref == $c' >/dev/null 2>&1 || return 1
             DRIVING=$(echo "$DEFAULTS" | jq --arg hash "$DRIVING_HASH" '.bundles[] | select(.onnx_sha256 == $hash)' 2>/dev/null)
             [ -n "$DRIVING" ] && [ "$DRIVING" != "null" ] || return 1
           }
 
           if check_defaults; then
-            echo "HF defaults match repo ONNX hash and tinygrad ref"
+            echo "HF defaults match repo ONNX hash, tinygrad ref and compile ref"
             exit 0
           fi
 
@@ -405,19 +423,19 @@ jobs:
 
           TINYGRAD_REF=$(gh api "repos/${GH_REPO}/contents/tinygrad_repo?ref=${REF}" --jq '.sha')
           echo "tinygrad ref: $TINYGRAD_REF"
+          COMPILE_REF="${{ needs.prepare_strategy.outputs.compile_ref }}"
 
           JSON_URL="https://huggingface.co/datasets/${HF_REPO}/resolve/main/${HF_DEFAULTS_PATH}/default_models.json"
 
           check_defaults() {
             DEFAULTS=$(curl -fsSL "${JSON_URL}?t=$(date +%s)" 2>/dev/null) || return 1
-            TINYGRAD_MATCH=$(echo "$DEFAULTS" | jq -r --arg ref "$TINYGRAD_REF" '.tinygrad_ref == $ref' 2>/dev/null)
-            [ "$TINYGRAD_MATCH" = "true" ] || return 1
+            echo "$DEFAULTS" | jq -e --arg t "$TINYGRAD_REF" --arg c "$COMPILE_REF" '.tinygrad_ref == $t and .compile_ref == $c' >/dev/null 2>&1 || return 1
             DM=$(echo "$DEFAULTS" | jq --arg hash "$DM_HASH" '.bundles[] | select(.onnx_sha256 == $hash)' 2>/dev/null)
             [ -n "$DM" ] && [ "$DM" != "null" ] || return 1
           }
 
           if check_defaults; then
-            echo "HF defaults match DM ONNX hash and tinygrad ref"
+            echo "HF defaults match DM ONNX hash, tinygrad ref and compile ref"
             exit 0
           fi
 

--- a/openpilot/sunnypilot/models/compile_ref.py
+++ b/openpilot/sunnypilot/models/compile_ref.py
@@ -1,0 +1,33 @@
+"""
+Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+"""
+
+import hashlib
+import os
+
+from openpilot.common.basedir import BASEDIR
+
+# the scripts modeld/SConscript rebuilds the pkls for; default models are keyed on these next to tinygrad_ref
+COMPILE_SCRIPTS = (
+  'openpilot/selfdrive/modeld/compile_modeld.py',
+  'openpilot/selfdrive/modeld/get_model_metadata.py',
+  'openpilot/selfdrive/modeld/compile_dm_warp.py',
+  'openpilot/system/camerad/cameras/nv12_info.py',
+  'openpilot/common/hardware/hw.py',
+)
+
+
+def get_compile_ref() -> str:
+  h = hashlib.sha256()
+  for path in COMPILE_SCRIPTS:
+    with open(os.path.join(BASEDIR, path), "rb") as f:
+      h.update(f"{path}\n".encode())
+      h.update(f.read())
+  return h.hexdigest()
+
+
+if __name__ == "__main__":
+  print(get_compile_ref())

--- a/openpilot/sunnypilot/models/tests/test_compile_ref.py
+++ b/openpilot/sunnypilot/models/tests/test_compile_ref.py
@@ -1,0 +1,17 @@
+import re
+
+from openpilot.common.basedir import BASEDIR
+from openpilot.common.test import OpenpilotTestCase
+from openpilot.sunnypilot.models.compile_ref import COMPILE_SCRIPTS
+
+
+class TestCompileRef(OpenpilotTestCase):
+  def test_matches_sconscript_dependencies(self):
+    with open(f"{BASEDIR}/openpilot/selfdrive/modeld/SConscript") as f:
+      sconscript = f.read()
+    deps = set()
+    for name in ("compile_modeld_script", "compile_dm_warp_script"):
+      block = re.search(rf"^{name} = \[(.*?)\]", sconscript, re.M | re.S).group(1)
+      deps |= {p.lstrip("#").replace("{modeld_dir}", "openpilot/selfdrive/modeld").lstrip("/")
+               for p in re.findall(r'File\(f?"([^"]+)"', block)}
+    assert deps == set(COMPILE_SCRIPTS)

--- a/release/ci/upload_default_model.py
+++ b/release/ci/upload_default_model.py
@@ -32,6 +32,7 @@ def main():
   parser.add_argument("--onnx-ref", required=True)
   parser.add_argument("--model-name", required=True)
   parser.add_argument("--tinygrad-ref", required=True)
+  parser.add_argument("--compile-ref", required=True)
   parser.add_argument("--run-number", required=True)
   args = parser.parse_args()
 
@@ -77,6 +78,7 @@ def main():
     defaults_json = {"tinygrad_ref": args.tinygrad_ref, "bundles": []}
 
   defaults_json['tinygrad_ref'] = args.tinygrad_ref
+  defaults_json['compile_ref'] = args.compile_ref
 
   existing_idx = next((i for i, b in enumerate(defaults_json['bundles'])
                        if b.get('onnx_sha256') == onnx_sha256), None)


### PR DESCRIPTION
**Fixes #1988**

### The Issue
On staging `3e87c0f` users could not engage and saw `Posenet Speed Invalid / Speed Error: nan m/s`. That alert was a red herring. modeld was crashing at startup, and the alert that should have said so was hidden.

Two things went wrong:
* **modeld crashed on a stale pkl.** A recent change added a new key to the compiled model pkl. CI caches the pkl on the ONNX hash and the tinygrad ref only, neither of which changed, so it reused an old pkl without the new key. modeld died on a bare `KeyError` before its first frame.
* **The crash was hidden by a false alert.** With modeld dead, locationd and paramsd never published. selfdrived evaluated the empty defaults of messages it had never received, which read as an invalid posenet speed of nan. That alert tied in priority with `processNotRunning: modeld` and won on frame count.

### The Fix
* selfdrived only raises the posenet, localizer and paramsd alerts once it has actually received the message they are based on. A message that never arrived is no longer evaluated as if it had, so the real `process not running` alert shows.
* modeld checks the pkl for the keys it needs immediately after loading and fails with a message saying the pkl was compiled by a different version and needs a rebuild, instead of a bare `KeyError`. The writer and reader share one list of keys, with a unit test for the stale case.
* CI now hashes the scripts that shape the pkl alongside the tinygrad ref, so a change to how the pkl is written invalidates the cached one. The first run after merging rebuilds once.

### Notes
* Source builds and downloaded model bundles were not affected.
