### PR TITLE
selfdrived: chime Big Model Ready on a real big frame, gate localizer alerts on seen

### DIFF
--- a/openpilot/selfdrive/selfdrived/selfdrived.py
+++ b/openpilot/selfdrive/selfdrived/selfdrived.py
@@ -85,6 +85,7 @@ class SelfdriveD(CruiseHelper):
     self.big_model_loading = False
     self.big_model_active = False
     self.big_model_failed = False
+    self.big_model_running = False
     self.big_model_ready_t = 0.
 
     # Setup sockets
@@ -198,10 +199,15 @@ class SelfdriveD(CruiseHelper):
     loading = self.params.get_bool("ChestnutLoading")
     if self.big_model_loading and not loading:
       self.big_model_ready_t = time.monotonic()
-      self.events_sp.add(custom.OnroadEventSP.EventName.bigModelReady)
     self.big_model_loading = loading
     if self.big_model_loading:
       self.events.add(EventName.bigModelLoading)
+
+    # ChestnutLoading also clears after a failed load, so only modelV2.big means the big model is up
+    running_big = self.sm.alive['modelV2'] and self.sm.valid['modelV2'] and self.sm['modelV2'].big
+    if running_big and not self.big_model_running:
+      self.events_sp.add(custom.OnroadEventSP.EventName.bigModelReady)
+    self.big_model_running = running_big
 
     big_active = self.params.get("ChestnutActive")
     chestnut_present = self.sm['deviceState'].chestnutPresent

--- a/openpilot/selfdrive/selfdrived/selfdrived.py
+++ b/openpilot/selfdrive/selfdrived/selfdrived.py
@@ -453,11 +453,13 @@ class SelfdriveD(CruiseHelper):
       self.logged_comm_issue = None
 
     if not self.CP.notCar and not big_model_settling:  # localization has nothing to work with during the load
-      if not self.sm['deviceMotion'].posenetOK:
+      # a message never received is capnp defaults, not a localizer verdict
+      if self.sm.seen['deviceMotion'] and not self.sm['deviceMotion'].posenetOK:
         self.events.add(EventName.posenetInvalid)
-      if not self.sm['deviceMotion'].inputsOK:
+      if self.sm.seen['deviceMotion'] and not self.sm['deviceMotion'].inputsOK:
         self.events.add(EventName.locationdTemporaryError)
-      if (not self.sm['vehicleParameters'].valid and cal_status == log.ExtrinsicsCalibration.Status.calibrated and
+      if (self.sm.seen['vehicleParameters'] and not self.sm['vehicleParameters'].valid and
+          cal_status == log.ExtrinsicsCalibration.Status.calibrated and
           not TESTING_CLOSET and (not SIMULATION or REPLAY)):
         self.events.add(EventName.paramsdTemporaryError)
 

--- a/openpilot/selfdrive/selfdrived/tests/test_big_model_ready.py
+++ b/openpilot/selfdrive/selfdrived/tests/test_big_model_ready.py
@@ -1,0 +1,65 @@
+import unittest
+from unittest.mock import Mock
+from types import SimpleNamespace
+
+from openpilot.cereal import custom, messaging
+from openpilot.common.prefix import OpenpilotPrefix
+from openpilot.selfdrive.selfdrived.events import Events, EventName
+from openpilot.selfdrive.selfdrived.selfdrived import SelfdriveD
+from openpilot.sunnypilot.selfdrive.selfdrived.events import EventsSP
+
+EventNameSP = custom.OnroadEventSP.EventName
+
+
+class TestBigModelReady(unittest.TestCase):
+  def setUp(self):
+    prefix = OpenpilotPrefix()
+    prefix.__enter__()
+    self.addCleanup(prefix.__exit__, None, None, None)
+    # Drive the real update_events up to its initialization gate, without processes or live Params.
+    sd = SelfdriveD.__new__(SelfdriveD)
+    sd.sm = messaging.SubMaster(['modelV2', 'controlsState', 'deviceState', 'lateralManeuverPlan', 'alertDebug'])
+    sd.sm.data['modelV2'] = sd.sm['modelV2'].as_builder()
+    sd.sm.seen['modelV2'] = sd.sm.alive['modelV2'] = sd.sm.valid['modelV2'] = True
+    sd.events = Events()
+    sd.events_sp = EventsSP()
+    sd.params = Mock()
+    sd.big_model_loading = sd.big_model_active = sd.big_model_failed = sd.big_model_running = False
+    sd.big_model_ready_t = 0.
+    sd.enabled = False
+    sd.initialized = False
+    sd.startup_event = None
+    self.sd = sd
+
+  def step(self, loading, active=None, big=False, alive=True):
+    sd = self.sd
+    sd.params.get_bool.return_value = loading
+    sd.params.get.return_value = active
+    sd.sm.alive['modelV2'] = alive
+    sd.sm['modelV2'].big = big
+    sd.update_events(SimpleNamespace())
+    return EventNameSP.bigModelReady in sd.events_sp.names, EventName.bigModelFailed in sd.events.names
+
+  def test_failed_load_never_chimes_ready(self):
+    self.assertEqual(self.step(loading=True), (False, False))
+    self.assertEqual(self.step(loading=True, active=False), (False, True))
+    self.assertEqual(self.step(loading=False, active=False), (False, False))
+    for _ in range(10):
+      self.assertEqual(self.step(loading=False, active=False), (False, False))
+
+  def test_good_load_chimes_once_on_first_big_frame(self):
+    self.assertEqual(self.step(loading=True), (False, False))
+    self.assertEqual(self.step(loading=False), (False, False))
+    self.assertEqual(self.step(loading=False, active=True, big=True), (True, False))
+    for _ in range(10):
+      self.assertEqual(self.step(loading=False, active=True, big=True), (False, False))
+
+  def test_big_frame_from_a_dead_socket_does_not_chime(self):
+    self.assertEqual(self.step(loading=False, big=True, alive=False), (False, False))
+    self.assertEqual(self.step(loading=False, big=True, alive=False), (False, False))
+
+  def test_rearms_after_a_fall_back_to_the_small_model(self):
+    self.assertEqual(self.step(loading=False, active=True, big=True), (True, False))
+    self.assertEqual(self.step(loading=False, active=True, big=False), (False, False))
+    self.assertEqual(self.step(loading=False, active=True, big=True), (True, False))
+    self.assertEqual(self.step(loading=False, active=True, big=True), (False, False))

--- a/openpilot/selfdrive/selfdrived/tests/test_localizer_alerts.py
+++ b/openpilot/selfdrive/selfdrived/tests/test_localizer_alerts.py
@@ -1,15 +1,18 @@
 import collections
+from unittest.mock import Mock
 
 from opendbc.car.structs import car
 
 from openpilot.cereal import log, messaging
 from openpilot.common.test import OpenpilotTestCase
 from openpilot.common.params import Params
+from openpilot.common.realtime import Ratekeeper
 from openpilot.selfdrive.locationd.helpers import PoseCalibrator
 from openpilot.selfdrive.selfdrived.events import Events
 from openpilot.selfdrive.selfdrived.helpers import ExcessiveActuationCheck
 from openpilot.selfdrive.selfdrived.selfdrived import SelfdriveD
 from openpilot.sunnypilot.selfdrive.selfdrived.events import EventsSP
+from openpilot.sunnypilot.selfdrive.car.intelligent_cruise_button_management.controller import IntelligentCruiseButtonManagement
 
 EventName = log.OnroadEvent.EventName
 
@@ -21,50 +24,20 @@ SERVICES = {'controlsState': None, 'deviceState': None, 'modelV2': None, 'userBo
             'vehicleParameters': None, 'carControl': None, 'pandaStates': 0}
 
 
-class FakeSubMaster:
-  """A SubMaster that has received nothing: every message is the capnp default."""
-
-  def __init__(self):
-    self.frame = 10000
-    self.data = {s: getattr(messaging.new_message(s, size), s) for s, size in SERVICES.items()}
-    self.seen = dict.fromkeys(SERVICES, False)
-    self.alive = dict.fromkeys(SERVICES, True)
-    self.valid = dict.fromkeys(SERVICES, True)
-    self.freq_ok = dict.fromkeys(SERVICES, True)
-    self.updated = dict.fromkeys(SERVICES, False)
-    self.recv_frame = collections.defaultdict(int)
-
-  def __getitem__(self, s):
-    return self.data[s]
-
-  def all_checks(self, service_list=None):
-    return True
-
-  def all_alive(self, service_list=None):
-    return True
-
-  def all_freq_ok(self, service_list=None):
-    return True
-
-
-class FakeRatekeeper:
-  lagging = False
-
-
-class FakeIcbm:
-  def run(self, *args):
-    pass
-
-
 class TestLocalizerAlerts(OpenpilotTestCase):
   def setup_method(self):
     self.sd = SelfdriveD.__new__(SelfdriveD)
     self.sd.params = Params()
-    self.sd.sm = FakeSubMaster()
+    self.sd.sm = messaging.SubMaster(list(SERVICES))
+    self.sd.sm.frame = 10000
+    for service, size in SERVICES.items():
+      self.sd.sm.data[service] = getattr(messaging.new_message(service, size), service)
+      self.sd.sm.alive[service] = self.sd.sm.valid[service] = self.sd.sm.freq_ok[service] = True
+    self.sd.sm.recv_frame = collections.defaultdict(int)
     self.sd.events = Events()
     self.sd.events_sp = EventsSP()
     self.sd.CP = car.CarParams.new_message()
-    self.sd.rk = FakeRatekeeper()
+    self.sd.rk = Mock(spec=Ratekeeper, lagging=False)
     self.sd.pose_calibrator = PoseCalibrator()
     self.sd.calibrated_pose = None
     self.sd.excessive_actuation_check = ExcessiveActuationCheck()
@@ -75,6 +48,7 @@ class TestLocalizerAlerts(OpenpilotTestCase):
     self.sd.big_model_loading = False
     self.sd.big_model_active = False
     self.sd.big_model_failed = False
+    self.sd.big_model_running = False
     self.sd.big_model_ready_t = 0.  # past the settling window
     self.sd.dm_lockout_set = False
     self.sd.dm_uncertain_alerted = False
@@ -95,7 +69,7 @@ class TestLocalizerAlerts(OpenpilotTestCase):
     self.sd.distance_traveled = 0
     self.sd.experimental_mode = False
     self.sd.is_metric = False
-    self.sd.icbm = FakeIcbm()
+    self.sd.icbm = Mock(spec=IntelligentCruiseButtonManagement)
 
     # calibrated, so only the seen guard keeps paramsdTemporaryError away
     self.sd.sm['extrinsicsCalibration'].calStatus = log.ExtrinsicsCalibration.Status.calibrated

--- a/openpilot/selfdrive/selfdrived/tests/test_localizer_alerts.py
+++ b/openpilot/selfdrive/selfdrived/tests/test_localizer_alerts.py
@@ -1,0 +1,117 @@
+import collections
+
+from opendbc.car.structs import car
+
+from openpilot.cereal import log, messaging
+from openpilot.common.test import OpenpilotTestCase
+from openpilot.common.params import Params
+from openpilot.selfdrive.locationd.helpers import PoseCalibrator
+from openpilot.selfdrive.selfdrived.events import Events
+from openpilot.selfdrive.selfdrived.helpers import ExcessiveActuationCheck
+from openpilot.selfdrive.selfdrived.selfdrived import SelfdriveD
+from openpilot.sunnypilot.selfdrive.selfdrived.events import EventsSP
+
+EventName = log.OnroadEvent.EventName
+
+# every service update_events() reads, with the size the list-typed ones need
+SERVICES = {'controlsState': None, 'deviceState': None, 'modelV2': None, 'userBookmark': None,
+            'driverMonitoringState': None, 'longitudinalPlanSP': None, 'peripheralState': None,
+            'extrinsicsCalibration': None, 'driverAssistance': None, 'deviceMotion': None,
+            'modelDataV2SP': None, 'managerState': None, 'radarState': None, 'longitudinalPlan': None,
+            'vehicleParameters': None, 'carControl': None, 'pandaStates': 0}
+
+
+class FakeSubMaster:
+  """A SubMaster that has received nothing: every message is the capnp default."""
+
+  def __init__(self):
+    self.frame = 10000
+    self.data = {s: getattr(messaging.new_message(s, size), s) for s, size in SERVICES.items()}
+    self.seen = dict.fromkeys(SERVICES, False)
+    self.alive = dict.fromkeys(SERVICES, True)
+    self.valid = dict.fromkeys(SERVICES, True)
+    self.freq_ok = dict.fromkeys(SERVICES, True)
+    self.updated = dict.fromkeys(SERVICES, False)
+    self.recv_frame = collections.defaultdict(int)
+
+  def __getitem__(self, s):
+    return self.data[s]
+
+  def all_checks(self, service_list=None):
+    return True
+
+  def all_alive(self, service_list=None):
+    return True
+
+  def all_freq_ok(self, service_list=None):
+    return True
+
+
+class FakeRatekeeper:
+  lagging = False
+
+
+class FakeIcbm:
+  def run(self, *args):
+    pass
+
+
+class TestLocalizerAlerts(OpenpilotTestCase):
+  def setup_method(self):
+    self.sd = SelfdriveD.__new__(SelfdriveD)
+    self.sd.params = Params()
+    self.sd.sm = FakeSubMaster()
+    self.sd.events = Events()
+    self.sd.events_sp = EventsSP()
+    self.sd.CP = car.CarParams.new_message()
+    self.sd.rk = FakeRatekeeper()
+    self.sd.pose_calibrator = PoseCalibrator()
+    self.sd.calibrated_pose = None
+    self.sd.excessive_actuation_check = ExcessiveActuationCheck()
+    self.sd.excessive_actuation = False
+    self.sd.initialized = True
+    self.sd.enabled = False
+    self.sd.startup_event = None
+    self.sd.big_model_loading = False
+    self.sd.big_model_active = False
+    self.sd.big_model_failed = False
+    self.sd.big_model_ready_t = 0.  # past the settling window
+    self.sd.dm_lockout_set = False
+    self.sd.dm_uncertain_alerted = False
+    self.sd.recalibrating_seen = False
+    self.sd.is_ldw_enabled = False
+    self.sd.disengage_on_accelerator = False
+    self.sd.mismatch_counter = 0
+    self.sd.not_running_prev = None
+    self.sd.ignored_processes = set()
+    self.sd.logged_comm_issue = None
+    self.sd.last_functional_fan_frame = 0
+    self.sd.sensor_packets = []
+    self.sd.camera_packets = []
+    self.sd.CS_prev = car.CarState.new_message()
+    self.sd.cruise_mismatch_counter = 0
+    self.sd.last_steering_pressed_frame = 0
+    self.sd.gps_location_service = 'gpsLocationExternal'
+    self.sd.distance_traveled = 0
+    self.sd.experimental_mode = False
+    self.sd.is_metric = False
+    self.sd.icbm = FakeIcbm()
+
+    # calibrated, so only the seen guard keeps paramsdTemporaryError away
+    self.sd.sm['extrinsicsCalibration'].calStatus = log.ExtrinsicsCalibration.Status.calibrated
+
+    self.CS = car.CarState.new_message()
+
+  def test_never_received(self):
+    self.sd.update_events(self.CS)
+    assert not self.sd.events.has(EventName.posenetInvalid)
+    assert not self.sd.events.has(EventName.locationdTemporaryError)
+    assert not self.sd.events.has(EventName.paramsdTemporaryError)
+
+  def test_posenet_not_ok_once_seen(self):
+    self.sd.sm.seen['deviceMotion'] = True
+    self.sd.sm['deviceMotion'].posenetOK = False
+    self.sd.sm['deviceMotion'].inputsOK = True
+    self.sd.update_events(self.CS)
+    assert self.sd.events.has(EventName.posenetInvalid)
+    assert not self.sd.events.has(EventName.locationdTemporaryError)

--- a/openpilot/sunnypilot/modeld_v2/tests/test_fallback.py
+++ b/openpilot/sunnypilot/modeld_v2/tests/test_fallback.py
@@ -8,7 +8,7 @@ See the LICENSE.md file in the root directory for more details.
 import io
 import requests
 
-from openpilot.common.file_chunker import get_chunk_name
+from openpilot.common.file_chunker import get_chunk_name, get_manifest_path
 from openpilot.common.hardware import hw
 from openpilot.common.test import OpenpilotTestCase
 from openpilot.selfdrive.modeld.helpers import dump_oob
@@ -51,6 +51,8 @@ class TestFallback(OpenpilotTestCase):
       artifact = bundle.models[0].artifact
       for i in range(len(artifact.chunks)):
         (tmp_path / get_chunk_name(artifact.fileName, i, len(artifact.chunks))).write_bytes(oob_bytes if i == 0 else b"")
+      # A completed download records the chunk count alongside the chunk files.
+      (tmp_path / get_manifest_path(artifact.fileName)).write_text(str(len(artifact.chunks)))
 
     monkeypatch.setattr(modeld_module, 'get_active_bundle', lambda params=None, *, chestnut=None: small_bundle)
     assert modeld_module.ModelState(CAM_W, CAM_H, chestnut=False).chestnut is False

--- a/openpilot/sunnypilot/models/fetcher.py
+++ b/openpilot/sunnypilot/models/fetcher.py
@@ -12,6 +12,7 @@ from requests.exceptions import (SSLError, RequestException, HTTPError)
 from openpilot.common.params import Params
 from openpilot.common.swaglog import cloudlog
 from openpilot.common.hardware.hw import Paths
+from openpilot.common.file_chunker import get_chunk_name, get_manifest_path
 from openpilot.sunnypilot.models.helpers import is_bundle_version_compatible
 from openpilot.cereal import custom
 
@@ -42,20 +43,34 @@ class ModelParser:
     if "chunks" in artifact_data:
       artifact.chunks = [ModelParser._parse_chunk(chunk_data) for chunk_data in artifact_data["chunks"]]
 
-      try:
-        model_dir = Paths.model_root()
-        os.makedirs(model_dir, exist_ok=True)
-        manifest_path = os.path.join(model_dir, f"{artifact.fileName}.chunkmanifest")
-        num_chunks = str(len(artifact.chunks))
-
-        if not os.path.exists(manifest_path) or open(manifest_path).read().strip() != num_chunks:
-          with open(manifest_path, "w") as f:
-            f.write(num_chunks)
-          cloudlog.info(f"Wrote chunk manifest for {artifact.fileName}: {num_chunks} chunks")
-      except Exception as e:
-        cloudlog.warning(f"Failed to write chunk manifest for {artifact.fileName}: {e}")
+      ModelParser._repair_chunk_manifest(artifact)
 
     return artifact
+
+  @staticmethod
+  def _repair_chunk_manifest(artifact: custom.ModelManagerSP.Artifact) -> None:
+    """Record the chunk count of an artifact already on disk. Every catalog parses each
+    tick and qcom and chestnut list the same file with different counts, so only the source
+    whose first chunk exists writes; a download writes its own manifest when it finishes."""
+    try:
+      model_dir = Paths.model_root()
+      os.makedirs(model_dir, exist_ok=True)
+      base_path = os.path.join(model_dir, artifact.fileName)
+      num_chunks = len(artifact.chunks)
+
+      if not os.path.isfile(get_chunk_name(base_path, 0, num_chunks)):
+        return
+
+      manifest_path = get_manifest_path(base_path)
+      expected = str(num_chunks)
+      if os.path.exists(manifest_path) and open(manifest_path).read().strip() == expected:
+        return
+
+      with open(manifest_path, "w") as f:
+        f.write(expected)
+      cloudlog.info(f"Wrote chunk manifest for {artifact.fileName}: {expected} chunks")
+    except Exception as e:
+      cloudlog.warning(f"Failed to write chunk manifest for {artifact.fileName}: {e}")
 
   @staticmethod
   def _parse_model(model_data) -> custom.ModelManagerSP.Model:

--- a/openpilot/sunnypilot/models/tests/test_manager_download.py
+++ b/openpilot/sunnypilot/models/tests/test_manager_download.py
@@ -24,7 +24,7 @@ from openpilot.common.test import OpenpilotTestCase
 from openpilot.common.file_chunker import get_chunk_name, get_manifest_path
 from openpilot.selfdrive.test.helpers import http_server_context
 from openpilot.sunnypilot.models import manager as manager_module
-from openpilot.sunnypilot.models.fetcher import ModelFetcher, get_cached_bundles
+from openpilot.sunnypilot.models.fetcher import ModelFetcher, ModelParser, get_cached_bundles
 from openpilot.sunnypilot.models import helpers
 from openpilot.sunnypilot.models.helpers import (get_active_bundle, get_active_source, get_selected_bundle,
                                                   resolve_bundle_by_ref, validate_active_bundles)
@@ -811,3 +811,63 @@ class TestLiveModelManifest(OpenpilotTestCase):
 
 if __name__ == '__main__':
   unittest.main()
+
+
+class TestChunkManifestRepair(OpenpilotTestCase):
+  """qcom and chestnut list the same file with different chunk counts; the manifest must
+  describe the chunks on disk, not whichever was parsed last"""
+
+  CHUNKED_NAME = "shared_model.pkl"
+
+  def setUp(self):
+    super().setUp()
+    self.model_root = tempfile.mkdtemp()
+    patcher = mock.patch('openpilot.sunnypilot.models.fetcher.Paths')
+    self.addCleanup(patcher.stop)
+    patcher.start().model_root.return_value = self.model_root
+
+  def artifact_data(self, num_chunks: int, file_name: str | None = None) -> dict:
+    name = file_name or self.CHUNKED_NAME
+    return {
+      "file_name": name,
+      "download_uri": {"url": f"https://example.com/{name}", "sha256": "s"},
+      "chunks": [{"file_name": get_chunk_name(name, i, num_chunks), "sha256": "s"}
+                 for i in range(num_chunks)],
+    }
+
+  def manifest_text(self) -> str | None:
+    path = get_manifest_path(os.path.join(self.model_root, self.CHUNKED_NAME))
+    if not os.path.isfile(path):
+      return None
+    with open(path) as f:
+      return f.read().strip()
+
+  def place_chunks(self, num_chunks: int) -> None:
+    base = os.path.join(self.model_root, self.CHUNKED_NAME)
+    for i in range(num_chunks):
+      with open(get_chunk_name(base, i, num_chunks), 'wb') as f:
+        f.write(b'x')
+
+  def test_no_manifest_for_an_undownloaded_artifact(self):
+    ModelParser._parse_artifact(self.artifact_data(4))
+    assert self.manifest_text() is None, "wrote a manifest for chunks that are not on disk"
+
+  def test_manifest_repaired_for_a_downloaded_artifact(self):
+    self.place_chunks(4)
+    ModelParser._parse_artifact(self.artifact_data(4))
+    assert self.manifest_text() == "4"
+
+  def test_two_sources_disagreeing_do_not_thrash(self):
+    # qcom says 4 chunks, chestnut says 5, and only qcom's were downloaded
+    self.place_chunks(4)
+    for _ in range(3):
+      ModelParser._parse_artifact(self.artifact_data(4))
+      ModelParser._parse_artifact(self.artifact_data(5))
+      assert self.manifest_text() == "4", "the other source overwrote the manifest"
+
+  def test_unchunked_artifact_writes_nothing(self):
+    ModelParser._parse_artifact({
+      "file_name": self.CHUNKED_NAME,
+      "download_uri": {"url": "https://example.com/x", "sha256": "s"},
+    })
+    assert self.manifest_text() is None


### PR DESCRIPTION
Fix misleading startup alerts, the big-model ready chime, and unnecessary model manifest writes.

- **Startup alerts:** Wait for the first localization and vehicle-parameter messages before checking their status. Previously, missing messages could trigger “Posenet Speed Invalid” and temporary errors before those processes reported any results.
- **Big Model Ready:** Play the chime when the first valid big-model frame arrives. A failed or timed-out load no longer plays “Big Model Ready” after “Big Model Failed” while the small model is running.
- **Model manifests:** Repair chunk manifests only when matching chunks exist on disk and the recorded count needs updating. This avoids creating manifests for undownloaded models or repeatedly overwriting them when catalogs list different chunk counts.

### Verification

- Regression tests cover startup alerts, successful and failed big-model loads, chime rearming, and manifest repair across catalogs.
- `pytest openpilot/selfdrive/selfdrived/tests openpilot/sunnypilot/models/tests/test_manager_download.py`: 72 passed, 1 skipped.
- Ruff passed on changed files.
