### PR TITLE
accelerators: run the big driving model on an attached Jetson (jetlink)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ bin/
 # created at launch for comma hardware PYTHONPATH (PC uses editable installs via pyproject.toml)
 /msgq
 /opendbc
+/jetlink
 /rednose
 /teleoprtc
 /tinygrad

--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "sunnypilot/neural_network_data"]
 	path = openpilot/sunnypilot/neural_network_data
   url = https://github.com/sunnypilot/neural-network-data.git
+[submodule "jetlink"]
+  path = jetlink_repo
+  url = https://github.com/zoompilot/jetlink.git

--- a/launch_chffrplus.sh
+++ b/launch_chffrplus.sh
@@ -79,6 +79,9 @@ function launch {
   ln -sfn rednose_repo/rednose rednose
   ln -sfn teleoprtc_repo/teleoprtc teleoprtc
   ln -sfn tinygrad_repo/tinygrad tinygrad
+  ln -sfn jetlink_repo/jetlink jetlink
+  # accelerator backends: USB gadgets, symlinks, anything needing root at boot
+  ./openpilot/sunnypilot/accelerators/setup.sh
 
   # hardware specific init
   if [ -f /AGNOS ]; then

--- a/openpilot/cereal/custom.capnp
+++ b/openpilot/cereal/custom.capnp
@@ -354,6 +354,8 @@ struct OnroadEventSP @0xda96579883444c35 {
     e2eChime @23;
     laneChangeRoadEdge @24;
     bigModelReady @25;
+    bigModelAvailable @26;
+    bigModelLinkLost @27;
   }
 }
 
@@ -462,6 +464,24 @@ struct ModelDataV2SP @0xa1680744031fdb2d {
   laneTurnDirection @0 :TurnDirection;
   leftLaneChangeEdgeBlock @1 :Bool;
   rightLaneChangeEdgeBlock @2 :Bool;
+
+  # A late-loading big model is connected and waiting for disengagement.
+  # This is availability, not proof of inference; modelV2.big reports execution.
+  # Startup-only runners and older logs leave this false.
+  bigModelAvailable @3 :Bool;
+
+  # Runtime state of an off-board accelerator (sunnypilot/accelerators). Offroad
+  # progress stays in the AcceleratorProgress param; telemetry waits for a customReserved slot.
+  acceleratorState @4 :AcceleratorState;
+  acceleratorName @5 :Text;
+
+  enum AcceleratorState {
+    none @0;
+    joining @1;
+    running @2;
+    retrying @3;
+    unavailable @4;
+  }
 
   enum TurnDirection {
     none @0;

--- a/openpilot/common/params_keys.h
+++ b/openpilot/common/params_keys.h
@@ -142,6 +142,18 @@ inline static std::unordered_map<std::string, ParamKeyAttributes> keys = {
     {"Version", {PERSISTENT, STRING}},
 
     // --- sunnypilot params --- //
+
+    // Accelerators: what runs the large model. See sunnypilot/accelerators/.
+    {"AcceleratorProgress", {CLEAR_ON_MANAGER_START, JSON}},
+    {"Offroad_AcceleratorUnavailable", {CLEAR_ON_MANAGER_START, JSON}},
+    // jetlink backend. Readiness must survive a reboot, or every ignition cycle
+    // would rebuild a multi-minute TensorRT engine.
+    {"JetlinkEnabled", {PERSISTENT | BACKUP, BOOL}},
+    {"JetlinkEndpoint", {PERSISTENT | BACKUP, STRING}},
+    {"JetlinkModel", {PERSISTENT | BACKUP, STRING}},
+    {"JetlinkEngineReady", {PERSISTENT, STRING}},
+    {"JetlinkSpec", {PERSISTENT, JSON}},
+    {"JetlinkCachedModels", {PERSISTENT, JSON}},
     {"ApiCache_DriveStats", {PERSISTENT, JSON}},
     {"AutoLaneChangeBsmDelay", {PERSISTENT | BACKUP, BOOL, "0"}},
     {"AutoLaneChangeTimer", {PERSISTENT | BACKUP, INT, "0"}},

--- a/openpilot/selfdrive/modeld/modeld.py
+++ b/openpilot/selfdrive/modeld/modeld.py
@@ -35,6 +35,7 @@ from openpilot.common.hardware.usb import CHESTNUT_USB_IDS
 from openpilot.selfdrive.modeld.constants import ModelConstants, Plan
 from openpilot.selfdrive.modeld.helpers import chestnut_present, chestnut_compiled, chestnut_ready, modeld_pkl_path, load_oob
 
+from openpilot.sunnypilot import accelerators
 from openpilot.sunnypilot.livedelay.helpers import get_lat_delay
 from openpilot.sunnypilot.modeld_v2.modeld_base import ModelStateBase
 from openpilot.sunnypilot.selfdrive.controls.lib.relc import RoadEdgeLaneChangeController
@@ -261,6 +262,8 @@ def main(demo=False):
     params.put_bool("ChestnutActive", False)
   else:
     params.remove("ChestnutActive")
+  # before going realtime: prepare() starts tinygrad's device thread, which would inherit FIFO 54 on core 7
+  JETLINK = not CHESTNUT and accelerators.ready() and accelerators.prepare()
 
   config_realtime_process(7, 54)
 
@@ -309,8 +312,16 @@ def main(demo=False):
     params.put_bool("ChestnutActive", model is not None)
     if model is not None:
       params.remove("ChestnutModelError")
+  elif JETLINK:
+    small_model = ModelState(vipc_client_main.width, vipc_client_main.height, False)
+    try:
+      model = accelerators.make_model_state(vipc_client_main.width, vipc_client_main.height, small_model)
+    except Exception:
+      cloudlog.exception("jetlink load failed")
+      model = None
 
-  small_model = ModelState(vipc_client_main.width, vipc_client_main.height, False) if model is None or CHESTNUT else None
+  if not JETLINK:
+    small_model = ModelState(vipc_client_main.width, vipc_client_main.height, False) if model is None or CHESTNUT else None
   if model is None:
     model = small_model
   params.put_bool("ChestnutLoading", False)
@@ -325,6 +336,8 @@ def main(demo=False):
   publish_state = PublishState()
   params = Params()
   chestnut_state = ChestnutState(pm, model.chestnut) if CHESTNUT else None
+  if JETLINK:
+    chestnut_state = accelerators.make_status_publisher(pm, model)
 
   # setup filter to track dropped frames
   frame_dropped_filter = FirstOrderFilter(0., 10., 1. / ModelConstants.MODEL_RUN_FREQ)
@@ -438,6 +451,9 @@ def main(demo=False):
                        run_count % round(ModelConstants.MODEL_RUN_FREQ / SERVICE_LIST['chestnutState'].frequency) == 0)
       model_output = model.run(bufs, transforms, inputs, chestnut_state.send if send_chestnut else None)
     except Exception:
+      # the joining state does its own fallback; the handler below would orphan its threads and link
+      if JETLINK:
+        raise
       if not params.get_bool("ChestnutActive"):
         raise
       # fallback to small model
@@ -470,6 +486,9 @@ def main(demo=False):
       r_lane_change_prob = desire_state[log.Desire.laneChangeRight]
       lane_change_prob = l_lane_change_prob + r_lane_change_prob
       mdv2sp_send = messaging.new_message('modelDataV2SP')
+      mdv2sp_send.modelDataV2SP.bigModelAvailable = getattr(model, 'big_model_available', False)
+      mdv2sp_send.modelDataV2SP.acceleratorState = getattr(model, 'big_model_state', 'none')
+      mdv2sp_send.modelDataV2SP.acceleratorName = 'jetlink' if JETLINK else ''
       left_edge, right_edge = RELC.update_and_fill(modelv2_send.modelV2, mdv2sp_send.modelDataV2SP, v_ego)
       DH.update(sm['carState'], sm['carControl'].latActive, lane_change_prob, left_edge, right_edge)
       modelv2_send.modelV2.meta.laneChangeState = DH.lane_change_state

--- a/openpilot/selfdrive/selfdrived/alerts_offroad.json
+++ b/openpilot/selfdrive/selfdrived/alerts_offroad.json
@@ -45,6 +45,10 @@
     "text": "Chestnut USB link is slow. Check the USB cable. The current speed is %1.",
     "severity": 0
   },
+  "Offroad_AcceleratorUnavailable": {
+    "text": "Model accelerator unavailable: %1",
+    "severity": 0
+  },
   "Offroad_UnregisteredHardware": {
     "text": "Failed to register with comma.ai backend. It will not connect or upload to comma.ai servers, and receives no support from comma.ai. If this is a device purchased at comma.ai/shop, open a ticket at https://comma.ai/support.",
     "severity": 1

--- a/openpilot/selfdrive/selfdrived/selfdrived.py
+++ b/openpilot/selfdrive/selfdrived/selfdrived.py
@@ -85,6 +85,7 @@ class SelfdriveD(CruiseHelper):
     self.big_model_loading = False
     self.big_model_active = False
     self.big_model_failed = False
+    self.big_model_running = False
     self.big_model_ready_t = 0.
 
     # Setup sockets
@@ -198,10 +199,15 @@ class SelfdriveD(CruiseHelper):
     loading = self.params.get_bool("ChestnutLoading")
     if self.big_model_loading and not loading:
       self.big_model_ready_t = time.monotonic()
-      self.events_sp.add(custom.OnroadEventSP.EventName.bigModelReady)
     self.big_model_loading = loading
     if self.big_model_loading:
       self.events.add(EventName.bigModelLoading)
+
+    # ChestnutLoading also clears after a failed load, so only modelV2.big means the big model is up
+    running_big = self.sm.alive['modelV2'] and self.sm.valid['modelV2'] and self.sm['modelV2'].big
+    if running_big and not self.big_model_running:
+      self.events_sp.add(custom.OnroadEventSP.EventName.bigModelReady)
+    self.big_model_running = running_big
 
     big_active = self.params.get("ChestnutActive")
     chestnut_present = self.sm['deviceState'].chestnutPresent

--- a/openpilot/selfdrive/selfdrived/selfdrived.py
+++ b/openpilot/selfdrive/selfdrived/selfdrived.py
@@ -453,11 +453,13 @@ class SelfdriveD(CruiseHelper):
       self.logged_comm_issue = None
 
     if not self.CP.notCar and not big_model_settling:  # localization has nothing to work with during the load
-      if not self.sm['deviceMotion'].posenetOK:
+      # a message never received is capnp defaults, not a localizer verdict
+      if self.sm.seen['deviceMotion'] and not self.sm['deviceMotion'].posenetOK:
         self.events.add(EventName.posenetInvalid)
-      if not self.sm['deviceMotion'].inputsOK:
+      if self.sm.seen['deviceMotion'] and not self.sm['deviceMotion'].inputsOK:
         self.events.add(EventName.locationdTemporaryError)
-      if (not self.sm['vehicleParameters'].valid and cal_status == log.ExtrinsicsCalibration.Status.calibrated and
+      if (self.sm.seen['vehicleParameters'] and not self.sm['vehicleParameters'].valid and
+          cal_status == log.ExtrinsicsCalibration.Status.calibrated and
           not TESTING_CLOSET and (not SIMULATION or REPLAY)):
         self.events.add(EventName.paramsdTemporaryError)
 

--- a/openpilot/selfdrive/selfdrived/selfdrived.py
+++ b/openpilot/selfdrive/selfdrived/selfdrived.py
@@ -33,6 +33,7 @@ from openpilot.sunnypilot.selfdrive.car.cruise_helpers import CruiseHelper
 from openpilot.sunnypilot.selfdrive.car.intelligent_cruise_button_management.controller import IntelligentCruiseButtonManagement
 from openpilot.sunnypilot.selfdrive.selfdrived.button_state_tracker import ButtonStateTracker
 from openpilot.sunnypilot.selfdrive.selfdrived.events import EventsSP
+from openpilot.sunnypilot.selfdrive.selfdrived.accelerator_events import AcceleratorEvents
 
 REPLAY = "REPLAY" in os.environ
 SIMULATION = "SIMULATION" in os.environ
@@ -87,6 +88,7 @@ class SelfdriveD(CruiseHelper):
     self.big_model_failed = False
     self.big_model_running = False
     self.big_model_ready_t = 0.
+    self.accelerator_events = AcceleratorEvents()
 
     # Setup sockets
     self.pm = messaging.PubMaster(['selfdriveState', 'onroadEvents'] + ['selfdriveStateSP', 'onroadEventsSP'])
@@ -222,6 +224,7 @@ class SelfdriveD(CruiseHelper):
       self.big_model_active = True
     if not self.enabled and not model_unavailable:
       self.big_model_active = False
+    self.accelerator_events.update(self.sm, self.enabled, self.events, self.events_sp)
 
     if self.sm.recv_frame['lateralManeuverPlan'] > 0:
       self.events.add(EventName.lateralManeuver)

--- a/openpilot/selfdrive/selfdrived/tests/test_big_model_ready.py
+++ b/openpilot/selfdrive/selfdrived/tests/test_big_model_ready.py
@@ -6,6 +6,7 @@ from openpilot.cereal import custom, messaging
 from openpilot.common.prefix import OpenpilotPrefix
 from openpilot.selfdrive.selfdrived.events import Events, EventName
 from openpilot.selfdrive.selfdrived.selfdrived import SelfdriveD
+from openpilot.sunnypilot.selfdrive.selfdrived.accelerator_events import AcceleratorEvents
 from openpilot.sunnypilot.selfdrive.selfdrived.events import EventsSP
 
 EventNameSP = custom.OnroadEventSP.EventName
@@ -18,11 +19,12 @@ class TestBigModelReady(unittest.TestCase):
     self.addCleanup(prefix.__exit__, None, None, None)
     # Drive the real update_events up to its initialization gate, without processes or live Params.
     sd = SelfdriveD.__new__(SelfdriveD)
-    sd.sm = messaging.SubMaster(['modelV2', 'controlsState', 'deviceState', 'lateralManeuverPlan', 'alertDebug'])
+    sd.sm = messaging.SubMaster(['modelV2', 'modelDataV2SP', 'controlsState', 'deviceState', 'lateralManeuverPlan', 'alertDebug'])
     sd.sm.data['modelV2'] = sd.sm['modelV2'].as_builder()
     sd.sm.seen['modelV2'] = sd.sm.alive['modelV2'] = sd.sm.valid['modelV2'] = True
     sd.events = Events()
     sd.events_sp = EventsSP()
+    sd.accelerator_events = AcceleratorEvents()
     sd.params = Mock()
     sd.big_model_loading = sd.big_model_active = sd.big_model_failed = sd.big_model_running = False
     sd.big_model_ready_t = 0.

--- a/openpilot/selfdrive/selfdrived/tests/test_big_model_ready.py
+++ b/openpilot/selfdrive/selfdrived/tests/test_big_model_ready.py
@@ -1,0 +1,65 @@
+import unittest
+from unittest.mock import Mock
+from types import SimpleNamespace
+
+from openpilot.cereal import custom, messaging
+from openpilot.common.prefix import OpenpilotPrefix
+from openpilot.selfdrive.selfdrived.events import Events, EventName
+from openpilot.selfdrive.selfdrived.selfdrived import SelfdriveD
+from openpilot.sunnypilot.selfdrive.selfdrived.events import EventsSP
+
+EventNameSP = custom.OnroadEventSP.EventName
+
+
+class TestBigModelReady(unittest.TestCase):
+  def setUp(self):
+    prefix = OpenpilotPrefix()
+    prefix.__enter__()
+    self.addCleanup(prefix.__exit__, None, None, None)
+    # Drive the real update_events up to its initialization gate, without processes or live Params.
+    sd = SelfdriveD.__new__(SelfdriveD)
+    sd.sm = messaging.SubMaster(['modelV2', 'controlsState', 'deviceState', 'lateralManeuverPlan', 'alertDebug'])
+    sd.sm.data['modelV2'] = sd.sm['modelV2'].as_builder()
+    sd.sm.seen['modelV2'] = sd.sm.alive['modelV2'] = sd.sm.valid['modelV2'] = True
+    sd.events = Events()
+    sd.events_sp = EventsSP()
+    sd.params = Mock()
+    sd.big_model_loading = sd.big_model_active = sd.big_model_failed = sd.big_model_running = False
+    sd.big_model_ready_t = 0.
+    sd.enabled = False
+    sd.initialized = False
+    sd.startup_event = None
+    self.sd = sd
+
+  def step(self, loading, active=None, big=False, alive=True):
+    sd = self.sd
+    sd.params.get_bool.return_value = loading
+    sd.params.get.return_value = active
+    sd.sm.alive['modelV2'] = alive
+    sd.sm['modelV2'].big = big
+    sd.update_events(SimpleNamespace())
+    return EventNameSP.bigModelReady in sd.events_sp.names, EventName.bigModelFailed in sd.events.names
+
+  def test_failed_load_never_chimes_ready(self):
+    self.assertEqual(self.step(loading=True), (False, False))
+    self.assertEqual(self.step(loading=True, active=False), (False, True))
+    self.assertEqual(self.step(loading=False, active=False), (False, False))
+    for _ in range(10):
+      self.assertEqual(self.step(loading=False, active=False), (False, False))
+
+  def test_good_load_chimes_once_on_first_big_frame(self):
+    self.assertEqual(self.step(loading=True), (False, False))
+    self.assertEqual(self.step(loading=False), (False, False))
+    self.assertEqual(self.step(loading=False, active=True, big=True), (True, False))
+    for _ in range(10):
+      self.assertEqual(self.step(loading=False, active=True, big=True), (False, False))
+
+  def test_big_frame_from_a_dead_socket_does_not_chime(self):
+    self.assertEqual(self.step(loading=False, big=True, alive=False), (False, False))
+    self.assertEqual(self.step(loading=False, big=True, alive=False), (False, False))
+
+  def test_rearms_after_a_fall_back_to_the_small_model(self):
+    self.assertEqual(self.step(loading=False, active=True, big=True), (True, False))
+    self.assertEqual(self.step(loading=False, active=True, big=False), (False, False))
+    self.assertEqual(self.step(loading=False, active=True, big=True), (True, False))
+    self.assertEqual(self.step(loading=False, active=True, big=True), (False, False))

--- a/openpilot/selfdrive/selfdrived/tests/test_localizer_alerts.py
+++ b/openpilot/selfdrive/selfdrived/tests/test_localizer_alerts.py
@@ -9,6 +9,7 @@ from openpilot.selfdrive.locationd.helpers import PoseCalibrator
 from openpilot.selfdrive.selfdrived.events import Events
 from openpilot.selfdrive.selfdrived.helpers import ExcessiveActuationCheck
 from openpilot.selfdrive.selfdrived.selfdrived import SelfdriveD
+from openpilot.sunnypilot.selfdrive.selfdrived.accelerator_events import AcceleratorEvents
 from openpilot.sunnypilot.selfdrive.selfdrived.events import EventsSP
 
 EventName = log.OnroadEvent.EventName
@@ -63,6 +64,7 @@ class TestLocalizerAlerts(OpenpilotTestCase):
     self.sd.sm = FakeSubMaster()
     self.sd.events = Events()
     self.sd.events_sp = EventsSP()
+    self.sd.accelerator_events = AcceleratorEvents()
     self.sd.CP = car.CarParams.new_message()
     self.sd.rk = FakeRatekeeper()
     self.sd.pose_calibrator = PoseCalibrator()

--- a/openpilot/selfdrive/selfdrived/tests/test_localizer_alerts.py
+++ b/openpilot/selfdrive/selfdrived/tests/test_localizer_alerts.py
@@ -1,0 +1,117 @@
+import collections
+
+from opendbc.car.structs import car
+
+from openpilot.cereal import log, messaging
+from openpilot.common.test import OpenpilotTestCase
+from openpilot.common.params import Params
+from openpilot.selfdrive.locationd.helpers import PoseCalibrator
+from openpilot.selfdrive.selfdrived.events import Events
+from openpilot.selfdrive.selfdrived.helpers import ExcessiveActuationCheck
+from openpilot.selfdrive.selfdrived.selfdrived import SelfdriveD
+from openpilot.sunnypilot.selfdrive.selfdrived.events import EventsSP
+
+EventName = log.OnroadEvent.EventName
+
+# every service update_events() reads, with the size the list-typed ones need
+SERVICES = {'controlsState': None, 'deviceState': None, 'modelV2': None, 'userBookmark': None,
+            'driverMonitoringState': None, 'longitudinalPlanSP': None, 'peripheralState': None,
+            'extrinsicsCalibration': None, 'driverAssistance': None, 'deviceMotion': None,
+            'modelDataV2SP': None, 'managerState': None, 'radarState': None, 'longitudinalPlan': None,
+            'vehicleParameters': None, 'carControl': None, 'pandaStates': 0}
+
+
+class FakeSubMaster:
+  """A SubMaster that has received nothing: every message is the capnp default."""
+
+  def __init__(self):
+    self.frame = 10000
+    self.data = {s: getattr(messaging.new_message(s, size), s) for s, size in SERVICES.items()}
+    self.seen = dict.fromkeys(SERVICES, False)
+    self.alive = dict.fromkeys(SERVICES, True)
+    self.valid = dict.fromkeys(SERVICES, True)
+    self.freq_ok = dict.fromkeys(SERVICES, True)
+    self.updated = dict.fromkeys(SERVICES, False)
+    self.recv_frame = collections.defaultdict(int)
+
+  def __getitem__(self, s):
+    return self.data[s]
+
+  def all_checks(self, service_list=None):
+    return True
+
+  def all_alive(self, service_list=None):
+    return True
+
+  def all_freq_ok(self, service_list=None):
+    return True
+
+
+class FakeRatekeeper:
+  lagging = False
+
+
+class FakeIcbm:
+  def run(self, *args):
+    pass
+
+
+class TestLocalizerAlerts(OpenpilotTestCase):
+  def setup_method(self):
+    self.sd = SelfdriveD.__new__(SelfdriveD)
+    self.sd.params = Params()
+    self.sd.sm = FakeSubMaster()
+    self.sd.events = Events()
+    self.sd.events_sp = EventsSP()
+    self.sd.CP = car.CarParams.new_message()
+    self.sd.rk = FakeRatekeeper()
+    self.sd.pose_calibrator = PoseCalibrator()
+    self.sd.calibrated_pose = None
+    self.sd.excessive_actuation_check = ExcessiveActuationCheck()
+    self.sd.excessive_actuation = False
+    self.sd.initialized = True
+    self.sd.enabled = False
+    self.sd.startup_event = None
+    self.sd.big_model_loading = False
+    self.sd.big_model_active = False
+    self.sd.big_model_failed = False
+    self.sd.big_model_ready_t = 0.  # past the settling window
+    self.sd.dm_lockout_set = False
+    self.sd.dm_uncertain_alerted = False
+    self.sd.recalibrating_seen = False
+    self.sd.is_ldw_enabled = False
+    self.sd.disengage_on_accelerator = False
+    self.sd.mismatch_counter = 0
+    self.sd.not_running_prev = None
+    self.sd.ignored_processes = set()
+    self.sd.logged_comm_issue = None
+    self.sd.last_functional_fan_frame = 0
+    self.sd.sensor_packets = []
+    self.sd.camera_packets = []
+    self.sd.CS_prev = car.CarState.new_message()
+    self.sd.cruise_mismatch_counter = 0
+    self.sd.last_steering_pressed_frame = 0
+    self.sd.gps_location_service = 'gpsLocationExternal'
+    self.sd.distance_traveled = 0
+    self.sd.experimental_mode = False
+    self.sd.is_metric = False
+    self.sd.icbm = FakeIcbm()
+
+    # calibrated, so only the seen guard keeps paramsdTemporaryError away
+    self.sd.sm['extrinsicsCalibration'].calStatus = log.ExtrinsicsCalibration.Status.calibrated
+
+    self.CS = car.CarState.new_message()
+
+  def test_never_received(self):
+    self.sd.update_events(self.CS)
+    assert not self.sd.events.has(EventName.posenetInvalid)
+    assert not self.sd.events.has(EventName.locationdTemporaryError)
+    assert not self.sd.events.has(EventName.paramsdTemporaryError)
+
+  def test_posenet_not_ok_once_seen(self):
+    self.sd.sm.seen['deviceMotion'] = True
+    self.sd.sm['deviceMotion'].posenetOK = False
+    self.sd.sm['deviceMotion'].inputsOK = True
+    self.sd.update_events(self.CS)
+    assert self.sd.events.has(EventName.posenetInvalid)
+    assert not self.sd.events.has(EventName.locationdTemporaryError)

--- a/openpilot/selfdrive/ui/sunnypilot/accelerator_link.py
+++ b/openpilot/selfdrive/ui/sunnypilot/accelerator_link.py
@@ -1,0 +1,42 @@
+"""
+Copyright (c) 2026-, Zeph Leggett.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+
+The user's say over the accelerator link, shared by the mici and tici models panels.
+On is the only enable; the backend reads the param, the panels only write it.
+"""
+from openpilot.selfdrive.ui.ui_state import ui_state
+from openpilot.sunnypilot import accelerators
+
+LINK_PARAM = "JetlinkEnabled"
+
+
+def link_enabled() -> bool:
+  """never raises: a params library older than the key would take the settings panel down"""
+  try:
+    return bool(ui_state.params.get(LINK_PARAM))
+  except Exception:
+    return False
+
+
+def set_link_enabled(enabled: bool) -> None:
+  try:
+    ui_state.params.put_bool(LINK_PARAM, enabled, block=True)
+    # manager caches which modeld it runs; the link decides that
+    ui_state.params.remove('ModelRunnerTypeCache')
+  except Exception:
+    pass  # same unknown-key case as the read
+
+
+def link_toggle_meaningful() -> bool:
+  """hidden on a plain device. ready() counts so a cached engine can be turned off
+  while the hardware is out of the car"""
+  return (accelerators.present() or accelerators.ready() or link_enabled()
+          or accelerators.unavailable_reason() is not None)
+
+
+def selected_accelerator_model() -> str:
+  """The picked accelerator model's name, '' when the link has no registry."""
+  return next((m['name'] for m in accelerators.model_choices() if m['selected']), '')

--- a/openpilot/selfdrive/ui/sunnypilot/layouts/settings/models.py
+++ b/openpilot/selfdrive/ui/sunnypilot/layouts/settings/models.py
@@ -10,14 +10,18 @@ import time
 import pyray as rl
 
 from openpilot.cereal import custom
+from openpilot.sunnypilot import accelerators
 from openpilot.sunnypilot.models.helpers import ACTIVE_BUNDLE_KEYS, get_selected_bundle, resolve_bundle_by_ref
 from openpilot.common.constants import CV
 from openpilot.selfdrive.ui.ui_state import device, ui_state
+from openpilot.selfdrive.ui.sunnypilot.accelerator_link import (link_enabled, link_toggle_meaningful,
+                                                                selected_accelerator_model, set_link_enabled)
 from openpilot.selfdrive.ui.sunnypilot.model_info import big_model_state, bundles_for_source, carrying_model, default_model_name, queued_name
 from openpilot.system.ui.lib.multilang import tr
 from openpilot.system.ui.lib.application import gui_app
 from openpilot.system.ui.widgets import DialogResult, Widget
 from openpilot.system.ui.widgets.confirm_dialog import alert_dialog, ConfirmDialog
+from openpilot.system.ui.widgets.option_dialog import MultiOptionDialog
 from openpilot.system.ui.widgets.scroller_tici import Scroller
 from openpilot.system.ui.widgets.toggle import ON_COLOR
 
@@ -37,6 +41,7 @@ class ModelsLayout(Widget):
     super().__init__()
     self.model_manager = None
     self.model_dialog = None
+    self.accelerator_dialog = None
     self._selection_source = None
     self._downloading = False
     self._verifying = False
@@ -64,6 +69,20 @@ class ModelsLayout(Widget):
       action_item=ScrollingButtonAction(tr("SELECT")),
       callback=lambda: self._open_source_dialog("chestnut")
     )
+
+    self.accelerator_model_item = ListItemSP(
+      title=tr("Accelerator Model"),
+      description=tr("The big model an attached accelerator runs, from its own registry. The model manager's slots do not apply to it."),
+      action_item=ScrollingButtonAction(tr("SELECT")),
+      callback=self._open_accelerator_dialog
+    )
+
+    # not a param-bound toggle: the write also drops manager's runner cache and
+    # is refused onroad, so it goes through accelerator_link by hand
+    self.accelerator_link_item = toggle_item_sp(
+      tr("Accelerator Link"),
+      tr("Run the big driving model on an attached accelerator."),
+      initial_state=link_enabled(), callback=self._set_link_state)
 
     self.download_item = download_status_item(lambda: tr("Download") if self._downloading else tr("Model Status"))
 
@@ -106,8 +125,43 @@ class ModelsLayout(Widget):
                                         1, None, True, "", style.BUTTON_ACTION_WIDTH, None, True,
                                         lambda v: f"{v / 100:.2f} m")
 
-    self.items = [self.small_model_item, self.big_model_item, self.cancel_download_item, self.download_item, self.refresh_item, self.clear_cache_item,
+    self.items = [self.small_model_item, self.big_model_item, self.accelerator_model_item, self.accelerator_link_item, self.cancel_download_item,
+                  self.download_item, self.refresh_item, self.clear_cache_item,
                   self.lane_turn_desire_toggle, self.lane_turn_value_control, self.lagd_toggle, self.delay_control, self.camera_offset]
+    self._refresh_accelerator_items()
+
+  def _set_link_state(self, enabled: bool):
+    if not ui_state.is_offroad():
+      self.accelerator_link_item.action_item.set_state(link_enabled())
+      return
+    set_link_enabled(enabled)
+
+  def _refresh_accelerator_items(self):
+    # present() and unavailable_reason() read sysfs, so this rides the half-second tick
+    choices = accelerators.model_choices()
+    self.accelerator_model_item.set_visible(bool(choices))
+    if choices:
+      name = next((m['name'] for m in choices if m['selected']), tr("None"))
+      self.accelerator_model_item.action_item.set_value(name, style.ITEM_TEXT_VALUE_COLOR)
+    self.accelerator_link_item.set_visible(link_toggle_meaningful())
+    self.accelerator_link_item.action_item.set_state(link_enabled())
+
+  def _open_accelerator_dialog(self):
+    choices = accelerators.model_choices()
+    if not choices:
+      return
+    self.accelerator_dialog = MultiOptionDialog(tr("Select an Accelerator Model"), [m['name'] for m in choices],
+                                                selected_accelerator_model(), callback=self._on_accelerator_selected)
+    gui_app.push_widget(self.accelerator_dialog)
+
+  def _on_accelerator_selected(self, result):
+    dialog, self.accelerator_dialog = self.accelerator_dialog, None
+    if result != DialogResult.CONFIRM or dialog is None or not dialog.selection:
+      return
+    # a selection that crosses ignition must not change the model mid-drive
+    if not ui_state.is_offroad():
+      return
+    accelerators.select_model(dialog.selection)
 
   def _update_lagd_description(self, lagd_toggle: bool):
     desc = tr("Enable this for the car to learn and adapt its steering response time. Disable to use a fixed steering response time. " +
@@ -150,6 +204,7 @@ class ModelsLayout(Widget):
     if (current_time := time.monotonic()) - self.last_cache_calc_time > 0.5:
       self.last_cache_calc_time = current_time
       self.clear_cache_item.action_item.set_value(f"{self.calculate_cache_size():.2f} MB")
+      self._refresh_accelerator_items()
 
     bundle = self.model_manager.selectedBundle if self.model_manager else None
     progresses = [model.artifact.downloadProgress for model in bundle.models if model.artifact.fileName] if bundle else []
@@ -208,13 +263,19 @@ class ModelsLayout(Widget):
     """The failover story for the Model Status row. One-way big -> small, and the
     fallback is runner-matched: a Default big can only fall back to the Default
     small (stock modeld), a custom big has no automatic fallback yet."""
-    if not ui_state.chestnut_present:
+    accelerator = ui_state.accelerator_view is not None
+    if not (ui_state.chestnut_present or accelerator):
       return ""
-    big_bundle = get_selected_bundle(ui_state.params, "chestnut")
-    big_name = big_bundle.internalName if big_bundle else default_model_name("chestnut")
-    big_is_default = big_bundle is None
     fallback_name = default_model_name("qcom")
     state = big_model_state()
+    if accelerator:
+      # the accelerator's model comes from its own registry, so it reads like a Default big
+      big_name = selected_accelerator_model() or tr("The big model")
+      big_is_default = True
+    else:
+      big_bundle = get_selected_bundle(ui_state.params, "chestnut")
+      big_name = big_bundle.internalName if big_bundle else default_model_name("chestnut")
+      big_is_default = big_bundle is None
     if state == 'failed':
       if big_is_default:
         return tr("Big model unavailable, {} is driving until the next drive.").format(fallback_name)
@@ -223,6 +284,8 @@ class ModelsLayout(Widget):
       if big_is_default:
         return tr("{} drives until the big model is ready.").format(fallback_name)
       return tr("Getting the big model ready.")
+    if accelerator and not ui_state.accelerator_view.ready:
+      return tr("{} will drive when the accelerator is ready.").format(big_name)
     if big_is_default:
       return tr("{} will drive. If it fails during a drive, {} takes over until the next drive.").format(big_name, fallback_name)
     return tr("{} will drive when the chestnut is ready.").format(big_name)
@@ -343,6 +406,8 @@ class ModelsLayout(Widget):
     offroad = ui_state.is_offroad()
     self.small_model_item.action_item.set_enabled(offroad)
     self.big_model_item.action_item.set_enabled(offroad)
+    self.accelerator_model_item.action_item.set_enabled(offroad)
+    self.accelerator_link_item.action_item.set_enabled(offroad)
     self.small_model_item.set_description("" if offroad else tr("Only available when vehicle is off, or always offroad mode is on"))
 
   def _render(self, rect):

--- a/openpilot/selfdrive/ui/sunnypilot/mici/layouts/models.py
+++ b/openpilot/selfdrive/ui/sunnypilot/mici/layouts/models.py
@@ -7,17 +7,37 @@ See the LICENSE.md file in the root directory for more details.
 import pyray as rl
 
 from openpilot.cereal import custom
+from openpilot.sunnypilot import accelerators
 from openpilot.selfdrive.ui.mici.widgets.dialog import BigDialog
 from openpilot.sunnypilot.models.helpers import ACTIVE_BUNDLE_KEYS, get_selected_bundle
-from openpilot.selfdrive.ui.mici.widgets.button import BigButton
+from openpilot.selfdrive.ui.mici.widgets.button import BigButton, BigToggle
 from openpilot.selfdrive.ui.ui_state import ui_state, device
-from openpilot.selfdrive.ui.sunnypilot.model_info import (active_source, big_model_state, bundles_for_source, carrying_model,
-                                                           default_model_name, model_info, queued_name)
+from openpilot.selfdrive.ui.sunnypilot.accelerator_link import link_enabled, link_toggle_meaningful, set_link_enabled
+from openpilot.selfdrive.ui.sunnypilot.model_info import (active_source, big_model_progress, big_model_state,
+                                                          bundles_for_source, carrying_model,
+                                                          default_model_name, model_info, queued_name)
 from openpilot.system.ui.lib.application import FontWeight, gui_app
 from openpilot.system.ui.lib.multilang import tr
 from openpilot.system.ui.widgets import Widget
 from openpilot.system.ui.widgets.label import UnifiedLabel
 from openpilot.system.ui.widgets.scroller import NavScroller
+
+
+class AcceleratorLinkToggle(BigToggle):
+  """not BigParamControl: the write also drops manager's runner cache and is refused onroad"""
+
+  def __init__(self):
+    super().__init__(tr("accelerator link"), initial_state=link_enabled(), toggle_callback=self._store)
+
+  def _store(self, checked: bool) -> None:
+    if not ui_state.is_offroad():
+      self.set_checked(link_enabled())
+      return
+    set_link_enabled(checked)
+
+  def refresh(self) -> None:
+    self.set_checked(link_enabled())
+
 
 def _model_info() -> tuple[str, str, str]:
   """(active model, info header, info text) for the panel. Runner-matched: the
@@ -30,6 +50,15 @@ def _model_info() -> tuple[str, str, str]:
     big = get_selected_bundle(ui_state.params, "chestnut")
     carry_display = big.displayName if big else default_model_name("chestnut")
   active_text = (carry_display or active_name).lower()
+  provisioning = big_model_progress()
+  if provisioning is not None:
+    stage, frac, msg = provisioning
+    if stage == 'failed':
+      return active_text, tr("big model"), tr("unavailable")
+    # "waiting for the jetson" says more than "connect 0%"; no percentage for a stage
+    # with nothing to measure
+    detail = tr(msg) if msg else tr(stage)
+    return active_text, tr("big model"), f"{detail} {frac * 100:.0f}%" if frac > 0 else detail
   if state == 'failed':
     return active_text, tr("big model"), tr("unavailable")
   if state == 'loading':
@@ -84,7 +113,10 @@ class ModelsLayoutMici(NavScroller):
     self.cancel_download_btn = BigButton(tr("cancel download"))
     self.cancel_download_btn.set_click_callback(lambda: ui_state.params.remove("ModelManager_DownloadRef"))
 
-    self.main_items = [self.current_model_info, self.select_model_btn, self.cancel_download_btn]
+    self.link_toggle = AcceleratorLinkToggle()
+    self.link_toggle.set_visible(link_toggle_meaningful())
+
+    self.main_items = [self.current_model_info, self.select_model_btn, self.cancel_download_btn, self.link_toggle]
     self._scroller.add_widgets(self.main_items)
 
   @property
@@ -121,7 +153,30 @@ class ModelsLayoutMici(NavScroller):
       btn = BigButton(label.lower(), value=value)
       btn.set_click_callback(lambda s=source: self._select_hardware(s))
       hardware_btns.append(btn)
+    choices = accelerators.model_choices()
+    if choices:
+      selected = next((m['name'] for m in choices if m['selected']), '')
+      btn = BigButton(tr('accelerator models'), value=selected.lower())
+      btn.set_click_callback(self._select_accelerator)
+      hardware_btns.append(btn)
     self._push_selection_view(hardware_btns)
+
+  def _select_accelerator(self):
+    buttons = []
+    for choice in accelerators.model_choices():
+      value = tr('cached on accelerator') if choice['cached'] else tr('build required')
+      if choice['selected']:
+        value += f" ({tr('selected')})"
+      btn = BigButton(choice['name'].lower(), value=value)
+      btn.set_click_callback(lambda m=choice: self._choose_accelerator(m))
+      buttons.append(btn)
+    self._push_selection_view(buttons)
+
+  def _choose_accelerator(self, choice):
+    if not ui_state.is_offroad():
+      return
+    accelerators.select_model(choice['name'])
+    self._pop_to_main()
 
   def _select_hardware(self, source):
     self._selection_source = source
@@ -198,6 +253,9 @@ class ModelsLayoutMici(NavScroller):
     should_update = self._download_frame % (gui_app.target_fps / 2) == 0
     if should_update:
       self._download_progress = self._download_progress + "." if len(self._download_progress) < 3 else ""
+      # present() and unavailable_reason() read sysfs, so they ride this half-second tick
+      self.link_toggle.refresh()
+      self.link_toggle.set_visible(link_toggle_meaningful())
 
     is_downloading = (manager.selectedBundle
                       and manager.selectedBundle.status == custom.ModelManagerSP.DownloadStatus.downloading)

--- a/openpilot/selfdrive/ui/sunnypilot/mici/tests/test_accelerator_link.py
+++ b/openpilot/selfdrive/ui/sunnypilot/mici/tests/test_accelerator_link.py
@@ -1,0 +1,388 @@
+"""
+Copyright (c) 2026-, Zeph Leggett.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+"""
+
+# The models panel's accelerator link, picker and status line, and the home-screen icon state.
+
+import os
+
+import pytest
+
+os.environ["BIG"] = "0"
+os.environ.setdefault("SCALE", "1")
+
+
+@pytest.fixture(scope="module")
+def gui():
+  """Hidden raylib window + isolated params dir. Widgets need textures, so a window is required."""
+  import pyray as rl
+  from openpilot.common.prefix import OpenpilotPrefix
+
+  with OpenpilotPrefix():
+    rl.set_config_flags(rl.FLAG_WINDOW_HIDDEN)
+    from openpilot.system.ui.lib.application import gui_app
+    gui_app.init_window("test_accelerator_link", fps=30)
+    yield gui_app
+    gui_app.close()
+
+
+@pytest.fixture
+def params(gui):
+  from openpilot.common.params import Params
+  from openpilot.selfdrive.ui.ui_state import ui_state
+
+  p = Params()
+  ui_state.params = p
+  # on device update_params() runs every frame before anything draws, so attributes it
+  # sets (always_offroad, screensaver_enabled, ...) exist by render time. Without this a
+  # layout reading one of them fails in the test for a reason the device never sees.
+  ui_state.update_params()
+  return p
+
+
+def render(widget):
+  """Drive one frame through Widget.render, which calls _update_state."""
+  import pyray as rl
+  widget.render(rl.Rectangle(0, 0, 800, 600))
+
+
+def wait_for_param(params, key, timeout=2.0):
+  """Widgets write with a non-blocking put(), which lands on a background thread."""
+  import time
+  deadline = time.monotonic() + timeout
+  last = params.get(key)
+  while time.monotonic() < deadline:
+    time.sleep(0.005)
+    val = params.get(key)
+    if val != last:
+      return val
+    last = val
+  return last
+
+
+class TestAcceleratorProgressRenders:
+  """The models panel's provisioning line.
+
+  Provisioning an accelerator is an upload plus a build, minutes long, and this
+  is the only place a user sees it happening. The layout sweep above runs with
+  no progress set, so none of these branches is covered by it.
+  """
+
+  STAGES = ['download', 'connect', 'upload', 'build', 'failed']
+
+  def _info(self, stage, frac):
+    from openpilot.selfdrive.ui.ui_state import ui_state
+    ui_state.accelerator_progress = {'stage': stage, 'frac': frac, 'msg': ''}
+    try:
+      from openpilot.selfdrive.ui.sunnypilot.mici.layouts.models import _model_info
+      return _model_info()
+    finally:
+      ui_state.accelerator_progress = None
+
+  @pytest.mark.parametrize("stage", STAGES)
+  def test_every_stage_gives_a_line(self, params, stage):
+    active, header, info = self._info(stage, 0.42)
+    assert active and header and info
+
+  def test_a_percentage_is_shown_while_working(self, params):
+    _, _, info = self._info('download', 0.42)
+    assert '42%' in info
+
+  def test_a_message_is_shown_instead_of_a_percentage_that_means_nothing(self, params):
+    # A join has nothing to measure: it is waiting for a Jetson to boot, or
+    # for a safe frame to swap on. Rendering that as "connect 0%" tells the
+    # driver nothing, and "getting ready" alone does not separate a Jetson
+    # that is unplugged from one six seconds from ready.
+    from openpilot.selfdrive.ui.ui_state import ui_state
+    ui_state.accelerator_progress = {'stage': 'connect', 'frac': 0.0, 'msg': 'waiting for the jetson'}
+    try:
+      from openpilot.selfdrive.ui.sunnypilot.mici.layouts.models import _model_info
+      _, _, info = _model_info()
+    finally:
+      ui_state.accelerator_progress = None
+    assert 'waiting for the jetson' in info
+    assert '%' not in info
+
+  def test_failure_says_so_rather_than_showing_100_percent(self, params):
+    _, _, info = self._info('failed', 1.0)
+    assert '100%' not in info
+
+  def test_ready_falls_back_to_the_normal_line(self, params):
+    # 'ready' is the steady state: the panel must go back to naming the model,
+    # not sit on a finished progress bar forever.
+    from openpilot.selfdrive.ui.sunnypilot.mici.layouts import models as models_layout
+    ready = self._info('ready', 1.0)
+    from openpilot.selfdrive.ui.ui_state import ui_state
+    ui_state.accelerator_progress = None
+    assert ready == models_layout._model_info()
+
+  @pytest.mark.parametrize("stage", STAGES)
+  def test_the_panel_draws_with_progress_set(self, params, stage):
+    from openpilot.selfdrive.ui.ui_state import ui_state
+    from openpilot.selfdrive.ui.sunnypilot.mici.layouts.models import ModelsLayoutMici
+
+    ui_state.accelerator_progress = {'stage': stage, 'frac': 0.5, 'msg': ''}
+    try:
+      layout = ModelsLayoutMici()
+      render(layout)
+      render(layout)
+      for item in layout._scroller.items:
+        render(item)
+      render(layout.current_model_info)
+    finally:
+      ui_state.accelerator_progress = None
+
+
+class TestAcceleratorIconState:
+  """The home screen and sidebar draw ui_state.chestnut_state. For a backend
+  the comma is the USB gadget for, the state has to come from the accelerator
+  view and the progress param, not from a USB id the comma will never enumerate.
+  A fitted chestnut keeps upstream's state machine untouched."""
+
+  class FakeSM:
+    def __init__(self, big=False, alive=False, recv=0):
+      self.recv_frame = {"modelV2": recv}
+      self.alive = {"modelV2": alive}
+      self.big = big
+
+    def __getitem__(self, name):
+      if name == "deviceState":
+        return type("DS", (), {"chestnutPresent": False})()
+      assert name == "modelV2"
+      return type("M", (), {"big": self.big})()
+
+  @staticmethod
+  def _view(present=True, ready=False, progress=None, state='none'):
+    from openpilot.selfdrive.ui.sunnypilot.ui_state import AcceleratorView
+    return AcceleratorView(present, ready, progress, True, state)
+
+  def _state(self, view, sm=None, started=False):
+    from openpilot.selfdrive.ui.ui_state import ui_state
+    saved = ui_state.sm, ui_state.started, ui_state.started_frame, ui_state.accelerator_view
+    ui_state.sm, ui_state.started, ui_state.started_frame = sm or self.FakeSM(), started, 0
+    ui_state.accelerator_view = view
+    try:
+      ui_state._update_chestnut_state()
+      return ui_state.chestnut_state
+    finally:
+      ui_state.sm, ui_state.started, ui_state.started_frame, ui_state.accelerator_view = saved
+
+  def test_offroad_states(self, params):
+    from openpilot.selfdrive.ui.ui_state import ChestnutState
+    assert self._state(self._view(present=False)) == ChestnutState.DISCONNECTED
+    assert self._state(self._view(ready=True)) == ChestnutState.READY
+    assert self._state(self._view()) == ChestnutState.UNCOMPILED
+    assert self._state(self._view(progress={'stage': 'build', 'frac': 0.3})) == ChestnutState.LOADING
+    assert self._state(self._view(progress={'stage': 'failed', 'frac': 1.0})) == ChestnutState.FAILED
+    assert self._state(self._view(ready=True, progress={'stage': 'connect', 'frac': 0.0})) == ChestnutState.LOADING
+    assert self._state(self._view(ready=True, progress={'stage': 'failed', 'frac': 1.0})) == ChestnutState.FAILED
+    assert self._state(self._view(ready=True, progress={'stage': 'ready', 'frac': 1.0})) == ChestnutState.READY
+
+  def test_absent_accelerator_does_not_pulse_onroad(self, params):
+    from openpilot.selfdrive.ui.ui_state import ChestnutState
+    view = self._view(present=False, ready=True, state='retrying')
+    assert self._state(view, self.FakeSM(alive=True, recv=1), started=True) == ChestnutState.DISCONNECTED
+
+  def test_onroad_states(self, params):
+    from openpilot.selfdrive.ui.ui_state import ChestnutState
+    driving = self.FakeSM(alive=True, recv=1)
+    assert self._state(self._view(ready=True, state='joining'), driving, started=True) == ChestnutState.LOADING
+    assert self._state(self._view(ready=True, state='retrying'), driving, started=True) == ChestnutState.LOADING
+    assert self._state(self._view(ready=True, state='running'), driving, started=True) == ChestnutState.ACTIVE
+    assert self._state(self._view(ready=True, state='unavailable'), driving, started=True) == ChestnutState.FAILED
+    assert self._state(self._view(ready=False, state='none'), driving, started=True) == ChestnutState.UNCOMPILED
+    # nothing from modeld yet is loading, not failed
+    assert self._state(self._view(ready=True), self.FakeSM(), started=True) == ChestnutState.LOADING
+    # a big frame is proof, whatever the status field says
+    big = self.FakeSM(big=True, alive=True, recv=1)
+    assert self._state(self._view(ready=True, state='unavailable'), big, started=True) == ChestnutState.ACTIVE
+
+
+class TestAcceleratorModelSelection:
+  def test_selection_does_not_write_model_manager_slots(self, params):
+    from unittest import mock
+    from openpilot.selfdrive.ui.sunnypilot.mici.layouts.models import ModelsLayoutMici
+
+    choice = {'name': 'Cinque Terre', 'selected': False, 'cached': True}
+    layout = ModelsLayoutMici()
+    with mock.patch('openpilot.selfdrive.ui.sunnypilot.mici.layouts.models.accelerators.select_model') as select, \
+         mock.patch('openpilot.selfdrive.ui.sunnypilot.mici.layouts.models.ui_state.is_offroad', return_value=True), \
+         mock.patch.object(layout, '_pop_to_main'), mock.patch.object(params, 'put') as put:
+      layout._choose_accelerator(choice)
+      select.assert_called_once_with('Cinque Terre')
+      put.assert_not_called()
+
+  def test_selection_that_crosses_ignition_does_not_change_the_model(self, params):
+    from unittest import mock
+    from openpilot.selfdrive.ui.sunnypilot.mici.layouts.models import ModelsLayoutMici
+
+    layout = ModelsLayoutMici()
+    with mock.patch('openpilot.selfdrive.ui.sunnypilot.mici.layouts.models.accelerators.select_model') as select, \
+         mock.patch('openpilot.selfdrive.ui.sunnypilot.mici.layouts.models.ui_state.is_offroad', return_value=False):
+      layout._choose_accelerator({'name': 'Cinque Terre'})
+      select.assert_not_called()
+
+  @staticmethod
+  def _usb(present):
+    from contextlib import ExitStack
+    from unittest import mock
+    from openpilot.selfdrive.ui import ui_state as module
+    stack = ExitStack()
+    stack.enter_context(mock.patch.object(module, 'read_int', return_value=1))
+    stack.enter_context(mock.patch.object(module, 'get_usb_state', return_value=[]))
+    stack.enter_context(mock.patch("openpilot.sunnypilot.accelerators.present", return_value=present))
+    return stack
+
+  def test_a_present_accelerator_is_not_an_unknown_usb_device(self, params):
+    import time
+    from openpilot.selfdrive.ui.ui_state import ui_state
+    saved = ui_state.usb_connected, ui_state.usb_connected_ts, ui_state.usb_unknown, ui_state.accelerator_view
+    try:
+      ui_state.usb_connected, ui_state.usb_connected_ts, ui_state.usb_unknown = True, time.monotonic() - 11.0, False
+      with self._usb(present=True):
+        ui_state.update_params()  # builds the view
+        ui_state.usb_connected_ts = time.monotonic() - 11.0
+        ui_state.update_params()  # decides
+      assert ui_state.accelerator_view is not None
+      assert ui_state.usb_unknown is False
+      with self._usb(present=False):
+        ui_state.update_params()
+        ui_state.usb_connected_ts = time.monotonic() - 11.0
+        ui_state.update_params()
+      assert ui_state.accelerator_view is None
+      assert ui_state.usb_unknown is True
+    finally:
+      ui_state.usb_connected, ui_state.usb_connected_ts, ui_state.usb_unknown, ui_state.accelerator_view = saved
+
+  def test_an_accelerator_recognised_after_the_grace_period_clears_unknown(self, params):
+    """The cable is seen from power-on but the Jetson configures the gadget
+    ~25 s after the UI starts, so the one-shot decision has already said
+    "unknown" by then. Presence arriving later must still clear it."""
+    from openpilot.selfdrive.ui.ui_state import ui_state
+    saved = ui_state.usb_connected, ui_state.usb_connected_ts, ui_state.usb_unknown, ui_state.accelerator_view
+    try:
+      ui_state.usb_connected, ui_state.usb_connected_ts, ui_state.usb_unknown = True, None, True
+      with self._usb(present=False):
+        ui_state.update_params()
+        assert ui_state.usb_unknown is True
+      with self._usb(present=True):
+        ui_state.update_params()
+        assert ui_state.usb_unknown is False
+    finally:
+      ui_state.usb_connected, ui_state.usb_connected_ts, ui_state.usb_unknown, ui_state.accelerator_view = saved
+
+
+class TestAcceleratorLinkToggle:
+  """The models panel's on / off control over the accelerator link.
+
+  On is the only enable, and the control is hidden on a device it means nothing
+  to: a plain comma must not grow a setting for hardware it will never see.
+  """
+
+  PARAM = "JetlinkEnabled"
+
+  @staticmethod
+  def _accelerators(present=False, ready=False, reason=None):
+    from contextlib import ExitStack
+    from unittest import mock
+
+    stack = ExitStack()
+    stack.enter_context(mock.patch("openpilot.sunnypilot.accelerators.present", return_value=present))
+    stack.enter_context(mock.patch("openpilot.sunnypilot.accelerators.ready", return_value=ready))
+    stack.enter_context(mock.patch("openpilot.sunnypilot.accelerators.unavailable_reason", return_value=reason))
+    return stack
+
+  def _meaningful(self, **accelerators) -> bool:
+    from openpilot.selfdrive.ui.sunnypilot.mici.layouts.models import link_toggle_meaningful
+    with self._accelerators(**accelerators):
+      return link_toggle_meaningful()
+
+  def test_hidden_on_a_plain_device(self, params):
+    params.remove(self.PARAM)
+    assert not self._meaningful()
+
+  def test_shown_when_an_accelerator_is_attached(self, params):
+    params.remove(self.PARAM)
+    assert self._meaningful(present=True)
+
+  def test_shown_when_ready_with_the_hardware_out_of_the_car(self, params):
+    # the engine is cached and the link may be on, so modeld will still try it at
+    # the next ignition. this is the case the off position exists for
+    params.remove(self.PARAM)
+    assert self._meaningful(ready=True)
+
+  def test_shown_when_the_backend_has_a_complaint(self, params):
+    params.remove(self.PARAM)
+    assert self._meaningful(reason="no gadget")
+
+  def test_shown_once_the_user_has_turned_it_on(self, params):
+    params.put_bool(self.PARAM, True, block=True)
+    assert self._meaningful()
+
+  def test_hidden_when_off_with_nothing_attached(self, params):
+    params.put_bool(self.PARAM, False, block=True)
+    assert not self._meaningful()
+
+  def test_absent_reads_as_off(self, params):
+    from openpilot.selfdrive.ui.sunnypilot.mici.layouts.models import link_enabled
+
+    params.remove(self.PARAM)
+    assert link_enabled() is False
+    params.put_bool(self.PARAM, True, block=True)
+    assert link_enabled() is True
+    params.put_bool(self.PARAM, False, block=True)
+    assert link_enabled() is False
+
+  def test_tap_toggles_on_and_off(self, params):
+    from openpilot.selfdrive.ui.sunnypilot.mici.layouts.models import AcceleratorLinkToggle
+    from openpilot.system.ui.lib.application import MousePos
+
+    params.remove(self.PARAM)
+    params.put("ModelRunnerTypeCache", 1)
+    toggle = AcceleratorLinkToggle()
+    assert not toggle._checked
+    toggle._handle_mouse_release(MousePos(0, 0))
+    assert params.get(self.PARAM) is True
+    assert params.get("ModelRunnerTypeCache") is None, "the link decides which modeld manager runs"
+    toggle._handle_mouse_release(MousePos(0, 0))
+    assert params.get(self.PARAM) is False
+
+  def test_refresh_follows_the_param(self, params):
+    from openpilot.selfdrive.ui.sunnypilot.mici.layouts.models import AcceleratorLinkToggle
+
+    params.remove(self.PARAM)
+    toggle = AcceleratorLinkToggle()
+    params.put_bool(self.PARAM, True, block=True)
+    toggle.refresh()
+    assert toggle._checked
+
+  def test_link_toggle_cannot_change_runner_after_ignition(self, params):
+    from unittest import mock
+    from openpilot.selfdrive.ui.sunnypilot.mici.layouts.models import AcceleratorLinkToggle
+
+    params.remove(self.PARAM)
+    toggle = AcceleratorLinkToggle()
+    with mock.patch('openpilot.selfdrive.ui.sunnypilot.mici.layouts.models.ui_state.is_offroad', return_value=False), \
+         mock.patch('openpilot.selfdrive.ui.sunnypilot.mici.layouts.models.set_link_enabled') as write:
+      toggle._store(True)
+      write.assert_not_called()
+    assert params.get(self.PARAM) is None
+    assert not toggle._checked, "the pill must not show a state the param does not have"
+
+  def test_layout_hides_the_toggle_until_it_means_something(self, params):
+    from openpilot.selfdrive.ui.sunnypilot.mici.layouts.models import ModelsLayoutMici
+
+    params.remove(self.PARAM)
+    with self._accelerators():
+      layout = ModelsLayoutMici()
+      assert not layout.link_toggle.is_visible
+      assert layout.link_toggle in layout._scroller.items
+    with self._accelerators(present=True):
+      layout = ModelsLayoutMici()
+      assert layout.link_toggle.is_visible
+      render(layout)
+      render(layout)
+      render(layout.link_toggle)

--- a/openpilot/selfdrive/ui/sunnypilot/model_info.py
+++ b/openpilot/selfdrive/ui/sunnypilot/model_info.py
@@ -5,8 +5,9 @@ This file is part of sunnypilot and is licensed under the MIT License.
 See the LICENSE.md file in the root directory for more details.
 """
 from openpilot.selfdrive.ui.ui_state import ui_state, ChestnutState
+from openpilot.sunnypilot import accelerators
 from openpilot.sunnypilot.models.fetcher import get_cached_bundles
-from openpilot.sunnypilot.models.helpers import get_active_source, get_selected_bundle, resolve_bundle_by_ref
+from openpilot.sunnypilot.models.helpers import effective_small_bundle, get_active_source, get_selected_bundle, resolve_bundle_by_ref
 from openpilot.sunnypilot.models.model_name import DEFAULT_BIG_MODEL, DEFAULT_MODEL
 
 
@@ -37,10 +38,27 @@ def big_model_state() -> str | None:
           ChestnutState.LOADING: 'loading'}.get(ui_state.chestnut_state)
 
 
+def big_model_progress() -> tuple[str, float, str] | None:
+  """(stage, 0..1, message) while an accelerator is working, else None. The message
+  is carried because a stage like "waiting for the jetson" has no meaningful fraction"""
+  progress = getattr(ui_state, 'accelerator_progress', None)
+  if not progress:
+    return None
+  stage = str(progress.get('stage', ''))
+  if stage in ('', 'ready'):
+    return None
+  return stage, float(progress.get('frac', 0.0)), str(progress.get('msg', ''))
+
+
 def carrying_model() -> tuple[str | None, str | None, str | None]:
   """(source, internal name, display name) of what actually drives. Runner-matched:
   when a Default big cannot carry, stock modeld runs the Default small, never the
   small slot's pick; a custom big has no automatic fallback yet -> (None, None, None)."""
+  # only when no board is fitted does the chestnut state describe the jetlink view
+  if not ui_state.chestnut_present and ui_state.chestnut_state == ChestnutState.ACTIVE:
+    name = accelerators.active_model_name()
+    if name is not None:
+      return 'accelerator', name, name
   source = active_source()
   if source == "chestnut":
     bundle = get_selected_bundle(ui_state.params, "chestnut")
@@ -53,7 +71,7 @@ def carrying_model() -> tuple[str | None, str | None, str | None]:
       name = default_model_name("qcom")
       return "qcom", name, name
     return None, None, None
-  bundle = get_selected_bundle(ui_state.params, "qcom")
+  bundle = effective_small_bundle(ui_state.params)
   if bundle:
     return "qcom", bundle.internalName, bundle.displayName
   name = default_model_name("qcom")
@@ -69,6 +87,14 @@ def queued_name(current_ref) -> str | None:
   return None
 
 
+def slot_bundle(source: str):
+  # the qcom slot reads through effective_small_bundle: under the jetlink override
+  # stock modeld runs the default small model and the stored bundle is not loaded
+  if source == "qcom":
+    return effective_small_bundle(ui_state.params)
+  return get_selected_bundle(ui_state.params, source)
+
+
 def model_info() -> tuple[str, str, str]:
   """returns (active source, active model name, other model name)
 
@@ -77,8 +103,8 @@ def model_info() -> tuple[str, str, str]:
   would flash the wrong model."""
   source = active_source()
   other = "qcom" if source == "chestnut" else "chestnut"
-  active_bundle = get_selected_bundle(ui_state.params, source)
-  other_bundle = get_selected_bundle(ui_state.params, other)
+  active_bundle = slot_bundle(source)
+  other_bundle = slot_bundle(other)
 
   active_name = active_bundle.displayName if active_bundle else default_model_name(source)
   other_name = other_bundle.displayName if other_bundle else default_model_name(other)

--- a/openpilot/selfdrive/ui/sunnypilot/tests/test_model_info.py
+++ b/openpilot/selfdrive/ui/sunnypilot/tests/test_model_info.py
@@ -1,0 +1,68 @@
+"""
+Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+"""
+from unittest import mock
+
+from openpilot.cereal import custom
+from openpilot.common.test import OpenpilotTestCase
+from openpilot.selfdrive.ui.sunnypilot import model_info
+from openpilot.selfdrive.ui.ui_state import ChestnutState
+from openpilot.sunnypilot.models.helpers import REQUIRED_JSON_VERSION
+from openpilot.sunnypilot.models.model_name import DEFAULT_MODEL
+
+
+def _raw_bundle(ref: str) -> dict:
+  bundle = custom.ModelManagerSP.ModelBundle.new_message()
+  bundle.ref = ref
+  bundle.minimumSelectorVersion = REQUIRED_JSON_VERSION
+  bundle.internalName = ref
+  bundle.displayName = ref
+  bundle.runner = custom.ModelManagerSP.Runner.tinygrad
+  return bundle.to_dict()
+
+
+class TestCarryingModel(OpenpilotTestCase):
+  """What the UI names as driving has to be what stock modeld loads. Under the
+  jetlink override that is the default small model, never the stored qcom bundle."""
+
+  def setUp(self):
+    super().setUp()
+    self.ui_state = mock.MagicMock()
+    self.ui_state.chestnut_present = False
+    self.ui_state.chestnut_state = ChestnutState.DISCONNECTED
+    self.ui_state.chestnut_active = False
+    self.ui_state.chestnut_loading = False
+    self.ui_state.is_offroad.return_value = True
+    self.ui_state.params.get.side_effect = lambda key: {"ModelManager_ActiveBundle": _raw_bundle("custom_small")}.get(key)
+    patcher = mock.patch.object(model_info, "ui_state", self.ui_state)
+    patcher.start()
+    self.addCleanup(patcher.stop)
+
+  def test_override_names_the_default_small_model(self):
+    with mock.patch("openpilot.sunnypilot.accelerators.uses_stock_runner", return_value=True):
+      assert model_info.carrying_model() == ("qcom", f"{DEFAULT_MODEL} (Default)", f"{DEFAULT_MODEL} (Default)")
+      source, active, _ = model_info.model_info()
+    assert (source, active) == ("qcom", f"{DEFAULT_MODEL} (Default)")
+
+  def test_without_override_names_the_stored_bundle(self):
+    with mock.patch("openpilot.sunnypilot.accelerators.uses_stock_runner", return_value=False):
+      assert model_info.carrying_model() == ("qcom", "custom_small", "custom_small")
+      source, active, _ = model_info.model_info()
+    assert (source, active) == ("qcom", "custom_small")
+
+  def test_link_active_names_the_accelerator_model(self):
+    self.ui_state.chestnut_state = ChestnutState.ACTIVE
+    with mock.patch("openpilot.sunnypilot.accelerators.uses_stock_runner", return_value=True), \
+         mock.patch("openpilot.sunnypilot.accelerators.active_model_name", return_value="big"):
+      assert model_info.carrying_model() == ("accelerator", "big", "big")
+
+  def test_fitted_board_is_chestnut_not_jetlink(self):
+    # a real chestnut ACTIVE keeps comma's semantics whatever JetlinkModel says
+    self.ui_state.chestnut_present = True
+    self.ui_state.chestnut_state = ChestnutState.ACTIVE
+    self.ui_state.params.get.side_effect = lambda key: {"ModelManager_ActiveBundleChestnut": _raw_bundle("big_custom")}.get(key)
+    with mock.patch("openpilot.sunnypilot.accelerators.active_model_name", return_value="jetlink_big"):
+      assert model_info.carrying_model() == ("chestnut", "big_custom", "big_custom")

--- a/openpilot/selfdrive/ui/sunnypilot/ui_state.py
+++ b/openpilot/selfdrive/ui/sunnypilot/ui_state.py
@@ -5,10 +5,12 @@ This file is part of sunnypilot and is licensed under the MIT License.
 See the LICENSE.md file in the root directory for more details.
 """
 from enum import Enum
+from typing import NamedTuple
 
 from openpilot.cereal import messaging, log, custom
 from opendbc.car.structs import car
 from openpilot.common.params import Params
+from openpilot.sunnypilot import accelerators
 from openpilot.selfdrive.ui.sunnypilot.layouts.settings.display import OnroadBrightness
 from openpilot.sunnypilot.models.helpers import ACTIVE_BUNDLE_KEYS, get_active_source
 from openpilot.sunnypilot.sunnylink.sunnylink_state import SunnylinkState
@@ -27,6 +29,16 @@ class OnroadTimerStatus(Enum):
   RESUME = 2
 
 
+class AcceleratorView(NamedTuple):
+  """What the UI knows about an off-board accelerator, built on the params pass when no
+  chestnut is fitted. Presence comes from the backend: the comma is the gadget and enumerates nothing."""
+  present: bool
+  ready: bool
+  progress: dict | None
+  uses_stock_runner: bool
+  state: str  # modelDataV2SP.acceleratorState, by enum name
+
+
 class UIStateSP:
   def __init__(self):
     self.params = Params()
@@ -35,7 +47,8 @@ class UIStateSP:
     self.is_sp_release: bool = self.params.get_bool("IsReleaseSpBranch")
     self.sm_services_ext = [
       "modelManagerSP", "selfdriveStateSP", "longitudinalPlanSP", "backupManagerSP",
-      "gpsLocation", "lateralTorqueParameters", "carStateSP", "liveMapDataSP", "carParamsSP", "lateralDelay"
+      "gpsLocation", "lateralTorqueParameters", "carStateSP", "liveMapDataSP", "carParamsSP", "lateralDelay",
+      "modelDataV2SP"
     ]
 
     self.sunnylink_state = SunnylinkState()
@@ -45,6 +58,9 @@ class UIStateSP:
 
     self.active_bundle = None
     self.model_runner_tinygrad: bool = False
+    self.accelerator_view: AcceleratorView | None = None
+    self.accelerator_progress: dict | None = None
+    self._accelerator_state_name: str = 'none'
     self.blindspot: bool = False
     self.chevron_metrics = None
     self.custom_interactive_timeout: int = 0
@@ -70,6 +86,34 @@ class UIStateSP:
       self.sunnylink_state.start()
     else:
       self.sunnylink_state.stop()
+    # read where sm is updated, so the params thread never touches a message
+    self._accelerator_state_name = str(self.sm['modelDataV2SP'].acceleratorState)
+
+  def _accelerator_state(self):
+    """ChestnutState for the accelerator view: progress param offroad, modelV2 and acceleratorState onroad"""
+    from openpilot.selfdrive.ui.ui_state import ChestnutState  # defined by the class that mixes this in
+    view = self.accelerator_view
+    if not self.started:
+      stage = str((view.progress or {}).get('stage', ''))
+      if not view.present:
+        return ChestnutState.DISCONNECTED
+      if stage and stage != 'ready':
+        return ChestnutState.FAILED if stage == 'failed' else ChestnutState.LOADING
+      return ChestnutState.READY if view.ready else ChestnutState.UNCOMPILED
+
+    model_seen = self.sm.recv_frame["modelV2"] > self.started_frame
+    if model_seen and self.sm.alive["modelV2"] and self.sm["modelV2"].big:
+      return ChestnutState.ACTIVE
+    if not view.present:
+      return ChestnutState.DISCONNECTED
+    # attached, a pending join is loading, not a failed model
+    if view.state in ('joining', 'retrying') or not model_seen:
+      return ChestnutState.LOADING
+    if not view.ready:
+      return ChestnutState.UNCOMPILED
+    if view.state == 'running':
+      return ChestnutState.ACTIVE
+    return ChestnutState.FAILED
 
   def onroad_brightness_handle_alerts(self, _ui_state, alert):
     if _ui_state.sm.recv_frame["carState"] < _ui_state.started_frame:
@@ -156,9 +200,24 @@ class UIStateSP:
                                chestnut_loading=self.chestnut_loading, offroad=self.is_offroad())
     self.active_bundle = self.params.get(ACTIVE_BUNDLE_KEYS[source])
     self.model_runner_tinygrad = self.active_bundle is not None and self.active_bundle.get("runner") == "tinygrad"
-    # stock only counts the default big model's compiled pkl. a downloaded big bundle runs on the
-    # chestnut just the same, so ChestnutState has to see it as available too.
-    self.chestnut_compiled = self.chestnut_compiled or self.model_runner_tinygrad
+    # read on the 5 Hz params pass, not per frame in a layout
+    self.accelerator_progress = accelerators.progress()
+    stock_runner = accelerators.uses_stock_runner()
+    # a downloaded big bundle runs on the chestnut too, so it counts as available, except
+    # under the accelerator override where stock modeld never loads it
+    if not stock_runner:
+      self.chestnut_compiled = self.chestnut_compiled or self.model_runner_tinygrad
+    # a fitted chestnut owns chestnut_state; the view exists only when there is something to show
+    view = None
+    if not self.sm['deviceState'].chestnutPresent:
+      present, ready = accelerators.present(), accelerators.ready()
+      if present or ready or self.accelerator_progress is not None or stock_runner:
+        view = AcceleratorView(present, ready, self.accelerator_progress, stock_runner, self._accelerator_state_name)
+    self.accelerator_view = view
+    # the Jetson configures the gadget ~25 s after a cold boot, after the one-shot
+    # usb_unknown decision; recognising it late still clears "unknown"
+    if view is not None and view.present and self.usb_unknown:
+      self.usb_unknown = False
     self.blindspot = self.params.get_bool("BlindSpot")
     self.chevron_metrics = self.params.get("ChevronInfo")
     self.custom_interactive_timeout = self.params.get("InteractivityTimeout", return_default=True)

--- a/openpilot/selfdrive/ui/tests/test_accelerator_ui.py
+++ b/openpilot/selfdrive/ui/tests/test_accelerator_ui.py
@@ -1,0 +1,278 @@
+"""
+Copyright (c) 2026-, Zeph Leggett.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+"""
+
+# ui_state's accelerator view beside upstream's chestnut state, and the tici
+# models panel's link toggle and accelerator picker.
+
+import os
+from contextlib import ExitStack
+from unittest import mock
+
+import pytest
+
+os.environ["BIG"] = "0"
+os.environ.setdefault("SCALE", "1")
+
+
+@pytest.fixture(scope="module")
+def gui():
+  """Hidden raylib window + isolated params dir. Widgets need textures, so a window is required."""
+  import pyray as rl
+  from openpilot.common.prefix import OpenpilotPrefix
+
+  with OpenpilotPrefix():
+    rl.set_config_flags(rl.FLAG_WINDOW_HIDDEN)
+    from openpilot.system.ui.lib.application import gui_app
+    gui_app.init_window("test_accelerator_ui", fps=30)
+    yield gui_app
+    gui_app.close()
+
+
+@pytest.fixture
+def params(gui):
+  from openpilot.common.params import Params
+  from openpilot.selfdrive.ui.ui_state import ui_state
+
+  p = Params()
+  ui_state.params = p
+  ui_state.update_params()
+  return p
+
+
+def accelerator(present=False, ready=False, progress=None, stock=False, choices=None):
+  stack = ExitStack()
+  for name, value in (("present", present), ("ready", ready), ("progress", progress),
+                      ("uses_stock_runner", stock), ("model_choices", choices or []),
+                      ("unavailable_reason", None)):
+    stack.enter_context(mock.patch(f"openpilot.sunnypilot.accelerators.{name}", return_value=value))
+  return stack
+
+
+class FakeSM:
+  def __init__(self, board, big=False, alive=False, recv=0, state='none'):
+    self.board = board
+    self.recv_frame = {"modelV2": recv}
+    self.alive = {"modelV2": alive}
+    self.big = big
+    self.state = state
+
+  def __getitem__(self, name):
+    if name == "deviceState":
+      return type("DS", (), {"chestnutPresent": self.board})()
+    if name == "modelDataV2SP":
+      return type("SP", (), {"acceleratorState": self.state})()
+    assert name == "modelV2"
+    return type("M", (), {"big": self.big})()
+
+
+class TestUIStateAcceleratorView:
+  @staticmethod
+  def _with(sm, started=False):
+    from openpilot.selfdrive.ui.ui_state import ui_state
+    saved = ui_state.sm, ui_state.started, ui_state.started_frame, ui_state.accelerator_view, ui_state.chestnut_present
+    ui_state.sm, ui_state.started, ui_state.started_frame = sm, started, 0
+    ui_state.chestnut_present = sm.board
+    return saved
+
+  @staticmethod
+  def _restore(saved):
+    from openpilot.selfdrive.ui.ui_state import ui_state
+    ui_state.sm, ui_state.started, ui_state.started_frame, ui_state.accelerator_view, ui_state.chestnut_present = saved
+
+  def test_a_fitted_chestnut_never_asks_the_accelerator(self, params):
+    """A board present is upstream's path byte for byte: no view, and nothing in the
+    state update consults sunnypilot/accelerators."""
+    from openpilot.selfdrive.ui.ui_state import ui_state, ChestnutState
+    saved = self._with(FakeSM(board=True))
+    try:
+      with accelerator(present=True, ready=True, stock=True):
+        ui_state.update_params()
+      assert ui_state.accelerator_view is None
+      ui_state.chestnut_compiled = True
+      with mock.patch("openpilot.sunnypilot.accelerators.present", side_effect=AssertionError("consulted")), \
+           mock.patch("openpilot.sunnypilot.accelerators.ready", side_effect=AssertionError("consulted")):
+        ui_state._update_chestnut_state()
+      assert ui_state.chestnut_state == ChestnutState.READY
+    finally:
+      self._restore(saved)
+
+  def test_no_board_and_nothing_of_ours_is_no_view(self, params):
+    from openpilot.selfdrive.ui.ui_state import ui_state, ChestnutState
+    saved = self._with(FakeSM(board=False))
+    try:
+      with accelerator():
+        ui_state.update_params()
+      assert ui_state.accelerator_view is None
+      ui_state._update_chestnut_state()
+      assert ui_state.chestnut_state == ChestnutState.DISCONNECTED
+    finally:
+      self._restore(saved)
+
+  def test_an_attached_accelerator_builds_the_view(self, params):
+    from openpilot.selfdrive.ui.ui_state import ui_state, ChestnutState
+    saved = self._with(FakeSM(board=False))
+    try:
+      with accelerator(present=True, ready=True, stock=True):
+        ui_state.update_params()
+      view = ui_state.accelerator_view
+      assert view is not None and view.present and view.ready and view.uses_stock_runner
+      ui_state._update_chestnut_state()
+      assert ui_state.chestnut_state == ChestnutState.READY
+    finally:
+      self._restore(saved)
+
+  def test_a_bundle_that_is_not_running_does_not_read_compiled(self, params):
+    """Under the accelerator override manager runs stock modeld, so a stored tinygrad
+    bundle must not make the icon say the big model is ready."""
+    from openpilot.selfdrive.ui.ui_state import ui_state
+    from openpilot.sunnypilot.models.helpers import ACTIVE_BUNDLE_KEYS
+    saved = self._with(FakeSM(board=False))
+    compiled, real = ui_state.chestnut_compiled, ui_state.params
+    # served from a wrapper rather than written: the model manager's validation
+    # discards a bundle it cannot resolve, from whatever thread reaches it first
+    fake = mock.Mock(wraps=real)
+    fake.get.side_effect = lambda key, *a, **k: {"runner": "tinygrad"} if key == ACTIVE_BUNDLE_KEYS["qcom"] else real.get(key, *a, **k)
+    try:
+      ui_state.chestnut_compiled = False
+      ui_state.params = fake
+      with accelerator(present=True, stock=True):
+        ui_state.update_params()
+      assert ui_state.model_runner_tinygrad
+      assert ui_state.chestnut_compiled is False
+      with accelerator(present=True, stock=False):
+        ui_state.update_params()
+      assert ui_state.chestnut_compiled is True
+    finally:
+      ui_state.params = real
+      ui_state.chestnut_compiled = compiled
+      self._restore(saved)
+
+  def test_onroad_disconnected_then_active(self, params):
+    from openpilot.selfdrive.ui.ui_state import ui_state, ChestnutState
+    saved = self._with(FakeSM(board=False, alive=True, recv=1, state='retrying'), started=True)
+    try:
+      with accelerator(present=False, ready=True, stock=True):
+        ui_state.update_params()
+      assert ui_state.accelerator_view is not None
+      ui_state._update_chestnut_state()
+      assert ui_state.chestnut_state == ChestnutState.DISCONNECTED
+
+      ui_state.sm = FakeSM(board=False, big=True, alive=True, recv=1, state='running')
+      with accelerator(present=True, ready=True, stock=True):
+        ui_state.update_params()
+      ui_state._update_chestnut_state()
+      assert ui_state.chestnut_state == ChestnutState.ACTIVE
+    finally:
+      self._restore(saved)
+
+  def test_the_status_name_is_read_where_sm_updates(self, params):
+    from openpilot.selfdrive.ui.sunnypilot.ui_state import UIStateSP
+    from openpilot.selfdrive.ui.ui_state import ui_state
+    saved = self._with(FakeSM(board=False, state='joining'))
+    try:
+      UIStateSP.update(ui_state)
+      with accelerator(present=True):
+        ui_state.update_params()
+      assert ui_state.accelerator_view.state == 'joining'
+    finally:
+      self._restore(saved)
+
+
+class TestTiciModelsPanel:
+  CHOICES = [{'name': 'Cinque Terre', 'selected': True, 'cached': True},
+             {'name': 'Lebowski', 'selected': False, 'cached': False}]
+
+  @staticmethod
+  def _layout():
+    from openpilot.selfdrive.ui.sunnypilot.layouts.settings.models import ModelsLayout
+    return ModelsLayout()
+
+  def test_hidden_on_a_plain_device(self, params):
+    with accelerator():
+      layout = self._layout()
+    assert not layout.accelerator_link_item.is_visible
+    assert not layout.accelerator_model_item.is_visible
+
+  def test_shown_with_an_accelerator(self, params):
+    with accelerator(present=True, choices=self.CHOICES):
+      layout = self._layout()
+    assert layout.accelerator_link_item.is_visible
+    assert layout.accelerator_model_item.is_visible
+
+  def test_toggle_writes_the_param_and_drops_the_runner_cache(self, params):
+    params.put("ModelRunnerTypeCache", 1)
+    with accelerator(present=True), mock.patch.object(ui_state_module().ui_state, "is_offroad", return_value=True):
+      layout = self._layout()
+      layout._set_link_state(True)
+      assert params.get_bool("JetlinkEnabled") is True
+      assert params.get("ModelRunnerTypeCache") is None
+      layout._set_link_state(False)
+      assert params.get_bool("JetlinkEnabled") is False
+
+  def test_toggle_is_inert_onroad(self, params):
+    params.remove("JetlinkEnabled")
+    with accelerator(present=True), mock.patch.object(ui_state_module().ui_state, "is_offroad", return_value=False):
+      layout = self._layout()
+      layout._set_link_state(True)
+      assert params.get("JetlinkEnabled") is None
+      assert layout.accelerator_link_item.action_item.get_state() is False
+
+  def test_picker_selects_through_the_module_api(self, params):
+    from openpilot.system.ui.widgets import DialogResult
+    with accelerator(present=True, choices=self.CHOICES), \
+         mock.patch("openpilot.sunnypilot.accelerators.select_model") as select, \
+         mock.patch.object(ui_state_module().ui_state, "is_offroad", return_value=True), \
+         mock.patch("openpilot.system.ui.lib.application.gui_app.push_widget"):
+      layout = self._layout()
+      layout._open_accelerator_dialog()
+      assert layout.accelerator_dialog is not None
+      layout.accelerator_dialog.selection = 'Lebowski'
+      layout._on_accelerator_selected(DialogResult.CONFIRM)
+      select.assert_called_once_with('Lebowski')
+      assert params.get("ModelManager_DownloadRef") is None
+
+  def test_picker_is_inert_onroad(self, params):
+    from openpilot.system.ui.widgets import DialogResult
+    with accelerator(present=True, choices=self.CHOICES), \
+         mock.patch("openpilot.sunnypilot.accelerators.select_model") as select, \
+         mock.patch.object(ui_state_module().ui_state, "is_offroad", return_value=False), \
+         mock.patch("openpilot.system.ui.lib.application.gui_app.push_widget"):
+      layout = self._layout()
+      layout._open_accelerator_dialog()
+      layout.accelerator_dialog.selection = 'Lebowski'
+      layout._on_accelerator_selected(DialogResult.CONFIRM)
+      select.assert_not_called()
+
+  def test_status_note_names_the_accelerator_not_the_chestnut(self, params):
+    from openpilot.selfdrive.ui.sunnypilot.ui_state import AcceleratorView
+    ui_state = ui_state_module().ui_state
+    saved = ui_state.accelerator_view, ui_state.chestnut_present
+    try:
+      ui_state.chestnut_present = False
+      with accelerator(present=True, choices=self.CHOICES), \
+           mock.patch("openpilot.selfdrive.ui.sunnypilot.layouts.settings.models.big_model_state", return_value=None):
+        layout = self._layout()
+        ui_state.accelerator_view = AcceleratorView(True, False, None, True, 'none')
+        note = layout._status_note()
+        assert "chestnut" not in note
+        assert "Cinque Terre will drive when the accelerator is ready." == note
+        ui_state.accelerator_view = AcceleratorView(True, True, None, True, 'none')
+        note = layout._status_note()
+        assert note.startswith("Cinque Terre will drive.") and "chestnut" not in note
+    finally:
+      ui_state.accelerator_view, ui_state.chestnut_present = saved
+
+  def test_panel_renders(self, params):
+    import pyray as rl
+    with accelerator(present=True, choices=self.CHOICES):
+      layout = self._layout()
+      layout.render(rl.Rectangle(0, 0, 800, 600))
+
+
+def ui_state_module():
+  from openpilot.selfdrive.ui import ui_state
+  return ui_state

--- a/openpilot/selfdrive/ui/ui_state.py
+++ b/openpilot/selfdrive/ui/ui_state.py
@@ -218,6 +218,10 @@ class UIState(UIStateSP):
       self._started_prev = self.started
 
   def _update_chestnut_state(self) -> None:
+    if self.accelerator_view is not None:
+      self.chestnut_state = self._accelerator_state()
+      return
+
     detected = self.sm["deviceState"].chestnutPresent
     if not self.started:
       self.chestnut_present = detected
@@ -267,7 +271,9 @@ class UIState(UIStateSP):
         self.usb_connected_ts = now
         self.usb_unknown = False
       elif self.usb_connected_ts is not None and now - self.usb_connected_ts > 10.:
-        self.usb_unknown = not any(is_chestnut_usb_id(d["vendorId"], d["productId"], True) for d in get_usb_state())
+        # the comma is the gadget for an off-board accelerator and enumerates nothing
+        self.usb_unknown = not (self.accelerator_view is not None or
+                                any(is_chestnut_usb_id(d["vendorId"], d["productId"], True) for d in get_usb_state()))
         self.usb_connected_ts = None
     elif self.usb_connected:
       if self.usb_disconnected_ts is None:

--- a/openpilot/sunnypilot/SConscript
+++ b/openpilot/sunnypilot/SConscript
@@ -1,2 +1,3 @@
+SConscript(['accelerators/SConscript'])
 SConscript(['common/transformations/SConscript'])
 SConscript(['selfdrive/locationd/SConscript'])

--- a/openpilot/sunnypilot/accelerators/SConscript
+++ b/openpilot/sunnypilot/accelerators/SConscript
@@ -1,0 +1,61 @@
+# The comma-side warp JIT, as a build product.
+#
+# jetlink runs `warp` on the comma and `run_policy` on the Jetson, and upstream
+# no longer ships a standalone warp JIT (#38684 fused warp and policy). Built
+# here like dm_warp_*.pkl in modeld/SConscript: launch_chffrplus.sh runs
+# build.py before manager, so a tinygrad bump has a fresh warp before ignition.
+# Building it in modeld or jetlinkd instead loses the ~9 s compile to ignition
+# and costs a drive on the small model.
+import glob
+import importlib.util
+import os
+
+from SCons.Script import Action
+
+Import('env', 'arch')
+
+lenv = env.Clone()
+basedir = env.Dir("#").abspath
+
+
+def jetlink_installed() -> bool:
+  """Is the jetlink submodule checked out? An empty jetlink_repo/ has no package in it."""
+  return os.path.isdir(os.path.join(basedir, 'jetlink_repo', 'jetlink'))
+
+
+# comma GPU only: the pickle is captured against Device.DEFAULT and only modeld
+# on the device loads one
+if arch == 'comma_arm64' and jetlink_installed():
+  from openpilot.common.hardware import HARDWARE
+  from openpilot.common.transformations.camera import _ar_ox_fisheye, _os_fisheye
+  from openpilot.common.transformations.model import MEDMODEL_INPUT_SIZE
+
+  camera = _os_fisheye if HARDWARE.get_device_type() == "mici" else _ar_ox_fisheye
+  cam_w, cam_h = camera.width, camera.height
+  model_w, model_h = MEDMODEL_INPUT_SIZE
+
+  jetlink_dir = Dir("#openpilot/sunnypilot/accelerators/jetlink").abspath
+
+  # the target name comes from warp_cache so build and modeld cannot drift.
+  # By file, not by package: the package __init__ imports Params, which loads
+  # libparams_c, which scons has not built yet
+  _spec = importlib.util.spec_from_file_location('jetlink_warp_cache', f"{jetlink_dir}/warp_cache.py")
+  warp_cache = importlib.util.module_from_spec(_spec)
+  _spec.loader.exec_module(warp_cache)
+  pkl = str(warp_cache.warp_path(cam_w, cam_h, model_w, model_h))
+  tinygrad_files = ["#" + x for x in glob.glob(env.Dir("#tinygrad_repo").relpath + "/**",
+                                               recursive=True, root_dir=basedir)
+                    if 'pycache' not in x and os.path.isfile(os.path.join(basedir, x))]
+  script_files = [
+    File(f"{jetlink_dir}/compile_warp.py"),
+    File(f"{jetlink_dir}/warp_cache.py"),                    # make_warp's caller, and the capture itself
+    File("#openpilot/selfdrive/modeld/compile_modeld.py"),   # make_warp
+    File("#openpilot/system/camerad/cameras/nv12_info.py"),  # the frame layout the graph indexes
+  ]
+
+  # no tinygrad flags, unlike dm_warp: the bare-environment warp is what the
+  # parity and timing numbers were measured against
+  cmd = (f'python3 {jetlink_dir}/compile_warp.py '
+         f'--camera-resolution {cam_w}x{cam_h} --model-size {model_w}x{model_h} '
+         f'--output {pkl}')
+  lenv.Command(pkl, tinygrad_files + script_files, Action(cmd, "  [JETLINK WARP] $TARGET"))

--- a/openpilot/sunnypilot/accelerators/__init__.py
+++ b/openpilot/sunnypilot/accelerators/__init__.py
@@ -1,0 +1,148 @@
+"""
+Copyright (c) 2026-, Zeph Leggett.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+
+An accelerator that runs the large driving model off the comma: jetlink.
+
+comma's chestnut board is not one of these: modeld, hardwared and the UI handle
+it natively and only ask here when no board is fitted. Selection is
+`if chestnut_present(): native elif accelerators.ready(): jetlink`.
+
+Every function is a thin call into jetlink.backend and is safe on any device:
+feature off costs a param read, package absent answers the negative default.
+present(), ready(), progress() and uses_stock_runner() are polled by the UI at
+5 Hz and must stay cheap.
+"""
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable
+from typing import NamedTuple
+
+from openpilot.common.params import Params
+from openpilot.common.swaglog import cloudlog
+
+from openpilot.sunnypilot.accelerators.jetlink import backend
+
+# written by jetlinkd and the joining state, read by the UI; a param because
+# the writer is another process
+P_PROGRESS = "AcceleratorProgress"
+
+
+class Daemon(NamedTuple):
+  """An offroad process the accelerator needs.
+
+  A description, not a PythonProcess: manager imports this package, so this
+  package cannot import manager. process_config owns the onroad gating.
+  """
+  name: str
+  module: str
+  should_run: Callable[..., bool]
+
+
+def present() -> bool:
+  """Is a Jetson attached, or asleep and known to be there? USB-independent."""
+  return backend.present()
+
+
+def ready() -> bool:
+  """Can the large model run right now? Params only, what the UI calls 'compiled'."""
+  return backend.ready()
+
+
+def unavailable_reason() -> str | None:
+  """Why the link the user asked for cannot run, for the offroad alert. None unless enabled."""
+  return backend.unavailable_reason()
+
+
+def prepare() -> bool:
+  """Process-wide setup modeld must do before going realtime, and a last veto. modeld only."""
+  return backend.prepare()
+
+
+def make_model_state(cam_w: int, cam_h: int, small=None):
+  """The joining ModelState: the small model driving now, the Jetson swapped in later."""
+  return backend.make_model_state(cam_w, cam_h, small)
+
+
+def make_status_publisher(pm, model):
+  """modeld's after_enqueue callback. Publishes nothing; logs telemetry at 1 Hz."""
+  return backend.make_status_publisher(pm, model)
+
+
+def uses_stock_runner() -> bool:
+  """Should manager run stock modeld regardless of the stored bundle?
+
+  Configuration only, never link state or ready(): a Jetson that boots late
+  must not move manager between modelds mid-drive.
+  """
+  return backend.uses_stock_runner()
+
+
+def model_choices() -> list[dict]:
+  return backend.model_choices()
+
+
+def select_model(name: str) -> None:
+  backend.select_model(name)
+
+
+def active_model_name() -> str | None:
+  return backend.active_model_name()
+
+
+def daemons() -> list[Daemon]:
+  """Offroad processes for process_config to build."""
+  return [Daemon("jetlinkd", "openpilot.sunnypilot.accelerators.jetlink.jetlinkd",
+                 lambda started, params, CP: backend.enabled())]
+
+
+def progress() -> dict | None:
+  """{stage, frac, msg} while something provisions, else None.
+
+  Read from the UI's param thread, so nothing may escape, UnknownKeyName included.
+  """
+  try:
+    value = Params().get(P_PROGRESS)
+  except Exception:
+    return None
+  return value if isinstance(value, dict) else None
+
+
+def report_progress(stage: str, frac: float, msg: str = '') -> None:
+  """Never raises: called from except handlers."""
+  try:
+    Params().put(P_PROGRESS, {'stage': stage, 'frac': round(frac, 4), 'msg': msg})
+  except Exception:
+    cloudlog.exception("accelerators: could not report progress")
+
+
+def clear_progress() -> None:
+  try:
+    Params().remove(P_PROGRESS)
+  except Exception:
+    cloudlog.exception("accelerators: could not clear progress")
+
+
+def shutdown(reason: str = '', timeout: float = 25.0) -> None:
+  """The device is powering off for good. Tell the Jetson, within `timeout`.
+
+  hardwared calls this before DoShutdown and publishes no deviceState until it
+  returns, so the request runs on a thread and is abandoned at the deadline.
+  """
+  if not backend.enabled():
+    return
+
+  def request():
+    try:
+      backend.shutdown(reason, timeout)
+    except Exception:
+      cloudlog.exception("accelerators: shutdown request failed")
+
+  t = threading.Thread(target=request, name='accelerator-shutdown', daemon=True)
+  t.start()
+  t.join(timeout)
+  if t.is_alive():
+    cloudlog.warning("accelerators: shutdown request still pending after %.0f s, going on without it", timeout)

--- a/openpilot/sunnypilot/accelerators/conftest.py
+++ b/openpilot/sunnypilot/accelerators/conftest.py
@@ -1,0 +1,24 @@
+"""
+Copyright (c) 2026-, Zeph Leggett.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+
+Keep these tests out of the device's real params.
+
+Some of them exercise code that clears params. On the comma that is the live
+directory: a suite run cleared JetlinkEngineReady once and left the device on
+the small model with nothing reported, because ready() is params-only.
+params.cc reads OPENPILOT_PREFIX on every Params(), so setting it before any
+test module is imported covers the whole subtree.
+"""
+from openpilot.common.prefix import OpenpilotPrefix
+
+# a prefix isolates Params and msgq; the environment alone left the msgq
+# directory absent on AGNOS and broke any test using a real SubMaster
+_prefix = OpenpilotPrefix()
+_prefix.__enter__()
+
+
+def pytest_sessionfinish(session, exitstatus):
+  _prefix.__exit__(None, None, None)

--- a/openpilot/sunnypilot/accelerators/jetlink/__init__.py
+++ b/openpilot/sunnypilot/accelerators/jetlink/__init__.py
@@ -1,0 +1,12 @@
+"""
+Copyright (c) 2026-, Zeph Leggett.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+
+Run openpilot's large driving models on an attached Jetson.
+
+The transport, protocol and TensorRT server live in the standalone `jetlink`
+package so other projects can reuse them. Everything here is the openpilot glue
+and nothing else; backend.py is the only part core openpilot ever calls.
+"""

--- a/openpilot/sunnypilot/accelerators/jetlink/backend.py
+++ b/openpilot/sunnypilot/accelerators/jetlink/backend.py
@@ -1,0 +1,323 @@
+"""
+Copyright (c) 2026-, Zeph Leggett.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+
+The accelerator backend: everything core openpilot calls, and nothing else.
+
+A module of functions behind sunnypilot.accelerators, the only thing core
+openpilot imports. Anything only jetlinkd needs lives in helpers or spec_cache.
+The `jetlink` client package can be absent on a device; this module imports
+without it, and the functions that need it answer their negative default when
+it is not there, logging once.
+"""
+from __future__ import annotations
+
+import threading
+import time
+
+from openpilot.common.swaglog import cloudlog
+
+from openpilot.sunnypilot.accelerators.jetlink import helpers, spec_cache
+
+# how long one attempt holds the gadget open waiting for a host. Not a deadline
+# on the large model: JoiningModelState retries for the drive, since the Jetson
+# boots after the comma is already onroad
+CONNECT_TIMEOUT = 45.0
+CONNECT_DELAY = 0.5
+# ten frame periods; a dead server must not hold the frame thread for seconds
+INFERENCE_TIMEOUT = 0.5
+# how long the load may wait for the early gadget bind; jetlinkd may still be
+# letting go of the endpoints
+PRESENT_TIMEOUT = 5.0
+
+# how long hardwared waits for jetlinkd to shut the Jetson down. Wake from
+# suspend is ~8 s to a server
+SHUTDOWN_TIMEOUT = 25.0
+
+_missing_reported = False
+
+
+def _package_missing(what: str) -> bool:
+  """True, and logged once, if the jetlink client package cannot be imported."""
+  global _missing_reported
+  try:
+    import jetlink.client  # noqa: F401
+  except ImportError:
+    if not _missing_reported:
+      cloudlog.warning("jetlink: package not installed, %s unavailable", what)
+      _missing_reported = True
+    return True
+  return False
+
+
+def _wait_for_host(deadline: float) -> bool:
+  reported = False
+  while time.monotonic() < deadline:
+    if helpers.host_attached():
+      return True
+    if not reported:
+      cloudlog.warning("jetlink: gadget up, waiting for the jetson to enumerate")
+      reported = True
+    time.sleep(CONNECT_DELAY)
+  return False
+
+
+def _present_early(ready: dict) -> None:
+  """Open and bind the gadget now, from a thread that is not modeld's.
+
+  modeld's main thread is already SCHED_FIFO 54 on core 7, and the FunctionFS
+  reader the open creates would inherit that and preempt the frame loop (see
+  joining._background_priority). Bounded, so a hung open cannot hold modeld's
+  load; a helper that finishes late closes what it opened.
+  """
+  from openpilot.sunnypilot.accelerators.jetlink.joining import _background_priority
+  lock = threading.Lock()
+
+  deadline = time.monotonic() + PRESENT_TIMEOUT
+
+  def present():
+    _background_priority()
+    # retried: manager has just stopped jetlinkd, which may not have let go of
+    # ep0 yet, and a single try fails in milliseconds
+    client = None
+    while client is None:
+      try:
+        client = helpers.connect()
+      except Exception as e:
+        if time.monotonic() >= deadline:
+          cloudlog.warning("jetlink: could not present the gadget early (%s), the join will", e)
+          return
+        time.sleep(0.2)
+    with lock:
+      if ready.get('abandoned'):
+        client.close()
+      else:
+        ready['client'] = client
+
+  t = threading.Thread(target=present, name='jetlink-present', daemon=True)
+  t.start()
+  t.join(max(0.0, deadline - time.monotonic()) + 0.5)
+  with lock:
+    if t.is_alive():
+      ready['abandoned'] = True
+      cloudlog.warning("jetlink: presenting the gadget took over %.0f s, the join will", PRESENT_TIMEOUT)
+
+
+def _connect_patiently(client=None):
+  """Open the link, tolerating a busy gadget or a Jetson that is still booting.
+
+  A `client` already holding the gadget (presented early) skips the open."""
+  deadline = time.monotonic() + CONNECT_TIMEOUT
+  last = None
+  while True:
+    if client is None:
+      try:
+        client = helpers.connect()
+      except Exception as e:
+        client, last = None, e
+    if client is not None:
+      if helpers.host_attached():
+        return client
+      # the gadget is held now, so the Jetson sees it the moment it is up;
+      # keep it open rather than churning the endpoints
+      if _wait_for_host(deadline):
+        return client
+      client.close()
+      raise TimeoutError(f"no jetson attached within {CONNECT_TIMEOUT:.0f}s")
+    if time.monotonic() > deadline:
+      raise last if last is not None else TimeoutError("could not open the link")
+    cloudlog.warning("jetlink: link not ready (%s), retrying", last)
+    time.sleep(CONNECT_DELAY)
+
+
+def enabled() -> bool:
+  return helpers.enabled()
+
+
+def present() -> bool:
+  return helpers.gadget_present()
+
+
+def ready() -> bool:
+  # params only, no link IO: jetlinkd has already recorded the answer
+  if not helpers.enabled() or helpers.gadget_error() is not None:
+    return False
+  spec = spec_cache.load()
+  selected = helpers.selected_model()
+  return (spec is not None and selected is not None and spec.sha256 == selected['oid']
+          and helpers.engine_ready_for(spec.sha256))
+
+
+def unavailable_reason() -> str | None:
+  return helpers.gadget_alert()
+
+
+def prepare() -> bool:
+  # the link is not worth waiting for: make_model_state joins in the background.
+  # The warp is: scons builds it before manager starts, so one missing now stays
+  # missing for the drive, and saying no keeps modeld on the plain small model
+  if _package_missing('the large model'):
+    return False
+  from openpilot.sunnypilot.accelerators.jetlink import warp_cache
+  if not warp_cache.is_cached(*warp_cache.device_geometry()):
+    cloudlog.warning("jetlink: no warp compiled yet, staying on the small model")
+    return False
+  # the last hook before modeld goes SCHED_FIFO on core 7, and the GPU's init
+  # spawns a thread that would inherit that. See warp_cache.init_device
+  warp_cache.init_device()
+  return True
+
+
+def make_model_state(cam_w: int, cam_h: int, small=None):
+  # returns straight away with the small model driving; see joining.py
+  if _package_missing('the large model'):
+    return None
+  from openpilot.sunnypilot.accelerators.jetlink.joining import JoiningModelState
+  from openpilot.sunnypilot.accelerators.jetlink import warp_cache
+
+  # the warp is loaded and warmed here, before the frame loop exists, rather
+  # than at the swap on a driving frame. Sized from the cached spec, which is
+  # what the link will hand back; another geometry is rejected
+  ready: dict = {}
+
+  def prepare():
+    from openpilot.sunnypilot.accelerators.jetlink.fallback import prepare_reset
+    # the gadget first, so the Jetson enumerates while the warp loads. Left to
+    # the join thread the bind landed ~3 s later, behind the small model's
+    # first frame, and one ignition had a 655 ms frame during the bind
+    _present_early(ready)
+    cached = spec_cache.load()
+    if cached is not None:
+      img_h, img_w = cached.input_shapes['img'][2:]
+      geometry = (img_w * 2, img_h * 2)
+    else:
+      geometry = warp_cache.device_geometry()[2:]
+    try:
+      ready['reset_small'] = prepare_reset(small)
+      warp = warp_cache.load_warp(cam_w, cam_h, *geometry)
+      warp_cache.warm(warp, cam_w, cam_h)
+    except Exception:
+      client = ready.pop('client', None)
+      if client is not None:
+        client.close()
+      raise
+    ready.update(warp=warp, geometry=geometry)
+
+  def build(client, spec):
+    from openpilot.sunnypilot.accelerators.jetlink.model_state import JetlinkModelState
+    img_h, img_w = spec.input_shapes['img'][2:]
+    warp = ready.get('warp') if ready.get('geometry') == (img_w * 2, img_h * 2) else None
+    if warp is None:
+      raise RuntimeError('no prepared warp for the server model geometry')
+    return JetlinkModelState(cam_w, cam_h, client, spec, small, warp=warp)
+
+  def connect():
+    # the early client is good for one attempt; after that the join thread
+    # opens its own
+    return _open_link(ready.pop('client', None))
+
+  return JoiningModelState(cam_w, cam_h, small, connect, build, prepare,
+                           reset_small=lambda: ready['reset_small']())
+
+
+def _open_link(client=None):
+  """Get a client and a spec. Link IO only, so it is safe off modeld's thread;
+  everything that touches tinygrad stays in `build`."""
+  from jetlink.client import EngineMissing
+
+  cached = spec_cache.load()
+  if cached is None:
+    if client is not None:
+      client.close()
+    raise RuntimeError("no cached jetlink model spec; jetlinkd has not provisioned")
+
+  selected = helpers.selected_model()
+  if selected is None or selected['oid'] != cached.sha256:
+    if client is not None:
+      client.close()
+    raise RuntimeError('selected jetlink model has not been provisioned')
+
+  # the endpoints may still be held by jetlinkd, and the Jetson may still be
+  # booting; both resolve on their own
+  client = _connect_patiently(client)
+  try:
+    hello = client.hello(timeout=10.0)
+    cloudlog.warning("jetlink: %s trt %s, engine %s, loaded %s",
+                     hello.get('device'), hello.get('trt_version'),
+                     hello.get('engine_state'), str(hello.get('loaded'))[:16])
+    # normally one round trip, since jetlinkd left the engine loaded. If the
+    # server restarted it is a load from the plan cache, 13 to 25 s
+    try:
+      spec = client.ensure_engine(cached.sha256, cached.nbytes, frame_skip=cached.frame_skip,
+                                  build_timeout=120.0)
+    except EngineMissing:
+      # the Jetson's cache was pruned or re-flashed since jetlinkd recorded it
+      # ready. Clear the record so the next parked period provisions again
+      helpers.set_engine_ready(None)
+      raise
+    client.deadline = INFERENCE_TIMEOUT
+    return client, spec
+  except BaseException:
+    client.close()
+    raise
+
+
+def make_status_publisher(pm, model):
+  from openpilot.sunnypilot.accelerators.jetlink.status import JetlinkStatus
+  # the model, not its client: the link arrives after this is built and may
+  # come and go mid-drive. Reading model.client per send follows it
+  return JetlinkStatus(pm, model)
+
+
+def uses_stock_runner() -> bool:
+  # the toggle alone. JetlinkModel defaults through selected_model(), so gating
+  # on it left an enabled device on modeld_tinygrad where jetlink never runs.
+  # Not presence or readiness: a late boot must not move manager mid-drive
+  return helpers.enabled()
+
+
+def model_choices() -> list[dict]:
+  if not helpers.link_configured():
+    return []
+  selected = helpers.selected_model() or {}
+  cached = helpers._get('JetlinkCachedModels') or []
+  return [{'name': m['name'], 'selected': m['oid'] == selected.get('oid'),
+           'cached': m['oid'] in cached} for m in helpers.model_index()]
+
+
+def select_model(name: str) -> None:
+  from openpilot.common.params import Params
+  if name not in {m['name'] for m in helpers.model_index()}:
+    raise ValueError(f'unknown jetlink model: {name}')
+  Params().put(helpers.P_MODEL, name)
+  Params().put_bool(helpers.P_ENABLED, True)
+  Params().remove('ModelRunnerTypeCache')
+
+
+def active_model_name() -> str | None:
+  if not ready():
+    return None
+  return next((m['name'] for m in model_choices() if m['selected']), None)
+
+
+def shutdown(reason: str, timeout: float = SHUTDOWN_TIMEOUT) -> None:
+  """Take the Jetson down with the comma. Runs in hardwared, which cannot
+  touch the link: jetlinkd owns the gadget offroad and is the only one that
+  can wake a sleeping Jetson. Hand the request over and wait; the wake and one
+  round trip take ~10 s, and manager will not kill jetlinkd until this returns.
+
+  Skipped when no Jetson is known to be there (dormant counts as there). A
+  jetlinkd busy in a long provision will not see the request; the timeout
+  covers that.
+  """
+  if not helpers.enabled() or not helpers.gadget_present():
+    return
+  cloudlog.warning("jetlink: asking the jetson to power off: %s", reason)
+  if not helpers.request_shutdown(reason):
+    return
+  if helpers.await_shutdown(timeout):
+    cloudlog.warning("jetlink: shutdown request handed to the jetson")
+  else:
+    cloudlog.warning("jetlink: nobody took the shutdown request within %.0f s", timeout)

--- a/openpilot/sunnypilot/accelerators/jetlink/compile_warp.py
+++ b/openpilot/sunnypilot/accelerators/jetlink/compile_warp.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""
+Copyright (c) 2026-, Zeph Leggett.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+
+Build the comma-side warp JIT. Invoked by accelerators/SConscript.
+
+Mirrors upstream's compile_dm_warp.py and stays as thin: everything about what
+gets captured lives in warp_cache, so jetlinkd's fallback builds the same pickle.
+"""
+import argparse
+
+from openpilot.selfdrive.modeld.compile_modeld import _parse_size
+from openpilot.sunnypilot.accelerators.jetlink.warp_cache import compile_warp
+
+if __name__ == "__main__":
+  p = argparse.ArgumentParser()
+  p.add_argument('--camera-resolution', type=_parse_size, required=True, help='camera resolution WxH')
+  p.add_argument('--model-size', type=_parse_size, required=True, help='model input WxH')
+  p.add_argument('--output', required=True)
+  args = p.parse_args()
+
+  cam_w, cam_h = args.camera_resolution
+  model_w, model_h = args.model_size
+  print(f"Compiling jetlink warp for {cam_w}x{cam_h} -> {model_w}x{model_h}...")
+  out = compile_warp(cam_w, cam_h, model_w, model_h, out=args.output)
+  print(f"  Saved to {out}")

--- a/openpilot/sunnypilot/accelerators/jetlink/fallback.py
+++ b/openpilot/sunnypilot/accelerators/jetlink/fallback.py
@@ -1,0 +1,32 @@
+"""
+Copyright (c) 2026-, Zeph Leggett.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+"""
+from tinygrad import Tensor, TinyJit
+
+
+def prepare_reset(model):
+  """Capture reset before driving, keeping the small JIT's buffer identities.
+
+  Its history is stale after the Jetson ran, so fallback starts from the same
+  zero history as modeld startup. Nothing is allocated or compiled on the
+  failure frame.
+  """
+  queues = tuple(model.input_queues[k] for k in ('img_q', 'big_img_q', 'feat_q', 'desire_q'))
+
+  @TinyJit
+  def clear():
+    Tensor.realize(*(q.assign(0) for q in queues))
+
+  for _ in range(3):
+    clear()
+
+  def reset():
+    clear()
+    model.prev_desire.fill(0)
+    model.npy['prev_feat'].fill(0)
+    model.npy['desire'].fill(0)
+
+  return reset

--- a/openpilot/sunnypilot/accelerators/jetlink/helpers.py
+++ b/openpilot/sunnypilot/accelerators/jetlink/helpers.py
@@ -1,0 +1,395 @@
+"""
+Copyright (c) 2026-, Zeph Leggett.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+
+Where the model is, whether the Jetson is attached, and how far along it is.
+
+Models come from models.json and comma's LFS, not the model manager: every
+bundle it offers is a tinygrad pkl for a GPU the Jetson does not have.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import time
+from pathlib import Path
+
+from openpilot.common.hardware.hw import Paths
+from openpilot.common.params import Params
+from openpilot.common.swaglog import cloudlog
+
+# none of these are CLEAR_ON_MANAGER_START: readiness must survive a reboot or
+# every ignition rebuilds a 160 s engine
+P_ENABLED = "JetlinkEnabled"        # user toggle; only True enables
+P_READY = "JetlinkEngineReady"      # sha256 of the model the Jetson has built
+P_ENDPOINT = "JetlinkEndpoint"      # optional "host:port" to use TCP instead of USB
+
+UNCHUNKED_SUFFIX = ".jetlink-unchunked"
+
+
+def _get(key: str, default=None):
+  """Read a param, tolerating a params library that predates the key.
+
+  Called from hardwared and the UI's param thread, so UnknownKeyName here
+  would take down a process that has nothing to do with jetlink.
+  """
+  try:
+    return Params().get(key)
+  except Exception:
+    return default
+
+
+def link_endpoint() -> tuple[str, int] | None:
+  """A host:port override, for running the Jetson over ethernet during bring-up."""
+  raw = _get(P_ENDPOINT)
+  if not raw:
+    return None
+  host, _, port = raw.strip().partition(':')
+  return host, int(port or 5599)
+
+
+# the comma is the USB gadget and the Jetson the host, decided by the kernels:
+# AGNOS has CONFIG_USB_F_FS built in, L4T images are often stripped of the
+# gadget modules. See jetlink/docs/transport.md
+GADGET_PATH = Path("/sys/kernel/config/usb_gadget/jetlink")
+FFS_MOUNT = Path("/dev/ffs-jetlink")
+UDC_PATH = Path("/sys/class/udc")
+# written by scripts/setup_gadget.sh at boot: "ok", or "error: <reason>"
+GADGET_STATUS = Path("/dev/shm/jetlink-gadget")
+CC_ORIENTATION = Path('/sys/class/power_supply/usb/typec_cc_orientation')
+
+
+def gadget_error() -> str | None:
+  """Why the USB gadget is unavailable, if it is.
+
+  The gadget is set up at boot by root from launch_chffrplus.sh, nowhere a
+  user would look. A missing file is not an error: the setup never ran.
+  """
+  try:
+    reason = GADGET_STATUS.read_text().strip()
+  except OSError:
+    return None
+  if not reason or reason == 'ok':
+    return None
+  return reason.removeprefix('error:').strip() or None
+
+
+def gadget_bound() -> bool:
+  """Has our gadget been attached to a device controller?"""
+  try:
+    return bool((GADGET_PATH / "UDC").read_text().strip())
+  except OSError:
+    return False
+
+
+def host_attached() -> bool:
+  """Has a host (the Jetson) enumerated and configured us?"""
+  try:
+    udc = (GADGET_PATH / "UDC").read_text().strip()
+  except OSError:
+    return False
+  if not udc:
+    return False
+  try:
+    return (UDC_PATH / udc / "state").read_text().strip() == "configured"
+  except OSError:
+    return False
+
+
+def link_configured() -> bool:
+  """Can we even attempt a link? The gadget exists, or TCP is configured.
+
+  Not host_attached(): the UDC only binds when something opens ep0, and nothing
+  opens ep0 unless the link looks usable. Waiting for a host deadlocks.
+  """
+  if gadget_error() is not None:
+    return False
+  if link_endpoint() is not None:
+    return True
+  try:
+    return (FFS_MOUNT / "ep0").exists()
+  except OSError:
+    # a root-only mount raises PermissionError from stat; unusable either way
+    return False
+
+
+# jetlinkd's pid while it has released the gadget on purpose so the Jetson can
+# sleep (Jetlinkd.go_dormant). Presence comes from this, not the UDC; a marker
+# whose writer is dead is a leftover from a kill
+DORMANT = Path("/dev/shm/jetlink-dormant")
+# hardwared's request to power the Jetson off; see backend.shutdown
+SHUTDOWN_REQUEST = Path("/dev/shm/jetlink-shutdown")
+
+
+def set_dormant(on: bool) -> None:
+  try:
+    if on:
+      DORMANT.write_text(str(os.getpid()))
+    else:
+      DORMANT.unlink(missing_ok=True)
+  except OSError:
+    cloudlog.exception("jetlink: could not update the dormant marker")
+
+
+def dormant() -> bool:
+  """Has a live jetlinkd released the gadget on purpose?"""
+  try:
+    pid = int(DORMANT.read_text())
+  except (OSError, ValueError):
+    return False
+  try:
+    os.kill(pid, 0)
+  except ProcessLookupError:
+    return False
+  except PermissionError:
+    pass  # alive, just not ours to signal
+  return True
+
+
+def request_shutdown(reason: str) -> bool:
+  try:
+    SHUTDOWN_REQUEST.write_text(json.dumps({'reason': reason}))
+    return True
+  except OSError:
+    cloudlog.exception("jetlink: could not write the shutdown request")
+    return False
+
+
+def pending_shutdown() -> str | None:
+  """The reason in a shutdown request that has not been dealt with, if any."""
+  try:
+    return str(json.loads(SHUTDOWN_REQUEST.read_text()).get('reason', ''))
+  except (OSError, ValueError):
+    return None
+
+
+def finish_shutdown() -> None:
+  try:
+    SHUTDOWN_REQUEST.unlink(missing_ok=True)
+  except OSError:
+    cloudlog.exception("jetlink: could not remove the shutdown request")
+
+
+def await_shutdown(timeout: float) -> bool:
+  """Wait for jetlinkd to take the request. False if nobody did in time."""
+  deadline = time.monotonic() + timeout
+  while time.monotonic() < deadline:
+    if not SHUTDOWN_REQUEST.exists():
+      return True
+    time.sleep(0.25)
+  finish_shutdown()
+  return False
+
+
+# a USB3 link recovery passes through "addressed" for a moment, and presence
+# read at 2 Hz should not blink for it
+PRESENCE_HOLD = 5.0
+_last_configured = 0.0
+
+
+def gadget_present() -> bool:
+  """Is a Jetson actually on the other end right now?
+
+  True once something holds the gadget open and a host has configured us,
+  held for PRESENCE_HOLD after that stops.
+  """
+  global _last_configured
+  if link_endpoint() is not None:
+    return True
+  if dormant():
+    # no enumeration during suspend; the CC line still tells a sleeping host from an unplugged one
+    try:
+      return int(CC_ORIENTATION.read_text()) != 0
+    except (OSError, ValueError):
+      return False
+  now = time.monotonic()
+  if host_attached():
+    _last_configured = now
+    return True
+  return now - _last_configured < PRESENCE_HOLD
+
+
+def connect(deadline: float | None = None):
+  """Open the link. USB unless an endpoint override is set.
+
+  `deadline` is per frame and defaults to FRAME_TIMEOUT: modeld blocks on a
+  frame the way it blocks on a chestnut.
+  """
+  from jetlink.client import FRAME_TIMEOUT, JetlinkClient
+  deadline = FRAME_TIMEOUT if deadline is None else deadline
+  endpoint = link_endpoint()
+  if endpoint is not None:
+    host, port = endpoint
+    cloudlog.warning("jetlink: connecting over tcp to %s:%d", host, port)
+    return JetlinkClient.open_tcp(host, port, deadline=deadline)
+  # the comma is the gadget and the Jetson the host; see gadget_present()
+  return JetlinkClient.open_ffs(str(FFS_MOUNT), gadget=str(GADGET_PATH), deadline=deadline)
+
+
+def enabled() -> bool:
+  """Has the user switched the link on? JetlinkEnabled == True and nothing else.
+
+  Not "absent means auto": the gadget comes up at boot with the package
+  installed, so auto turned installation into enablement.
+  """
+  return bool(_get(P_ENABLED))
+
+
+def gadget_alert() -> str | None:
+  """The gadget failure worth an alert: only for someone who asked for the link."""
+  return gadget_error() if enabled() else None
+
+
+# -- the model ------------------------------------------------------------
+
+def active_bundle():
+  from openpilot.sunnypilot.models.helpers import get_selected_bundle
+  return get_selected_bundle(Params(), "chestnut")
+
+
+def _artifact_names(bundle) -> list[str]:
+  out = []
+  for model in getattr(bundle, 'models', []) or []:
+    artifact = getattr(model, 'artifact', None)
+    name = getattr(artifact, 'fileName', None) if artifact else None
+    if name and name.endswith('.onnx'):
+      out.append(name)
+  return out
+
+
+def active_model_path() -> Path | None:
+  """Path to the selected large model's ONNX, materialising chunks if needed.
+
+  No bundle selected is the normal case: no model-manager bundle ships an
+  ONNX, so a Jetson runs the model from models.json. None means no large
+  model here yet and the caller stays on the small model.
+  """
+  bundle = active_bundle()
+  root = Path(Paths.model_root())
+  for name in _artifact_names(bundle) if bundle is not None else []:
+    plain = root / name
+    if plain.is_file() and plain.stat().st_size > 1_000_000:
+      return plain
+    # chunked download: reassemble once, next to the chunks
+    manifest = root / f'{name}.chunkmanifest'
+    if manifest.is_file():
+      return _materialise(root / name)
+  return shipped_model_path()
+
+
+BIG_MODEL_NAME = 'big_driving_supercombo.onnx'
+MODEL_INDEX = Path(__file__).with_name('models.json')
+P_MODEL = "JetlinkModel"          # name of the chosen entry in models.json
+
+
+def repo_root() -> Path:
+  return Path(__file__).resolve().parents[4]
+
+
+def big_model_pointer() -> Path:
+  from openpilot.selfdrive.modeld.helpers import MODELS_DIR
+  return MODELS_DIR / BIG_MODEL_NAME
+
+
+def model_index() -> list[dict]:
+  """The large models a Jetson can run.
+
+  Hand-maintained: openpilot overwrites one file, so older models exist only
+  as git-lfs objects no manifest lists. See models.json.
+  """
+  try:
+    with open(MODEL_INDEX) as f:
+      return json.load(f).get('models', [])
+  except Exception:
+    cloudlog.exception("jetlink: could not read the model index")
+    return []
+
+
+def selected_model() -> dict | None:
+  """The entry the user picked, or the default.
+
+  An unknown name falls back: the index can shrink under a param that outlived it.
+  """
+  models = model_index()
+  if not models:
+    return None
+  wanted = _get(P_MODEL)
+  if wanted:
+    for m in models:
+      if m.get('name') == wanted:
+        return m
+    cloudlog.warning("jetlink: no model called %r in the index, using the default", wanted)
+  return next((m for m in models if m.get('default')), models[0])
+
+
+def shipped_model_path() -> Path | None:
+  """The chosen large model, if it has been fetched.
+
+  Keyed on the index entry, not the in-tree pointer, which moves with upstream
+  syncs. Size is the cheap check that the file is the one we mean.
+  """
+  model = selected_model()
+  if model is None:
+    return None
+  path = Path(Paths.model_root()) / model_file_name(model)
+  if path.is_file() and path.stat().st_size == model['size']:
+    return path
+  return None
+
+
+def _materialise(path: Path) -> Path | None:
+  from openpilot.common.file_chunker import open_file_chunked
+  out = path.with_name(path.name + UNCHUNKED_SUFFIX)
+  if out.is_file() and out.stat().st_size > 1_000_000:
+    return out
+  free = shutil.disk_usage(path.parent).free
+  try:
+    with open_file_chunked(str(path)) as src, open(out, 'wb') as dst:
+      shutil.copyfileobj(src, dst, length=4 << 20)
+  except Exception:
+    cloudlog.exception("jetlink: could not reassemble %s (%d MB free)", path.name, free >> 20)
+    out.unlink(missing_ok=True)
+    return None
+  return out
+
+
+def cleanup_unchunked(keep: Path | None = None) -> None:
+  root = Path(Paths.model_root())
+  for p in root.glob(f'*{UNCHUNKED_SUFFIX}'):
+    if keep is None or p != keep:
+      p.unlink(missing_ok=True)
+
+
+def model_file_name(model: dict) -> str:
+  """One file per model, so switching back does not re-download."""
+  return f"{model['oid'][:16]}.onnx"
+
+
+def fetch_shipped_model(progress=None, should_stop=None) -> Path | None:
+  """Download the chosen large model if it is not here yet. None when nothing is chosen."""
+  from openpilot.sunnypilot.accelerators.jetlink import lfs
+  model = selected_model()
+  if model is None:
+    return None
+  dest = Path(Paths.model_root()) / model_file_name(model)
+  return lfs.fetch_oid(model['oid'], model['size'], dest, repo_root(),
+                       progress=progress, should_stop=should_stop)
+
+
+# -- readiness ------------------------------------------------------------
+
+def engine_ready_for(sha256: str | None) -> bool:
+  if not sha256:
+    return False
+  return (_get(P_READY) or '') == sha256
+
+
+def set_engine_ready(sha256: str | None) -> None:
+  params = Params()
+  if sha256:
+    params.put(P_READY, sha256)
+  else:
+    params.remove(P_READY)

--- a/openpilot/sunnypilot/accelerators/jetlink/jetlinkd.py
+++ b/openpilot/sunnypilot/accelerators/jetlink/jetlinkd.py
@@ -1,0 +1,595 @@
+#!/usr/bin/env python3
+"""
+Copyright (c) 2026-, Zeph Leggett.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+
+Presents the USB gadget and provisions whatever large model is selected.
+
+Two jobs, and the first one is the reason this runs even when there is nothing
+to do: **something has to hold the gadget open**. The comma is the USB device,
+and its controller only binds while a process owns the FunctionFS endpoints.
+Nothing holds them, nothing enumerates, and a Jetson powered on later never
+appears. The two boxes come up on different power rails - usually the comma
+first - so the comma has to sit there presenting itself until the Jetson
+arrives, however long that takes.
+
+The second job is provisioning: uploading the model and building a TensorRT
+engine takes minutes, far longer than modeld's 60 s big-model timeout, so it
+happens offroad and the result is cached on the Jetson and recorded in a param.
+The engine is also left loaded on the server, so modeld's connect at ignition
+is a round trip rather than a 13 to 25 s deserialization.
+
+manager stops this daemon with SIGINT at the onroad transition and SIGKILLs it
+5 s later. Every long wait in here polls `stop`, because a FunctionFS owner
+killed mid-transfer leaves the gadget in a state only a reboot reliably clears.
+
+Ownership of the link is exclusive: jetlinkd offroad, modeld onroad. manager's
+only_offroad gate enforces that. On the handover the gadget briefly unbinds and
+the Jetson re-enumerates, which both ends handle.
+
+The exception to holding the gadget is the parked car. A Jetson on an
+always-on supply sleeps when it has had no gadget for a while and wakes on
+the next USB edge, so once the engine is ready and DORMANT_HOLD has passed
+this daemon releases the gadget on purpose and only presents it again when
+there is work: a model change, a readiness the server no longer confirms, or
+hardwared asking for the Jetson to be powered off with the comma. modeld's
+bind at ignition is the wake.
+"""
+from __future__ import annotations
+
+import functools
+import json
+import os
+import signal
+import subprocess
+import threading
+import time
+from pathlib import Path
+
+from openpilot.common.realtime import Ratekeeper
+from openpilot.common.swaglog import cloudlog
+
+from openpilot.sunnypilot import accelerators
+from openpilot.common.params import Params
+from openpilot.sunnypilot.accelerators.jetlink import helpers, spec_cache, warp_cache
+
+POLL_HZ = 2.0
+RETRY_BACKOFF = 30.0       # after a failed provision
+RETRY_BACKOFF_MAX = 900.0  # ceiling once the failures keep coming
+RECONNECT_BACKOFF = 5.0    # after the link itself failed
+
+# Once there is nothing left to do, how long after ignition-off (which is when
+# manager starts us) the gadget is released so the Jetson can sleep. The
+# server sleeps 120 s after the gadget goes, so the Jetson is down about three
+# minutes after the car is parked; a quick stop inside the hold rejoins at
+# once, one outside it costs the ~8 s wake. See jetlink/server/sleep.py.
+DORMANT_HOLD = 60.0
+# A sleeping Jetson wakes on the gadget bind: ~6 s to a kernel, ~1 s to
+# enumerate on the bench.
+WAKE_TIMEOUT = 20.0
+
+# Keep a recording-writeback storm from stalling the gadget read path.
+# loggerd/encoderd write video continuously; on a memory-tight comma (stock
+# min_free_kbytes ~7 MB, ~40 MB free) a segment's dirty pages pile up until the
+# kernel has to reclaim them synchronously - write them back before it can
+# evict them - exactly while a FunctionFS transfer is allocating its buffer.
+# Measured on the 2026-09-06 bench: nr_dirty to 108 MB, direct reclaim, and the
+# gadget read stalled 200-350 ms, past backend.INFERENCE_TIMEOUT, so the big
+# model fell back and rejoined (91 lagging frames, three losses in 15 min).
+# Capping dirty memory (so reclaim finds clean, evictable pages) and holding a
+# real free-memory floor (so allocations do not reclaim at all) removed it:
+# dirty peak 7 MB, worst frame 244 -> 72 ms, zero lagging frames over 20 min;
+# under a 500 MB memory hog plus CPU contention, 128 MB/16 MB held it too.
+#
+# System-wide on purpose - the gadget read shares the kernel with every writer.
+# Applied here rather than at boot so a device with the link switched off runs
+# stock values: the previous ones are recorded in SYSCTL_PREV before the first
+# change and put back on the way out. A SIGKILL skips the restore and leaves
+# them in place until reboot; that record survives us in /dev/shm so the next
+# run still knows the stock values and never records our own as them.
+VM_SYSCTLS = {
+  'vm.dirty_bytes': '16777216',
+  'vm.dirty_background_bytes': '8388608',
+  'vm.min_free_kbytes': '131072',
+}
+SYSCTL_PREV = Path('/dev/shm/jetlink-sysctl-prev')
+PROC_SYS = Path('/proc/sys')
+
+
+def _read_sysctls(keys) -> dict[str, str]:
+  values = {}
+  for key in keys:
+    try:
+      values[key] = (PROC_SYS / key.replace('.', '/')).read_text().strip()
+    except OSError:
+      cloudlog.exception(f"jetlink: could not read {key}")
+  return values
+
+
+def _write_sysctls(values: dict[str, str]) -> None:
+  # The launcher runs us as comma; sysctl -w through sudo -n is the same
+  # privilege setup_gadget.sh uses. Root (a bench run) writes /proc directly.
+  for key, value in values.items():
+    try:
+      if os.geteuid() == 0:
+        (PROC_SYS / key.replace('.', '/')).write_text(value)
+      else:
+        subprocess.run(['sudo', '-n', 'sysctl', '-w', f'{key}={value}'], check=True,
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=5)
+    except Exception:
+      cloudlog.exception(f"jetlink: could not set {key}={value}")
+
+
+def apply_vm_tuning() -> None:
+  """Record the stock values once, then apply ours."""
+  if not SYSCTL_PREV.exists():
+    prev = _read_sysctls(VM_SYSCTLS)
+    if prev:
+      try:
+        SYSCTL_PREV.write_text(json.dumps(prev))
+      except OSError:
+        cloudlog.exception("jetlink: could not record the previous sysctls")
+  _write_sysctls(VM_SYSCTLS)
+
+
+def restore_vm_tuning() -> None:
+  """Put the recorded values back and drop the record."""
+  try:
+    prev = json.loads(SYSCTL_PREV.read_text())
+  except FileNotFoundError:
+    return
+  except (OSError, ValueError):
+    cloudlog.exception("jetlink: unreadable sysctl record, leaving the values as they are")
+    prev = {}
+  if isinstance(prev, dict):
+    _write_sysctls({k: str(v) for k, v in prev.items() if k in VM_SYSCTLS})
+  try:
+    SYSCTL_PREV.unlink()
+  except OSError:
+    pass
+
+
+def _timed_out(e: BaseException) -> bool:
+  """Did the exchange time out with the stream still usable?
+
+  jetlink draws that line itself: LinkTimeout is documented as leaving the
+  stream in sync, every other LinkError as not.
+  """
+  try:
+    from jetlink.transport.base import LinkTimeout
+  except ImportError:
+    return False  # no way to tell, so assume the worst and reopen
+  return isinstance(e, LinkTimeout)
+
+
+class Jetlinkd:
+  def __init__(self):
+    self.client = None
+    self.stop = False
+    self.ready = False
+    self.next_attempt = 0.0
+    self.next_provision = 0.0
+    self.failures = 0
+    self.was_attached = False
+    self.fetch_failed = False
+    self.verified = False   # the server has confirmed the ready param this attach
+    self.warp_built = False  # tried the comma-side warp this run
+    self.warp_thread: threading.Thread | None = None
+    self.started = time.monotonic()
+    self.dormant = False     # released the gadget on purpose; see go_dormant
+    self.vm_tuned = False    # our sysctls are in; restore on the way out
+
+  # -- lifecycle ------------------------------------------------------------
+
+  def request_stop(self, *_) -> None:
+    self.stop = True
+
+  def close_link(self) -> None:
+    """Always go through this. A FunctionFS owner that exits without closing
+    leaves the gadget bound with nothing servicing it, and the next teardown
+    can wedge the driver hard enough that only a reboot clears it."""
+    client, self.client = self.client, None
+    if client is not None:
+      try:
+        client.close()
+      except Exception:
+        cloudlog.exception("jetlink: error closing the link")
+
+  def open_link(self) -> bool:
+    """Present the gadget so a Jetson can enumerate whenever it powers on."""
+    if self.client is not None:
+      return True
+    try:
+      self.client = helpers.connect(deadline=5.0)
+      cloudlog.warning("jetlink: gadget presented, waiting for a jetson")
+      return True
+    except Exception:
+      cloudlog.exception("jetlink: could not present the gadget")
+      self.next_attempt = time.monotonic() + RECONNECT_BACKOFF
+      return False
+
+  # -- provisioning ---------------------------------------------------------
+
+  def fetch_model(self):
+    """Download the pinned large model, once, on a device that has a Jetson.
+
+    The install carries a pointer rather than the object, so the first time a
+    Jetson is attached we have to go and get it. Minutes on a slow link, so it
+    reports progress and gives up the moment manager wants us gone - the loop
+    is single threaded and this is the one call in it that blocks for long.
+    """
+    if self.fetch_failed:
+      return None
+    try:
+      path = helpers.fetch_shipped_model(
+        progress=lambda frac: accelerators.report_progress('download', frac, 'downloading the large model'),
+        should_stop=lambda: self.stop,
+      )
+    except Exception:
+      cloudlog.exception("jetlink: could not fetch the large model")
+      accelerators.report_progress('failed', 1.0, 'could not download the large model')
+      # One attempt per run. Retrying a gigabyte on a loop would be worse than
+      # staying on the small model until the next boot.
+      self.fetch_failed = True
+      return None
+    return path
+
+  def build_warp(self) -> None:
+    """Make sure a comma-side warp exists. Normally there is nothing to do.
+
+    scons builds it (accelerators/SConscript), which runs from the launcher
+    before manager starts, so on any device that ran a build this returns at
+    the is_cached check. What is left for this to cover is a prebuilt install
+    whose image was made without the target - there is no other way to get a
+    warp there, and without one modeld will not start the large model at all.
+
+    Not part of provision(): the warp depends only on this device's camera and
+    the small model's input size, not on which large model is selected or on
+    the Jetson answering. A warp that cannot be built costs the large model,
+    not the drive - modeld falls back exactly as it does for any other
+    big-model load failure.
+
+    On a thread, because the compile is ~9 s of GPU work with nothing in it
+    that can poll `stop`, and manager SIGKILLs this daemon 5 s after the SIGINT
+    it sends at the onroad transition. Blocking the loop here meant the link
+    was still open when the kill landed - observed twice in one evening, 7.5 s
+    and 5 s - which is exactly the mid-transfer kill the module docstring says
+    to avoid. Abandoning the compile is safe: it touches no link, and it writes
+    the pickle through a temporary, so a killed build leaves nothing
+    half-written for the next run to find.
+    """
+    if self.warp_built:
+      return
+    self.warp_built = True
+    geometry = warp_cache.device_geometry()
+    if warp_cache.is_cached(*geometry):
+      return
+    # Only past here is there a real compile to report. Reporting first meant a
+    # "compiling the camera warp" that flashed through the UI on every start
+    # for a warp the build had already made.
+    accelerators.report_progress('warp', 0.0, 'compiling the camera warp')
+
+    def build() -> None:
+      if warp_cache.ensure(*geometry):
+        accelerators.clear_progress()
+
+    self.warp_thread = threading.Thread(target=build, daemon=True, name='jetlink_warp')
+    self.warp_thread.start()
+
+  @staticmethod
+  def _eta(seconds: float) -> str:
+    if seconds >= 90:
+      return f"about {seconds / 60:.0f} min left"
+    return f"about {max(seconds, 1):.0f}s left"
+
+  def _report_with_eta(self, stage: str, frac: float, msg: str) -> None:
+    """Progress, with how long the build still has to run.
+
+    models.json carries `built_seconds` per model and has since it was written,
+    measured on this hardware, so that the UI could say how long a first
+    provision takes. Nothing ever read it, and the panel showed "build 12%"
+    while a driver waited out five minutes with no idea it was five and not
+    thirty. The number belongs here rather than in the UI: it comes from the
+    backend's own registry, and openpilot/selfdrive/ui stays free of any
+    knowledge that jetlink exists.
+
+    Only the build is estimated. The upload already reports MB of MB, and a
+    connect has nothing to predict.
+    """
+    if stage == 'build':
+      entry = helpers.selected_model() or {}
+      built = entry.get('built_seconds')
+      if built:
+        msg = self._eta(float(built) * max(0.0, 1.0 - frac))
+    accelerators.report_progress(stage, frac, msg)
+
+  def provision(self) -> bool:
+    """Make the Jetson ready for the selected model. Host must be attached.
+
+    The identity comes from the registry, not from the file. models.json
+    carries the git-lfs `oid`, which is the sha256, and `size`, which is the
+    byte count - exactly the pair ENGINE_REQ wants. This used to hash the local
+    ONNX to derive them, which meant the comma could not so much as ask the
+    Jetson what it already had without holding 766 MB itself, and re-derived a
+    number that was sitting in the registry the whole time.
+
+    The Jetson keeps its own copy of every ONNX and never prunes them, so once
+    a model has been provisioned the comma's copy is dead weight. Now it is
+    only fetched when the server actually asks for the bytes, which means a
+    model change with no network works as long as the Jetson has the engine.
+    """
+    # Imported here rather than at module scope: jetlinkd is constructed on
+    # devices whose jetlink package may be absent, and the module must import
+    # without it. Same reason backend._open_link does it.
+    from jetlink.client import EngineMissing
+
+    entry = helpers.selected_model()
+    sha256 = (entry or {}).get('oid')
+    nbytes = (entry or {}).get('size')
+    if not sha256 or not nbytes:
+      # Nothing selected, or a registry entry with no identity. Not an error.
+      helpers.set_engine_ready(None)
+      accelerators.clear_progress()
+      return False
+    nbytes = int(nbytes)
+
+    # The param says ready, but the Jetson's cache may have been pruned,
+    # re-flashed or swapped since. Ask once per attach; after that the answer
+    # cannot change under us.
+    if self.verified and helpers.engine_ready_for(sha256):
+      return True
+
+    # Only needed if the server turns out not to have this model. None is a
+    # legitimate state here, not a failure: see EngineMissing below.
+    model_path = helpers.active_model_path()
+
+    cloudlog.warning("jetlink: provisioning %s (%d MB, sha %s)",
+                     entry.get('name', sha256[:16]), nbytes >> 20, sha256[:16])
+    accelerators.report_progress('connect', 0.0, 'talking to the jetson')
+
+    hello = self.client.hello(timeout=10.0)
+    Params().put('JetlinkCachedModels', hello.get('cached_models', []))
+    cloudlog.warning("jetlink: server %s trt %s", hello.get('device'), hello.get('trt_version'))
+    # Asked without the file first, always. The server answers from the sha
+    # alone when it already has the model, which is every poll of a parked car,
+    # and only the answer "I need the bytes" is worth reading 766 MB for.
+    ask = functools.partial(self.client.ensure_engine, sha256, nbytes,
+                            progress=self._report_with_eta,
+                            build_timeout=1800.0, should_stop=lambda: self.stop)
+    try:
+      spec = ask(onnx_path=None)
+    except EngineMissing:
+      upload = self._verified_upload(model_path, sha256, nbytes)
+      if upload is None:
+        # Nothing to give. Fetch it and let the next poll try again rather than
+        # holding the link through a download that takes minutes.
+        if model_path is None and self.fetch_model() is not None:
+          return False
+        raise
+      spec = ask(onnx_path=upload)
+
+    spec_cache.store(spec, model_path)
+    helpers.set_engine_ready(spec.sha256)
+    cached = helpers._get('JetlinkCachedModels') or []
+    Params().put('JetlinkCachedModels', sorted(set(cached) | {spec.sha256}))
+    self.verified = True
+    accelerators.report_progress('ready', 1.0, 'engine ready')
+    helpers.cleanup_unchunked(keep=model_path)
+    cloudlog.warning("jetlink: engine ready for %s", spec.sha256[:16])
+    return True
+
+  def _verified_upload(self, model_path, sha256: str, nbytes: int):
+    """The file to upload if the server asks for it, once it is proven to be it.
+
+    Taking the identity from the registry moves the trust from the file to
+    models.json, which is right for asking a question and wrong for answering
+    one: uploading under a sha the bytes do not have would leave the Jetson
+    with a plan whose name lies about its contents, and nothing downstream
+    would ever notice. So the hash happens here, on the one path where the
+    bytes actually go somewhere, rather than on every poll of a parked car.
+    """
+    if model_path is None:
+      return None
+    try:
+      if model_path.stat().st_size != nbytes:
+        cloudlog.error("jetlink: %s is %d bytes, the registry says %d; not uploading it",
+                       model_path.name, model_path.stat().st_size, nbytes)
+        return None
+      from jetlink.spec import sha256_file
+      have, _ = sha256_file(str(model_path))
+      if have != sha256:
+        cloudlog.error("jetlink: %s hashes to %s, the registry says %s; not uploading it",
+                       model_path.name, have[:16], sha256[:16])
+        return None
+    except OSError:
+      return None
+    return model_path
+
+  # -- the parked car -------------------------------------------------------
+
+  def go_dormant(self) -> None:
+    """Release the gadget so the Jetson can sleep. The marker goes first so
+    present() never blinks: presence follows it, not the UDC, while we are
+    dormant. Readiness is kept; the server is asked again on the next
+    attach as it is after any other detach."""
+    cloudlog.warning("jetlink: nothing left to do, releasing the gadget so the jetson can sleep")
+    helpers.set_dormant(True)
+    self.close_link()
+    self.dormant = True
+    self.was_attached = False
+    self.verified = False
+
+  def wake(self) -> None:
+    """Present the gadget again. If the Jetson is asleep, the bind wakes it."""
+    cloudlog.warning("jetlink: presenting the gadget again")
+    helpers.set_dormant(False)
+    self.dormant = False
+
+  def has_work(self) -> bool:
+    """Is there a reason to wake the Jetson? Only things the link can fix
+    count: the warp is local and build_warp handles it regardless."""
+    spec = spec_cache.load()
+    if spec is None or not helpers.engine_ready_for(spec.sha256):
+      return True
+    selected = helpers.selected_model()
+    return selected is not None and selected.get('oid') != spec.sha256
+
+  def shutdown_jetson(self, reason: str) -> None:
+    """hardwared is shutting the comma down and wants the Jetson off too.
+    The request file is ours to remove, whatever happens: hardwared is
+    waiting on it and the comma goes down either way."""
+    cloudlog.warning("jetlink: shutting the jetson down: %s", reason)
+    try:
+      if self.dormant:
+        self.wake()
+      if not self.open_link():
+        raise RuntimeError("could not present the gadget")
+      deadline = time.monotonic() + WAKE_TIMEOUT
+      while not helpers.host_attached():
+        if self.stop or time.monotonic() > deadline:
+          raise TimeoutError(f"no jetson attached within {WAKE_TIMEOUT:.0f} s")
+        time.sleep(0.25)
+      resp = self.client.shutdown(reason, timeout=5.0)
+      cloudlog.warning("jetlink: jetson answered the shutdown request: %s", resp)
+    except Exception:
+      cloudlog.exception("jetlink: could not shut the jetson down")
+    finally:
+      helpers.finish_shutdown()
+
+  # -- VM tuning ------------------------------------------------------------
+
+  def tune_vm(self) -> None:
+    if not self.vm_tuned:
+      apply_vm_tuning()
+      self.vm_tuned = True
+
+  def untune_vm(self) -> None:
+    if self.vm_tuned:
+      restore_vm_tuning()
+      self.vm_tuned = False
+
+  # -- main loop ------------------------------------------------------------
+
+  def backoff(self) -> float:
+    """How long to wait before provisioning again, doubling per failure.
+
+    A Jetson that is powered but never answers is the case this exists for:
+    at a flat 30 s it would be retried 120 times an hour for as long as the
+    car is parked, and every one of those costs a round of USB churn.
+    """
+    return min(RETRY_BACKOFF * 2 ** (self.failures - 1), RETRY_BACKOFF_MAX)
+
+  def step(self) -> None:
+    if not helpers.enabled():
+      if self.client is not None or self.ready:
+        cloudlog.warning("jetlink: disabled, releasing the link")
+        helpers.set_engine_ready(None)
+        self.ready = False
+        self.close_link()
+      if self.dormant:
+        self.wake()
+      self.untune_vm()
+      return
+
+    self.tune_vm()
+    reason = helpers.pending_shutdown()
+    if reason is not None:
+      self.shutdown_jetson(reason)
+      return
+
+    if self.dormant:
+      if self.has_work():
+        self.wake()
+      else:
+        return
+
+    # Before the link and before the attach gate: the warp needs neither, and
+    # it is the one thing modeld refuses to start the large model without. It
+    # used to sit below `if not attached: return`, so a Jetson that was slow to
+    # enumerate delayed the compile as well. Cheap now that the build normally
+    # got there first, but the ordering still matters on the install that has
+    # to fall back.
+    self.build_warp()
+
+    if time.monotonic() < self.next_attempt:
+      return
+    if not self.open_link():
+      return
+
+    attached = helpers.host_attached()
+    if attached != self.was_attached:
+      cloudlog.warning("jetlink: jetson %s", "attached" if attached else "gone")
+      self.was_attached = attached
+      if attached:
+        # A host that has just arrived gets a clean slate rather than sitting
+        # out a backoff earned by whatever was on the link before it, and its
+        # engine cache is checked before the ready param is trusted again.
+        self.failures = 0
+        self.next_provision = 0.0
+        self.verified = False
+      else:
+        # It powered down or rebooted. Readiness is about the engine on the
+        # Jetson, which survives, so keep it; modeld reconnects on its own.
+        self.ready = False
+    if not attached:
+      return
+    # Provisioning backs off on its own timer, so that a long wait for an
+    # unresponsive server still leaves us watching for one that reappears.
+    if time.monotonic() < self.next_provision:
+      return
+
+    try:
+      self.ready = self.provision()
+      self.failures = 0
+      self.next_provision = 0.0
+      if self.ready and time.monotonic() - self.started >= DORMANT_HOLD:
+        self.go_dormant()
+    except Exception as e:
+      cloudlog.exception("jetlink: provisioning failed")
+      accelerators.report_progress('failed', 1.0, 'see the log')
+      self.ready = False
+      # Only reopen when the link itself is suspect. Unbinding the gadget
+      # makes the host re-enumerate, and doing that every time a server that
+      # is simply not up yet fails to answer is hours of USB churn.
+      if not _timed_out(e):
+        self.close_link()
+      self.failures += 1
+      self.next_provision = time.monotonic() + self.backoff()
+
+  def run(self) -> None:
+    if helpers.enabled():
+      self.tune_vm()
+    rk = Ratekeeper(POLL_HZ)
+    try:
+      while not self.stop:
+        rk.keep_time()
+        try:
+          self.step()
+        except Exception:
+          # Nothing may escape: this daemon restarting in a loop would be worse
+          # than it sitting out a cycle.
+          cloudlog.exception("jetlink: unhandled error")
+          self.close_link()
+          self.next_attempt = time.monotonic() + RECONNECT_BACKOFF
+    finally:
+      self.close_link()
+      self.untune_vm()
+    helpers.set_dormant(False)
+    if self.warp_thread is not None and self.warp_thread.is_alive():
+      cloudlog.warning("jetlink: stopped with the warp still compiling; it will rebuild next time")
+    cloudlog.warning("jetlink: stopped")
+
+
+def main() -> None:
+  d = Jetlinkd()
+  # manager stops us with SIGTERM at the onroad transition. Closing the link
+  # properly on the way out is what keeps the driver healthy for modeld.
+  signal.signal(signal.SIGTERM, d.request_stop)
+  signal.signal(signal.SIGINT, d.request_stop)
+  d.run()
+
+
+if __name__ == "__main__":
+  main()

--- a/openpilot/sunnypilot/accelerators/jetlink/jetlinkd.py
+++ b/openpilot/sunnypilot/accelerators/jetlink/jetlinkd.py
@@ -7,35 +7,20 @@ See the LICENSE.md file in the root directory for more details.
 
 Presents the USB gadget and provisions whatever large model is selected.
 
-Two jobs, and the first one is the reason this runs even when there is nothing
-to do: **something has to hold the gadget open**. The comma is the USB device,
-and its controller only binds while a process owns the FunctionFS endpoints.
-Nothing holds them, nothing enumerates, and a Jetson powered on later never
-appears. The two boxes come up on different power rails - usually the comma
-first - so the comma has to sit there presenting itself until the Jetson
-arrives, however long that takes.
+Something has to hold the FunctionFS endpoints or the comma never enumerates,
+and the Jetson usually powers up after the comma, so this runs even with
+nothing to do. Provisioning (upload plus a TensorRT build) takes minutes, far
+past modeld's 60 s big-model timeout, so it happens offroad; the result is
+cached on the Jetson, recorded in a param and left loaded on the server.
 
-The second job is provisioning: uploading the model and building a TensorRT
-engine takes minutes, far longer than modeld's 60 s big-model timeout, so it
-happens offroad and the result is cached on the Jetson and recorded in a param.
-The engine is also left loaded on the server, so modeld's connect at ignition
-is a round trip rather than a 13 to 25 s deserialization.
+manager stops this with SIGINT at ignition and SIGKILLs it 5 s later, so every
+long wait polls `stop`: a FunctionFS owner killed mid-transfer leaves the
+gadget in a state only a reboot clears. jetlinkd owns the link offroad, modeld
+onroad; on the handover the gadget briefly unbinds and the Jetson re-enumerates.
 
-manager stops this daemon with SIGINT at the onroad transition and SIGKILLs it
-5 s later. Every long wait in here polls `stop`, because a FunctionFS owner
-killed mid-transfer leaves the gadget in a state only a reboot reliably clears.
-
-Ownership of the link is exclusive: jetlinkd offroad, modeld onroad. manager's
-only_offroad gate enforces that. On the handover the gadget briefly unbinds and
-the Jetson re-enumerates, which both ends handle.
-
-The exception to holding the gadget is the parked car. A Jetson on an
-always-on supply sleeps when it has had no gadget for a while and wakes on
-the next USB edge, so once the engine is ready and DORMANT_HOLD has passed
-this daemon releases the gadget on purpose and only presents it again when
-there is work: a model change, a readiness the server no longer confirms, or
-hardwared asking for the Jetson to be powered off with the comma. modeld's
-bind at ignition is the wake.
+Once the engine is ready and DORMANT_HOLD has passed the gadget is released so
+a Jetson on an always-on supply can sleep. It is presented again when there is
+work; modeld's bind at ignition is the wake.
 """
 from __future__ import annotations
 
@@ -60,39 +45,35 @@ RETRY_BACKOFF = 30.0       # after a failed provision
 RETRY_BACKOFF_MAX = 900.0  # ceiling once the failures keep coming
 RECONNECT_BACKOFF = 5.0    # after the link itself failed
 
-# Once there is nothing left to do, how long after ignition-off (which is when
-# manager starts us) the gadget is released so the Jetson can sleep. The
-# server sleeps 120 s after the gadget goes, so the Jetson is down about three
-# minutes after the car is parked; a quick stop inside the hold rejoins at
-# once, one outside it costs the ~8 s wake. See jetlink/server/sleep.py.
+# how long after ignition-off the gadget is released once there is nothing to
+# do. The server sleeps 120 s after the gadget goes; a stop inside the hold
+# rejoins at once, one outside it costs the ~8 s wake
 DORMANT_HOLD = 60.0
-# A sleeping Jetson wakes on the gadget bind: ~6 s to a kernel, ~1 s to
-# enumerate on the bench.
+# a sleeping Jetson wakes on the bind: ~6 s to a kernel, ~1 s to enumerate
 WAKE_TIMEOUT = 20.0
 
-# Keep a recording-writeback storm from stalling the gadget read path.
-# loggerd/encoderd write video continuously; on a memory-tight comma (stock
-# min_free_kbytes ~7 MB, ~40 MB free) a segment's dirty pages pile up until the
-# kernel has to reclaim them synchronously - write them back before it can
-# evict them - exactly while a FunctionFS transfer is allocating its buffer.
-# Measured on the 2026-09-06 bench: nr_dirty to 108 MB, direct reclaim, and the
-# gadget read stalled 200-350 ms, past backend.INFERENCE_TIMEOUT, so the big
-# model fell back and rejoined (91 lagging frames, three losses in 15 min).
-# Capping dirty memory (so reclaim finds clean, evictable pages) and holding a
-# real free-memory floor (so allocations do not reclaim at all) removed it:
-# dirty peak 7 MB, worst frame 244 -> 72 ms, zero lagging frames over 20 min;
-# under a 500 MB memory hog plus CPU contention, 128 MB/16 MB held it too.
+# loggerd's dirty pages pile up until the kernel reclaims them synchronously,
+# right while a FunctionFS transfer allocates its buffer: gadget reads stalled
+# 200-350 ms, past backend.INFERENCE_TIMEOUT, and the big model fell back.
+# Capping dirty memory and holding a free-memory floor took the worst frame
+# from 244 to 72 ms with no lagging frames over 20 min.
 #
-# System-wide on purpose - the gadget read shares the kernel with every writer.
-# Applied here rather than at boot so a device with the link switched off runs
-# stock values: the previous ones are recorded in SYSCTL_PREV before the first
-# change and put back on the way out. A SIGKILL skips the restore and leaves
-# them in place until reboot; that record survives us in /dev/shm so the next
-# run still knows the stock values and never records our own as them.
+# System-wide, since the gadget read shares the kernel with every writer.
+# Applied here so a device with the link off runs stock values, which are
+# recorded in SYSCTL_PREV and put back only on disable. Never restored on
+# exit: manager stops this daemon at ignition, exactly when the contention
+# starts, so modeld would get stock values every drive. A reboot resets them
 VM_SYSCTLS = {
   'vm.dirty_bytes': '16777216',
   'vm.dirty_background_bytes': '8388608',
   'vm.min_free_kbytes': '131072',
+}
+# stock AGNOS runs the dirty limits in ratio mode, so both *_bytes keys read 0,
+# and the kernel silently drops a 0 written back to them. Writing the ratio key
+# is what zeroes the bytes key, so the ratios are recorded alongside
+VM_RATIO_KEYS = {
+  'vm.dirty_bytes': 'vm.dirty_ratio',
+  'vm.dirty_background_bytes': 'vm.dirty_background_ratio',
 }
 SYSCTL_PREV = Path('/dev/shm/jetlink-sysctl-prev')
 PROC_SYS = Path('/proc/sys')
@@ -109,8 +90,7 @@ def _read_sysctls(keys) -> dict[str, str]:
 
 
 def _write_sysctls(values: dict[str, str]) -> None:
-  # The launcher runs us as comma; sysctl -w through sudo -n is the same
-  # privilege setup_gadget.sh uses. Root (a bench run) writes /proc directly.
+  # sudo -n sysctl is the same privilege setup_gadget.sh uses; root writes /proc
   for key, value in values.items():
     try:
       if os.geteuid() == 0:
@@ -125,7 +105,7 @@ def _write_sysctls(values: dict[str, str]) -> None:
 def apply_vm_tuning() -> None:
   """Record the stock values once, then apply ours."""
   if not SYSCTL_PREV.exists():
-    prev = _read_sysctls(VM_SYSCTLS)
+    prev = _read_sysctls([*VM_SYSCTLS, *VM_RATIO_KEYS.values()])
     if prev:
       try:
         SYSCTL_PREV.write_text(json.dumps(prev))
@@ -144,7 +124,18 @@ def restore_vm_tuning() -> None:
     cloudlog.exception("jetlink: unreadable sysctl record, leaving the values as they are")
     prev = {}
   if isinstance(prev, dict):
-    _write_sysctls({k: str(v) for k, v in prev.items() if k in VM_SYSCTLS})
+    values = {}
+    for key in VM_SYSCTLS:
+      if key not in prev:
+        continue
+      ratio = VM_RATIO_KEYS.get(key)
+      if str(prev[key]) == '0' and ratio in prev:
+        # the kernel drops a 0 written to a *_bytes key; the ratio key is the
+        # way back to ratio mode
+        values[ratio] = str(prev[ratio])
+      else:
+        values[key] = str(prev[key])
+    _write_sysctls(values)
   try:
     SYSCTL_PREV.unlink()
   except OSError:
@@ -154,13 +145,12 @@ def restore_vm_tuning() -> None:
 def _timed_out(e: BaseException) -> bool:
   """Did the exchange time out with the stream still usable?
 
-  jetlink draws that line itself: LinkTimeout is documented as leaving the
-  stream in sync, every other LinkError as not.
+  Only LinkTimeout leaves the stream in sync; every other LinkError does not.
   """
   try:
     from jetlink.transport.base import LinkTimeout
   except ImportError:
-    return False  # no way to tell, so assume the worst and reopen
+    return False  # cannot tell, so reopen
   return isinstance(e, LinkTimeout)
 
 
@@ -179,7 +169,7 @@ class Jetlinkd:
     self.warp_thread: threading.Thread | None = None
     self.started = time.monotonic()
     self.dormant = False     # released the gadget on purpose; see go_dormant
-    self.vm_tuned = False    # our sysctls are in; restore on the way out
+    self.vm_tuned = False    # our sysctls are in; restored only on disable
 
   # -- lifecycle ------------------------------------------------------------
 
@@ -187,9 +177,8 @@ class Jetlinkd:
     self.stop = True
 
   def close_link(self) -> None:
-    """Always go through this. A FunctionFS owner that exits without closing
-    leaves the gadget bound with nothing servicing it, and the next teardown
-    can wedge the driver hard enough that only a reboot clears it."""
+    """Always go through this: a FunctionFS owner that exits without closing
+    can wedge the driver until a reboot."""
     client, self.client = self.client, None
     if client is not None:
       try:
@@ -213,12 +202,10 @@ class Jetlinkd:
   # -- provisioning ---------------------------------------------------------
 
   def fetch_model(self):
-    """Download the pinned large model, once, on a device that has a Jetson.
+    """Download the pinned large model, once.
 
-    The install carries a pointer rather than the object, so the first time a
-    Jetson is attached we have to go and get it. Minutes on a slow link, so it
-    reports progress and gives up the moment manager wants us gone - the loop
-    is single threaded and this is the one call in it that blocks for long.
+    Minutes on a slow link, so it reports progress and stops when manager
+    wants the daemon gone; it is the one call in the loop that blocks for long.
     """
     if self.fetch_failed:
       return None
@@ -230,35 +217,21 @@ class Jetlinkd:
     except Exception:
       cloudlog.exception("jetlink: could not fetch the large model")
       accelerators.report_progress('failed', 1.0, 'could not download the large model')
-      # One attempt per run. Retrying a gigabyte on a loop would be worse than
-      # staying on the small model until the next boot.
+      # one attempt per run; retrying a gigabyte on a loop is worse than staying small
       self.fetch_failed = True
       return None
     return path
 
   def build_warp(self) -> None:
-    """Make sure a comma-side warp exists. Normally there is nothing to do.
+    """Build a comma-side warp only if one is missing.
 
-    scons builds it (accelerators/SConscript), which runs from the launcher
-    before manager starts, so on any device that ran a build this returns at
-    the is_cached check. What is left for this to cover is a prebuilt install
-    whose image was made without the target - there is no other way to get a
-    warp there, and without one modeld will not start the large model at all.
-
-    Not part of provision(): the warp depends only on this device's camera and
-    the small model's input size, not on which large model is selected or on
-    the Jetson answering. A warp that cannot be built costs the large model,
-    not the drive - modeld falls back exactly as it does for any other
-    big-model load failure.
-
-    On a thread, because the compile is ~9 s of GPU work with nothing in it
-    that can poll `stop`, and manager SIGKILLs this daemon 5 s after the SIGINT
-    it sends at the onroad transition. Blocking the loop here meant the link
-    was still open when the kill landed - observed twice in one evening, 7.5 s
-    and 5 s - which is exactly the mid-transfer kill the module docstring says
-    to avoid. Abandoning the compile is safe: it touches no link, and it writes
-    the pickle through a temporary, so a killed build leaves nothing
-    half-written for the next run to find.
+    scons builds it before manager starts, so this only covers a prebuilt
+    image made without the target. Independent of provision(): the warp
+    depends on the camera and the small model's input size, not on the
+    Jetson. On a thread because the ~9 s compile cannot poll `stop` and
+    manager SIGKILLs the daemon 5 s after SIGINT, which landed mid-transfer
+    twice in one evening; a killed compile writes through a temporary and
+    leaves nothing behind.
     """
     if self.warp_built:
       return
@@ -266,9 +239,8 @@ class Jetlinkd:
     geometry = warp_cache.device_geometry()
     if warp_cache.is_cached(*geometry):
       return
-    # Only past here is there a real compile to report. Reporting first meant a
-    # "compiling the camera warp" that flashed through the UI on every start
-    # for a warp the build had already made.
+    # only past here is there a compile to report; reporting first flashed
+    # "compiling the camera warp" through the UI on every start
     accelerators.report_progress('warp', 0.0, 'compiling the camera warp')
 
     def build() -> None:
@@ -287,16 +259,9 @@ class Jetlinkd:
   def _report_with_eta(self, stage: str, frac: float, msg: str) -> None:
     """Progress, with how long the build still has to run.
 
-    models.json carries `built_seconds` per model and has since it was written,
-    measured on this hardware, so that the UI could say how long a first
-    provision takes. Nothing ever read it, and the panel showed "build 12%"
-    while a driver waited out five minutes with no idea it was five and not
-    thirty. The number belongs here rather than in the UI: it comes from the
-    backend's own registry, and openpilot/selfdrive/ui stays free of any
-    knowledge that jetlink exists.
-
-    Only the build is estimated. The upload already reports MB of MB, and a
-    connect has nothing to predict.
+    built_seconds in models.json is measured on this hardware. It belongs here
+    rather than in the UI, which knows nothing about jetlink. Only the build is
+    estimated: the upload reports MB of MB and a connect has nothing to predict.
     """
     if stage == 'build':
       entry = helpers.selected_model() or {}
@@ -308,41 +273,32 @@ class Jetlinkd:
   def provision(self) -> bool:
     """Make the Jetson ready for the selected model. Host must be attached.
 
-    The identity comes from the registry, not from the file. models.json
-    carries the git-lfs `oid`, which is the sha256, and `size`, which is the
-    byte count - exactly the pair ENGINE_REQ wants. This used to hash the local
-    ONNX to derive them, which meant the comma could not so much as ask the
-    Jetson what it already had without holding 766 MB itself, and re-derived a
-    number that was sitting in the registry the whole time.
-
-    The Jetson keeps its own copy of every ONNX and never prunes them, so once
-    a model has been provisioned the comma's copy is dead weight. Now it is
-    only fetched when the server actually asks for the bytes, which means a
-    model change with no network works as long as the Jetson has the engine.
+    The identity comes from models.json (the git-lfs oid is the sha256, size
+    the byte count), so the comma can ask without holding or hashing the ONNX.
+    The file is only fetched when the server asks for the bytes; the Jetson
+    keeps its own copy of every ONNX and never prunes it.
     """
-    # Imported here rather than at module scope: jetlinkd is constructed on
-    # devices whose jetlink package may be absent, and the module must import
-    # without it. Same reason backend._open_link does it.
+    # imported here: the jetlink package may be absent and this module must
+    # still import. Same as backend._open_link
     from jetlink.client import EngineMissing
 
     entry = helpers.selected_model()
     sha256 = (entry or {}).get('oid')
     nbytes = (entry or {}).get('size')
     if not sha256 or not nbytes:
-      # Nothing selected, or a registry entry with no identity. Not an error.
+      # nothing selected, or an entry with no identity; not an error
       helpers.set_engine_ready(None)
       accelerators.clear_progress()
       return False
     nbytes = int(nbytes)
 
-    # The param says ready, but the Jetson's cache may have been pruned,
-    # re-flashed or swapped since. Ask once per attach; after that the answer
-    # cannot change under us.
+    # the param says ready, but the Jetson's cache may have been pruned or
+    # re-flashed since. Ask once per attach
     if self.verified and helpers.engine_ready_for(sha256):
       return True
 
-    # Only needed if the server turns out not to have this model. None is a
-    # legitimate state here, not a failure: see EngineMissing below.
+    # only needed if the server turns out not to have this model; None is a
+    # legitimate state here, see EngineMissing below
     model_path = helpers.active_model_path()
 
     cloudlog.warning("jetlink: provisioning %s (%d MB, sha %s)",
@@ -352,9 +308,8 @@ class Jetlinkd:
     hello = self.client.hello(timeout=10.0)
     Params().put('JetlinkCachedModels', hello.get('cached_models', []))
     cloudlog.warning("jetlink: server %s trt %s", hello.get('device'), hello.get('trt_version'))
-    # Asked without the file first, always. The server answers from the sha
-    # alone when it already has the model, which is every poll of a parked car,
-    # and only the answer "I need the bytes" is worth reading 766 MB for.
+    # ask without the file first: the server answers from the sha alone when it
+    # has the model, which is every poll of a parked car
     ask = functools.partial(self.client.ensure_engine, sha256, nbytes,
                             progress=self._report_with_eta,
                             build_timeout=1800.0, should_stop=lambda: self.stop)
@@ -363,8 +318,8 @@ class Jetlinkd:
     except EngineMissing:
       upload = self._verified_upload(model_path, sha256, nbytes)
       if upload is None:
-        # Nothing to give. Fetch it and let the next poll try again rather than
-        # holding the link through a download that takes minutes.
+        # nothing to give. Fetch it and let the next poll try again rather than
+        # holding the link through a download that takes minutes
         if model_path is None and self.fetch_model() is not None:
           return False
         raise
@@ -381,14 +336,11 @@ class Jetlinkd:
     return True
 
   def _verified_upload(self, model_path, sha256: str, nbytes: int):
-    """The file to upload if the server asks for it, once it is proven to be it.
+    """The file to upload, once its hash is proven to match the registry.
 
-    Taking the identity from the registry moves the trust from the file to
-    models.json, which is right for asking a question and wrong for answering
-    one: uploading under a sha the bytes do not have would leave the Jetson
-    with a plan whose name lies about its contents, and nothing downstream
-    would ever notice. So the hash happens here, on the one path where the
-    bytes actually go somewhere, rather than on every poll of a parked car.
+    Uploading under a sha the bytes do not have would leave the Jetson with a
+    plan whose name lies about its contents, so the hash happens here, on the
+    one path where the bytes go somewhere.
     """
     if model_path is None:
       return None
@@ -411,9 +363,8 @@ class Jetlinkd:
 
   def go_dormant(self) -> None:
     """Release the gadget so the Jetson can sleep. The marker goes first so
-    present() never blinks: presence follows it, not the UDC, while we are
-    dormant. Readiness is kept; the server is asked again on the next
-    attach as it is after any other detach."""
+    present() never blinks. Readiness is kept; the server is asked again on
+    the next attach."""
     cloudlog.warning("jetlink: nothing left to do, releasing the gadget so the jetson can sleep")
     helpers.set_dormant(True)
     self.close_link()
@@ -429,7 +380,7 @@ class Jetlinkd:
 
   def has_work(self) -> bool:
     """Is there a reason to wake the Jetson? Only things the link can fix
-    count: the warp is local and build_warp handles it regardless."""
+    count; the warp is local and build_warp handles it."""
     spec = spec_cache.load()
     if spec is None or not helpers.engine_ready_for(spec.sha256):
       return True
@@ -438,8 +389,7 @@ class Jetlinkd:
 
   def shutdown_jetson(self, reason: str) -> None:
     """hardwared is shutting the comma down and wants the Jetson off too.
-    The request file is ours to remove, whatever happens: hardwared is
-    waiting on it and the comma goes down either way."""
+    The request file is removed whatever happens: hardwared is waiting on it."""
     cloudlog.warning("jetlink: shutting the jetson down: %s", reason)
     try:
       if self.dormant:
@@ -473,11 +423,10 @@ class Jetlinkd:
   # -- main loop ------------------------------------------------------------
 
   def backoff(self) -> float:
-    """How long to wait before provisioning again, doubling per failure.
+    """Wait before provisioning again, doubling per failure.
 
-    A Jetson that is powered but never answers is the case this exists for:
-    at a flat 30 s it would be retried 120 times an hour for as long as the
-    car is parked, and every one of those costs a round of USB churn.
+    A powered Jetson that never answers would otherwise be retried 120 times
+    an hour for as long as the car is parked, each a round of USB churn.
     """
     return min(RETRY_BACKOFF * 2 ** (self.failures - 1), RETRY_BACKOFF_MAX)
 
@@ -505,12 +454,8 @@ class Jetlinkd:
       else:
         return
 
-    # Before the link and before the attach gate: the warp needs neither, and
-    # it is the one thing modeld refuses to start the large model without. It
-    # used to sit below `if not attached: return`, so a Jetson that was slow to
-    # enumerate delayed the compile as well. Cheap now that the build normally
-    # got there first, but the ordering still matters on the install that has
-    # to fall back.
+    # before the link and the attach gate: the warp needs neither, and modeld
+    # will not start the large model without it
     self.build_warp()
 
     if time.monotonic() < self.next_attempt:
@@ -523,20 +468,19 @@ class Jetlinkd:
       cloudlog.warning("jetlink: jetson %s", "attached" if attached else "gone")
       self.was_attached = attached
       if attached:
-        # A host that has just arrived gets a clean slate rather than sitting
-        # out a backoff earned by whatever was on the link before it, and its
-        # engine cache is checked before the ready param is trusted again.
+        # a host that has just arrived gets a clean slate rather than a backoff
+        # earned by whatever was on the link before it
         self.failures = 0
         self.next_provision = 0.0
         self.verified = False
       else:
-        # It powered down or rebooted. Readiness is about the engine on the
-        # Jetson, which survives, so keep it; modeld reconnects on its own.
+        # it powered down or rebooted. Readiness is about the engine on the
+        # Jetson, which survives; modeld reconnects on its own
         self.ready = False
     if not attached:
       return
-    # Provisioning backs off on its own timer, so that a long wait for an
-    # unresponsive server still leaves us watching for one that reappears.
+    # provisioning backs off on its own timer, so a long wait for an
+    # unresponsive server still watches for one that reappears
     if time.monotonic() < self.next_provision:
       return
 
@@ -550,9 +494,9 @@ class Jetlinkd:
       cloudlog.exception("jetlink: provisioning failed")
       accelerators.report_progress('failed', 1.0, 'see the log')
       self.ready = False
-      # Only reopen when the link itself is suspect. Unbinding the gadget
-      # makes the host re-enumerate, and doing that every time a server that
-      # is simply not up yet fails to answer is hours of USB churn.
+      # only reopen when the link itself is suspect: unbinding makes the host
+      # re-enumerate, and doing that for a server that is not up yet is hours
+      # of USB churn
       if not _timed_out(e):
         self.close_link()
       self.failures += 1
@@ -568,14 +512,13 @@ class Jetlinkd:
         try:
           self.step()
         except Exception:
-          # Nothing may escape: this daemon restarting in a loop would be worse
-          # than it sitting out a cycle.
+          # nothing may escape: restarting in a loop is worse than sitting out a cycle
           cloudlog.exception("jetlink: unhandled error")
           self.close_link()
           self.next_attempt = time.monotonic() + RECONNECT_BACKOFF
     finally:
+      # the sysctls stay: a stop here is the ignition handoff to modeld
       self.close_link()
-      self.untune_vm()
     helpers.set_dormant(False)
     if self.warp_thread is not None and self.warp_thread.is_alive():
       cloudlog.warning("jetlink: stopped with the warp still compiling; it will rebuild next time")
@@ -584,8 +527,8 @@ class Jetlinkd:
 
 def main() -> None:
   d = Jetlinkd()
-  # manager stops us with SIGTERM at the onroad transition. Closing the link
-  # properly on the way out is what keeps the driver healthy for modeld.
+  # manager stops this at the onroad transition; closing the link properly is
+  # what keeps the driver healthy for modeld
   signal.signal(signal.SIGTERM, d.request_stop)
   signal.signal(signal.SIGINT, d.request_stop)
   d.run()

--- a/openpilot/sunnypilot/accelerators/jetlink/joining.py
+++ b/openpilot/sunnypilot/accelerators/jetlink/joining.py
@@ -1,0 +1,391 @@
+"""
+Copyright (c) 2026-, Zeph Leggett.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+
+A ModelState that starts as the small model and upgrades to the Jetson.
+
+modeld's large-model load is a one-shot with BIG_MODEL_TIMEOUT and a silent,
+one-way fallback. That suits a chestnut, powered from the comma. A Jetson is
+on the ignition rail: cranking browns it out, so its boot starts about when
+the comma goes onroad and takes 45 to 100 s, long after modeld gave up.
+
+So modeld is handed the small model it already loaded, and the Jetson is
+swapped in underneath once the link, the engine and the warp are all there.
+modeld re-reads `model` every frame, and `modelV2.big` keeps its meaning.
+
+Two rules the swap keeps:
+
+- tinygrad work happens on modeld's thread. The joining thread does link IO
+  only; building the JetlinkModelState unpickles a TinyJit, and doing that
+  next to the small model running frames on the same device is not safe.
+- never swap while the plan is steering. The two models disagree by ~195 m of
+  planned path, and the swap costs a frame or two. Require fresh, fully
+  disengaged controls; standstill alone is not enough, longitudinal control
+  may still hold the brake.
+"""
+from __future__ import annotations
+
+import os
+import threading
+import time
+
+import openpilot.cereal.messaging as messaging
+from openpilot.sunnypilot import accelerators
+from openpilot.common.realtime import drop_realtime, set_core_affinity
+from openpilot.common.swaglog import cloudlog
+
+# after a join fails or the large model dies mid-drive. Long enough not to
+# thrash a booting Jetson, short enough to catch one that finished a moment later
+REJOIN_DELAY = 5.0
+# doubled per consecutive failure, reset by a join that lasted STABLE_SECONDS.
+# A link that dies on its first frame every time must not cost a swap, a
+# demote and an alert every few seconds
+REJOIN_DELAY_MAX = 60.0
+STABLE_SECONDS = 60.0
+ENGAGEMENT_POLL_MS = 100
+ENGAGEMENT_MAX_AGE = 0.25
+# how often a link that is ready but has nowhere to land gets checked, and
+# how long the check may take; both off the frame loop
+KEEPALIVE_PERIOD = 10.0
+PING_TIMEOUT = 2.0
+
+
+def _background_priority() -> None:
+  """Get this thread off modeld's realtime core before it does anything.
+
+  A thread started after config_realtime_process(7, 54) inherits SCHED_FIFO
+  and the single-core affinity, and an equal-priority thread that wakes takes
+  the core until it blocks. Measured with these threads left as created: exec
+  p95 90.8 ms, max 159.9, 5% frame drops, enough for modeldLagging.
+  """
+  drop_realtime()
+  try:
+    online = os.sched_getaffinity(0)
+    everything = set(range(os.cpu_count() or 1))
+    if everything - online:
+      set_core_affinity(sorted(everything))
+  except (OSError, AttributeError):
+    # PC, or a kernel that will not widen the mask; SCHED_OTHER is the part
+    # that matters
+    pass
+
+
+class JoiningModelState:
+  """Duck-types selfdrive.modeld.modeld.ModelState, with a second one inside."""
+
+  def __init__(self, cam_w: int, cam_h: int, small, connect, build, prepare=None, reset_small=None):
+    self._small = small
+    self._active = small
+    self._cam = (cam_w, cam_h)
+    self._connect = connect
+    self._build = build
+    self._reset_small = reset_small
+
+    # whatever the swap would otherwise do on the frame loop, done now on
+    # modeld's main thread before the frame loop exists; at the swap it cost
+    # a 1.5 s frame
+    if prepare is not None:
+      try:
+        t0 = time.monotonic()
+        prepare()
+        cloudlog.warning("jetlink: prepared the large model ahead of the swap in %.2f s", time.monotonic() - t0)
+      except Exception:
+        cloudlog.exception("jetlink: could not prepare the large model ahead of the swap")
+        raise
+
+    # handed over by the joining thread, consumed by the first frame that finds
+    # it safe to swap. Only ever assigned under the lock
+    self._joined: tuple[object, object] | None = None
+    # kept true during a keepalive ping, which temporarily takes _joined
+    self._available = False
+    self._retired = None
+    self._lock = threading.Lock()
+    self._rejoin = threading.Event()
+    self._rejoin.set()
+    # earliest the join loop may try again. Without a backoff a fault that
+    # recurs on the first frame after every swap is a connect, build and demote
+    # every 700 ms for the drive, each costing modeld a 100 ms frame
+    self._rejoin_at = 0.0
+    self._failures = 0
+    self._joined_at = 0.0
+
+    # assume engaged and moving until a message says otherwise, so a swap can
+    # never happen on no information
+    self._engaged = True
+    self._standstill = False
+    self._engagement_updated = 0.0
+    self._stop = threading.Event()
+
+    # whether the large model has produced a frame; a first inference that
+    # fails never announces readiness. Travels in modelV2.big and
+    # modelDataV2SP, not a param: a chestnut's load is over once, this never is
+    self._loading = True
+
+    self._threads = [threading.Thread(target=self._join_loop, daemon=True),
+                     threading.Thread(target=self._watch_engagement, daemon=True)]
+    for t in self._threads:
+      t.start()
+
+  # -- what modeld reads ------------------------------------------------------
+
+  @property
+  def big_model_available(self) -> bool:
+    """Connected and waiting to switch; published with each small-model frame."""
+    return not self._stop.is_set() and self._available and self._active is self._small
+
+  @property
+  def chestnut(self) -> bool:
+    # modelV2.big. False while proxying, as the small model would report
+    return getattr(self._active, 'chestnut', False)
+
+  @property
+  def loading(self) -> bool:
+    """Still bringing the accelerator up: the small model is driving."""
+    return self._active is self._small
+
+  @property
+  def big_model_state(self) -> str:
+    """modelDataV2SP.acceleratorState, one of its enum names."""
+    if self._stop.is_set():
+      return 'unavailable'
+    if self._active is not self._small:
+      return 'running'
+    return 'retrying' if self._failures else 'joining'
+
+  @property
+  def vision_input_names(self):
+    return self._active.vision_input_names
+
+  @property
+  def client(self):
+    # read by the status publisher on every send, so the telemetry follows the link
+    return getattr(self._active, 'client', None)
+
+  @property
+  def lat_delay(self):
+    return self._active.lat_delay
+
+  @lat_delay.setter
+  def lat_delay(self, value):
+    # modeld writes this every frame. Set on both, so a model that joins
+    # mid-drive does not start on a stale delay
+    self._small.lat_delay = value
+    if self._active is not self._small:
+      self._active.lat_delay = value
+
+  # -- the frame path ---------------------------------------------------------
+
+  def run(self, bufs, transforms, inputs, after_enqueue=None):
+    self._maybe_swap()
+    active = self._active
+    try:
+      result = active.run(bufs, transforms, inputs, after_enqueue)
+    except Exception:
+      if active is self._small:
+        # nothing to do with the link; modeld's own handler owns this
+        raise
+      cloudlog.exception("jetlink: large model failed mid-drive, back to the small model")
+      self._demote()
+      if self._reset_small is not None:
+        self._reset_small()
+      # re-run the frame rather than propagate: modeld's fallback is permanent,
+      # this one is retryable. after_enqueue is dropped, the large model may
+      # already have called it
+      return self._small.run(bufs, transforms, inputs, None)
+    if active is not self._small and self._loading:
+      # a connected engine can still fail its first inference; only announce
+      # readiness after a frame the caller can publish
+      self._joined_at = time.monotonic()
+      self._loading = False
+      accelerators.clear_progress()
+      cloudlog.warning("jetlink: large model joined mid-drive, modelV2.big is now true")
+    return result
+
+  def warmup(self) -> None:
+    """Nothing to do, and it still has to exist.
+
+    The warp is warmed by `prepare` in __init__ and the first real frame
+    carries the reset. modeld does not call this on the jetlink path, but a
+    caller that duck-types it must not take an AttributeError, which modeld
+    reads as "big model load failed".
+    """
+
+  @property
+  def _window_open(self) -> bool:
+    # standstill does not make an active longitudinal controller safe to swap
+    fresh = 0 <= time.monotonic() - self._engagement_updated < ENGAGEMENT_MAX_AGE
+    return fresh and not self._engaged
+
+  def _maybe_swap(self) -> None:
+    if self._joined is None or not self._window_open:
+      return
+    with self._lock:
+      joined, self._joined = self._joined, None
+      if joined is not None:
+        self._available = False
+    if joined is None:
+      return
+    client, spec = joined
+    try:
+      # everything tinygrad touches happens here, on modeld's thread. No
+      # warmup: the first real frame carries the reset (~30 ms on the server),
+      # where a warmup frame over the link was two more dropped frames
+      t0 = time.monotonic()
+      big = self._build(client, spec)
+      big.lat_delay = self._small.lat_delay
+      cloudlog.warning("jetlink: built the large model state in %.0f ms", (time.monotonic() - t0) * 1000)
+    except Exception:
+      cloudlog.exception("jetlink: could not bring up the large model, staying small")
+      with self._lock:
+        self._retired = client
+      # backed off like a demote, or a build that fails the same way every
+      # time is a connect and a build per second for the drive
+      self._back_off()
+      return
+    self._active = big
+
+  def _demote(self) -> None:
+    big, self._active = self._active, self._small
+    self._loading = True
+    self._report('connect', 'lost the jetson, reconnecting')
+    with self._lock:
+      self._retired = big
+    self._back_off()
+
+  def _close_retired(self) -> None:
+    with self._lock:
+      retired, self._retired = self._retired, None
+    if retired is not None:
+      try:
+        retired.close()
+      except Exception:
+        cloudlog.exception('jetlink: closing the retired link')
+
+  def _back_off(self) -> None:
+    """Push the next attempt out, further each time one fails on its heels.
+
+    Each failed cycle is a swap frame, a demote frame, a soft disable and a
+    "Big Model Ready" chime. A join that held for STABLE_SECONDS starts from
+    the bottom again.
+    """
+    stable = self._joined_at and time.monotonic() - self._joined_at > STABLE_SECONDS
+    self._failures = 1 if stable else self._failures + 1
+    self._joined_at = 0.0
+    delay = min(REJOIN_DELAY * 2 ** (self._failures - 1), REJOIN_DELAY_MAX)
+    self._rejoin_at = time.monotonic() + delay
+    self._rejoin.set()
+    cloudlog.warning("jetlink: next attempt in %.0f s (failure %d)", delay, self._failures)
+
+  # -- background -------------------------------------------------------------
+
+  def _report(self, stage: str, msg: str) -> None:
+    """Tell the UI what the join is waiting on.
+
+    Offroad the param carries jetlinkd's provisioning; without this, a Jetson
+    that is not plugged in looked like one six seconds from loading. No
+    fraction to give, and the panel does not invent one.
+    """
+    accelerators.report_progress(stage, 0.0, msg)
+
+  def _join_loop(self) -> None:
+    """Open the link and get the engine ready. No tinygrad in here."""
+    _background_priority()
+    while not self._stop.is_set():
+      # no timeout: once joined there is nothing to poll for, and close() sets
+      # this. An idle wake per second is not free on modeld's core
+      self._rejoin.wait()
+      # unbind and reader joins can block; only this thread does teardown,
+      # and it finishes before opening another link
+      self._close_retired()
+      if self._stop.is_set():
+        return
+      self._rejoin.clear()
+      if self._stop.wait(max(0.0, self._rejoin_at - time.monotonic())):
+        return
+      self._report('connect', 'waiting for the jetson')
+      try:
+        client, spec = self._connect()
+      except Exception as e:
+        # expected while the Jetson boots. Not exception(): a stack trace every
+        # 5 s for the first minute of every drive is noise
+        cloudlog.warning("jetlink: not joined yet (%s), retrying in %.0fs", e, REJOIN_DELAY)
+        if self._stop.wait(REJOIN_DELAY):
+          return
+        self._rejoin.set()
+        continue
+      with self._lock:
+        if self._stop.is_set():
+          client.close()
+          return
+        self._available = True
+        self._joined = (client, spec)
+      cloudlog.warning("jetlink: link ready, waiting for a window to swap")
+      self._report('connect', 'ready; disengage to switch models')
+      self._keep_alive()
+
+  def _keep_alive(self) -> None:
+    """Ping a link that is waiting for a swap window.
+
+    On a drive with no stop and no disengage that is the whole drive, and a
+    Jetson that reboots in there would otherwise be found at the swap: a build
+    on a dead link, a demote and the backoff, all on modeld's thread.
+
+    The client is taken out of _joined for the ping and put back after, so the
+    frame loop sees a whole one or none, and never waits on the lock.
+    """
+    while not self._stop.is_set():
+      if self._rejoin.wait(KEEPALIVE_PERIOD):
+        return
+      with self._lock:
+        joined, self._joined = self._joined, None
+      if joined is None:
+        return  # swapped in on a frame, or closed under us
+      try:
+        joined[0].ping(timeout=PING_TIMEOUT)
+      except Exception as e:
+        self._available = False
+        cloudlog.warning("jetlink: the link died before it could be used (%s), reopening", e)
+        try:
+          joined[0].close()
+        except Exception:
+          pass
+        self._rejoin_at = time.monotonic() + REJOIN_DELAY
+        self._rejoin.set()
+        return
+      with self._lock:
+        if self._stop.is_set():
+          # close() ran during the ping and found nothing to close
+          joined[0].close()
+          return
+        self._joined = joined
+
+  def _watch_engagement(self) -> None:
+    _background_priority()
+    sm = messaging.SubMaster(['selfdriveState', 'carState', 'carControl'])
+    while not self._stop.is_set():
+      sm.update(ENGAGEMENT_POLL_MS)
+      self._update_engagement(sm)
+
+  def _update_engagement(self, sm) -> None:
+    # recheck on every poll, including ones with no new messages: that is
+    # when alive turns false. The frame thread expires the snapshot too
+    valid = all(sm.seen[s] and sm.alive[s] and sm.valid[s] for s in ('selfdriveState', 'carState', 'carControl'))
+    # forks can keep lateral control active independently of enabled (MADS)
+    self._engaged = not valid or sm['selfdriveState'].enabled or sm['carControl'].latActive or sm['carControl'].longActive
+    self._standstill = valid and sm['carState'].standstill
+    self._engagement_updated = time.monotonic()
+
+  def close(self) -> None:
+    self._stop.set()
+    self._available = False
+    self._rejoin.set()
+    accelerators.clear_progress()
+    with self._lock:
+      joined, self._joined = self._joined, None
+    if joined is not None:
+      joined[0].close()
+    close = getattr(self._active, 'close', None)
+    if close is not None and self._active is not self._small:
+      close()

--- a/openpilot/sunnypilot/accelerators/jetlink/lfs.py
+++ b/openpilot/sunnypilot/accelerators/jetlink/lfs.py
@@ -1,0 +1,192 @@
+"""
+Copyright (c) 2026-, Zeph Leggett.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+
+Fetching the large model's ONNX, which the install deliberately does not carry.
+
+The big model is a git-lfs object .lfsconfig excludes from the install: it is
+0.8 to 1.8 GB and only a device with a Jetson attached needs it, so it is
+fetched on demand. The pointer file says which model; which server has it
+varies (sunnypilot substitutes its own big model, comma's LFS holds comma's),
+so each endpoint is asked in turn.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import urllib.request
+from collections.abc import Callable
+from pathlib import Path
+
+from openpilot.common.swaglog import cloudlog
+
+LFS_MEDIA_TYPE = 'application/vnd.git-lfs+json'
+# comma's LFS is on GitLab, not GitHub: GitHub's LFS API and
+# media.githubusercontent both 404 these. Both endpoints serve anonymously
+COMMA_LFS = 'https://gitlab.com/commaai/openpilot-lfs.git/info/lfs'
+CONNECT_TIMEOUT = 30.0
+CHUNK = 4 << 20
+
+
+class LfsError(Exception):
+  pass
+
+
+def parse_pointer(path: Path) -> tuple[str, int] | None:
+  """Read a git-lfs pointer file, or None if this is the real object.
+
+  A pointer is a few hundred bytes of text, so size tells them apart cheaply.
+  """
+  try:
+    if path.stat().st_size > 4096:
+      return None
+    text = path.read_text()
+  except (OSError, UnicodeDecodeError):
+    return None
+
+  oid = size = None
+  for line in text.splitlines():
+    key, _, value = line.partition(' ')
+    if key == 'oid':
+      oid = value.removeprefix('sha256:').strip()
+    elif key == 'size':
+      try:
+        size = int(value)
+      except ValueError:
+        return None
+  if not oid or size is None:
+    return None
+  return oid, size
+
+
+def lfsconfig_endpoint(repo_root: Path) -> str | None:
+  """The LFS url this checkout is configured for, if any."""
+  try:
+    text = (repo_root / '.lfsconfig').read_text()
+  except OSError:
+    return None
+  for line in text.splitlines():
+    key, sep, value = line.strip().partition('=')
+    if sep and key.strip() == 'url':
+      return value.strip() or None
+  return None
+
+
+def endpoints(repo_root: Path) -> list[str]:
+  """Where to look, nearest first: the checkout's own server, then comma's."""
+  out = []
+  configured = lfsconfig_endpoint(repo_root)
+  if configured:
+    out.append(configured.removesuffix('/'))
+  if COMMA_LFS not in out:
+    out.append(COMMA_LFS)
+  return out
+
+
+def resolve(endpoint: str, oid: str, size: int, timeout: float = CONNECT_TIMEOUT) -> str | None:
+  """Ask one LFS server for a download href, or None if it does not have it."""
+  body = json.dumps({
+    'operation': 'download',
+    'transfers': ['basic'],
+    'objects': [{'oid': oid, 'size': size}],
+  }).encode()
+  request = urllib.request.Request(f'{endpoint}/objects/batch', data=body, method='POST',
+                                   headers={'Accept': LFS_MEDIA_TYPE, 'Content-Type': LFS_MEDIA_TYPE})
+  try:
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+      payload = json.load(response)
+  except Exception:
+    cloudlog.warning("jetlink: lfs batch failed at %s", endpoint, exc_info=True)
+    return None
+
+  for obj in payload.get('objects', []):
+    if obj.get('oid') != oid:
+      continue
+    if 'error' in obj:
+      cloudlog.warning("jetlink: %s has no %s (%s)", endpoint, oid[:16], obj['error'].get('message'))
+      return None
+    href = (obj.get('actions', {}).get('download') or {}).get('href')
+    if href:
+      return href
+  return None
+
+
+def download(href: str, oid: str, size: int, dest: Path,
+             progress: Callable[[float], None] | None = None,
+             should_stop: Callable[[], bool] | None = None) -> Path:
+  """Stream to a .part file, hashing as we go, and only then take the name.
+
+  A half-written model must never be where the next boot would hand it to TensorRT.
+  """
+  free = shutil.disk_usage(dest.parent).free
+  if free < size + (64 << 20):
+    raise LfsError(f"need {size >> 20} MB for the large model, {free >> 20} MB free")
+
+  part = dest.with_name(dest.name + '.part')
+  digest = hashlib.sha256()
+  written = 0
+  # whole percent only: the callback writes a param, and a gigabyte at 4 MB a
+  # chunk would write it a few hundred times
+  reported = -1
+  try:
+    with urllib.request.urlopen(href, timeout=CONNECT_TIMEOUT) as response, open(part, 'wb') as out:
+      while True:
+        if should_stop is not None and should_stop():
+          raise LfsError("download interrupted")
+        chunk = response.read(CHUNK)
+        if not chunk:
+          break
+        out.write(chunk)
+        digest.update(chunk)
+        written += len(chunk)
+        if progress is not None and size:
+          percent = int(100 * written / size)
+          if percent != reported:
+            reported = percent
+            progress(min(1.0, written / size))
+  except LfsError:
+    part.unlink(missing_ok=True)
+    raise
+  except Exception as e:
+    part.unlink(missing_ok=True)
+    raise LfsError(f"could not download the large model: {e}") from e
+
+  if written != size:
+    part.unlink(missing_ok=True)
+    raise LfsError(f"large model is {written} bytes, expected {size}")
+  if digest.hexdigest() != oid:
+    part.unlink(missing_ok=True)
+    raise LfsError(f"large model hashes to {digest.hexdigest()[:16]}, expected {oid[:16]}")
+
+  part.replace(dest)
+  return dest
+
+
+def fetch(pointer: Path, dest: Path, repo_root: Path,
+          progress: Callable[[float], None] | None = None,
+          should_stop: Callable[[], bool] | None = None) -> Path | None:
+  """Materialise the object a pointer file describes. None if it is not one."""
+  parsed = parse_pointer(pointer)
+  if parsed is None:
+    return None
+  return fetch_oid(*parsed, dest, repo_root, progress=progress, should_stop=should_stop)
+
+
+def fetch_oid(oid: str, size: int, dest: Path, repo_root: Path,
+              progress: Callable[[float], None] | None = None,
+              should_stop: Callable[[], bool] | None = None) -> Path:
+  """Materialise one lfs object by oid, from whichever server has it."""
+  if dest.is_file() and dest.stat().st_size == size:
+    return dest
+
+  for endpoint in endpoints(repo_root):
+    href = resolve(endpoint, oid, size)
+    if href is None:
+      continue
+    cloudlog.warning("jetlink: fetching the large model (%d MB) from %s", size >> 20, endpoint)
+    return download(href, oid, size, dest, progress=progress, should_stop=should_stop)
+
+  raise LfsError(f"no configured LFS server has {oid[:16]}")

--- a/openpilot/sunnypilot/accelerators/jetlink/model_state.py
+++ b/openpilot/sunnypilot/accelerators/jetlink/model_state.py
@@ -1,0 +1,184 @@
+"""
+Copyright (c) 2026-, Zeph Leggett.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+
+A ModelState whose policy runs on the Jetson.
+
+Everything that touches the car stays on the comma: cameras, calibration, the
+warp, the parser, controlsd, panda, CAN. The Jetson is a pure function, warped
+frames and context in, 18452 floats out, and holds no control state.
+
+The split is at `run_policy`. The warp stays on the comma's GPU: its input is a
+2 MB camera buffer already there and its output the 393 KB the link carries
+anyway. The history queues live on the Jetson, shipping them would cost ~10 MB
+a frame instead of ~0.5 MB. Upstream fused warp and policy into one JIT, so
+scons compiles a standalone warp at build time; see warp_cache.
+"""
+from __future__ import annotations
+
+import os
+import time
+from collections.abc import Callable
+
+import numpy as np
+from tinygrad.device import Device
+from tinygrad.tensor import Tensor
+
+from msgq.visionipc import VisionBuf
+
+from openpilot.common.swaglog import cloudlog
+from openpilot.selfdrive.modeld.constants import ModelConstants
+from openpilot.selfdrive.modeld.parse_model_outputs import Parser
+from openpilot.system.camerad.cameras.nv12_info import get_nv12_info
+from openpilot.sunnypilot.accelerators.jetlink import warp_cache
+from openpilot.sunnypilot.modeld_v2.modeld_base import ModelStateBase
+
+SEND_RAW_PRED = os.getenv('SEND_RAW_PRED')
+SLOW_FRAME = 0.05  # the full 20 Hz budget, not just the largest outliers
+
+
+class JetlinkModelState(ModelStateBase):
+  """Duck-types selfdrive.modeld.modeld.ModelState."""
+
+  prev_desire: np.ndarray  # for tracking the rising edge of the pulse
+
+  def __init__(self, cam_w: int, cam_h: int, client, spec, small=None, warp=None):
+    ModelStateBase.__init__(self)
+    self.client = client
+    self.spec = spec
+    # not chestnut hardware, but the same role: modelV2.big, the UI and the
+    # model manager key off this flag
+    self.chestnut = True
+
+    # make_warp is sized in NV12 pixels and the model input after deinterleave,
+    # so img (1, 12, 128, 256) is a 512x256 warp, MEDMODEL_INPUT_SIZE
+    img_h, img_w = spec.input_shapes['img'][2:]
+    # a warm warp is handed in when there is one: the first call costs ~2 s and
+    # this can run on modeld's frame thread (warp_cache.warm)
+    self.warp = warp if warp is not None else warp_cache.load_warp(cam_w, cam_h, img_w * 2, img_h * 2)
+
+    # the small ModelState is only a geometry cross-check now
+    small_img = small.input_shapes['img'] if small is not None else None
+    if small_img is not None and tuple(small_img[2:]) != tuple(spec.input_shapes['img'][2:]):
+      raise RuntimeError(f"warp geometry {small_img[2:]} does not match the large model "
+                         + f"{spec.input_shapes['img'][2:]}; a large-model warp JIT is needed")
+
+    self.input_shapes = spec.input_shapes
+    self.output_slices = spec.output_slices
+    self.vision_input_names = [k for k in spec.input_shapes if 'img' in k]
+    # from the spec, not ModelConstants: the server derives its history stride
+    # from the same field
+    self.frame_skip = spec.frame_skip
+
+    # the warp's own two inputs stay separate NPY tensors; everything past the
+    # warp is the server's. Writing the numpy array is what feeds the JIT
+    self.npy = {'tfm': np.zeros((3, 3), dtype=np.float32),
+                'big_tfm': np.zeros((3, 3), dtype=np.float32)}
+    self.warp_inputs = {k: Tensor(v, device='NPY').realize() for k, v in self.npy.items()}
+
+    # compile_modeld.make_input_queues' packed_npy_inputs, minus the GPU queues
+    # the server owns
+    self.packed = np.zeros(spec.packed_nelem, dtype=np.float32)
+    views = np.split(self.packed, np.cumsum(spec.packed_sizes[:-1]))
+    self.npy.update({k: v.reshape(s) for (k, s), v in
+                     zip(spec.packed_shapes.items(), views, strict=True)})
+
+    # read once: it must be the device the cached JIT was compiled against
+    self.warp_dev = Device.DEFAULT
+    self.prev_desire = np.zeros(ModelConstants.DESIRE_LEN, dtype=np.float32)
+    self.parser = Parser()
+    self.frame_buf_params = {k: get_nv12_info(cam_w, cam_h) for k in ('img', 'big_img')}
+    self.full_frames: dict[str, Tensor] = {}
+    self._blob_cache: dict[tuple[str, int], Tensor] = {}
+    self._need_reset = True
+    self._frame_id = 0
+
+  def slice_outputs(self, model_outputs: np.ndarray, output_slices: dict[str, slice]) -> dict[str, np.ndarray]:
+    return {k: model_outputs[np.newaxis, v] for k, v in output_slices.items()}
+
+  def run(self, bufs: dict[str, VisionBuf], transforms: dict[str, np.ndarray],
+          inputs: dict[str, np.ndarray], after_enqueue: Callable[[], None] | None = None) -> dict[str, np.ndarray]:
+    for key in bufs.keys():
+      ptr = np.frombuffer(bufs[key].data, dtype=np.uint8).ctypes.data
+      yuv_size = self.frame_buf_params[key][3]
+      cache_key = (key, ptr)
+      if cache_key not in self._blob_cache:
+        self._blob_cache[cache_key] = Tensor.from_blob(ptr, (yuv_size,), dtype='uint8', device=self.warp_dev)
+      self.full_frames[key] = self._blob_cache[cache_key]
+
+    # Model decides when action is completed, so desire input is just a pulse triggered on rising edge
+    inputs['desire_pulse'][0] = 0
+    self.npy['desire'][:] = np.where(inputs['desire_pulse'] - self.prev_desire > .99, inputs['desire_pulse'], 0)
+    self.prev_desire[:] = inputs['desire_pulse']
+    self.npy['traffic_convention'][:] = inputs['traffic_convention']
+    self.npy['action_t'][:] = inputs['action_t']
+    self.npy['tfm'][:, :] = transforms['img'][:, :]
+    self.npy['big_tfm'][:, :] = transforms['big_img'][:, :]
+
+    t0 = time.perf_counter()
+    warped = warp_cache.call_warp(self.warp, **self.warp_inputs,
+                                  frame=self.full_frames['img'], big_frame=self.full_frames['big_img'])
+    t1 = time.perf_counter()
+    # .data() rather than .numpy(): same ~2.5 ms mean (a write-combined GPU
+    # mapping read), but no per-frame allocation and no 52 ms outlier
+    data = warped.data()
+    t2 = time.perf_counter()
+
+    self._frame_id += 1
+    seq = self.client.infer_begin(data, self.packed, self._frame_id,
+                                  reset=self._need_reset, want_state=after_enqueue is not None)
+    t3 = time.perf_counter()
+    self._need_reset = False
+    # publish health while the Jetson works
+    if after_enqueue is not None:
+      after_enqueue()
+    callback_done = time.perf_counter()
+    # blocks like a chestnut frame; a long frame is a dropped camera frame.
+    # Only a stall past the client's deadline raises, into the joining
+    # state's demotion to the small model
+    model_output = self.client.infer_end(seq)
+    t4 = time.perf_counter()
+    # a frame past the budget is a dropped camera frame and three in a row
+    # are modeldLagging; send against reply says which end it was
+    if self._frame_id <= 3 or t4 - t0 > SLOW_FRAME:
+      # persisted on the comma so a drive can separate server execution from
+      # receive stalls once the Jetson is offline; server total excludes USB
+      gpu_us, queue_us, total_us = self.client.last_timings
+      cloudlog.warning("jetlink: frame %d warp %.1f data %.1f send %.1f reply %.1f ms; "
+                       + "server gpu %.1f queue %.1f total %.1f ms", self._frame_id,
+                       (t1 - t0) * 1e3, (t2 - t1) * 1e3, (t3 - t2) * 1e3, (t4 - t3) * 1e3,
+                       gpu_us / 1e3, queue_us / 1e3, total_us / 1e3)
+      receive = getattr(self.client.t, 'last_receive', {})
+      cloudlog.warning("jetlink: frame %d health %.1f wait %.1f ms; "
+                       + "ffs maxima prepare %.1f read_wait %.1f handoff %.1f ms", self._frame_id,
+                       (callback_done - t3) * 1e3, (t4 - callback_done) * 1e3,
+                       receive.get('prepare', 0.0) * 1e3, receive.get('read_wait', 0.0) * 1e3,
+                       receive.get('handoff', 0.0) * 1e3)
+
+    # the non-finite check runs on the server (Status.NOT_FINITE -> LinkError),
+    # so modeld's big->small failover fires as it does for a chestnut
+    outputs_dict = self.parser.parse_outputs(self.slice_outputs(model_output, self.output_slices))
+    self.npy['prev_feat'][:] = model_output[self.output_slices['hidden_state']]
+    if SEND_RAW_PRED:
+      outputs_dict['raw_pred'] = model_output.copy()
+    return outputs_dict
+
+  def close(self) -> None:
+    """Let go of the link; modeld calls this on a big model that finished loading too late."""
+    self.client.close()
+
+  def warmup(self) -> None:
+    dummy_frames = {k: np.zeros(self.frame_buf_params[k][3], dtype=np.uint8) for k in self.vision_input_names}
+    eye = np.eye(3, dtype=np.float32)
+    dims = {'desire_pulse': ModelConstants.DESIRE_LEN, 'traffic_convention': 2, 'action_t': 2}
+    self.run(dummy_frames, dict.fromkeys(self.vision_input_names, eye),
+             {k: np.zeros(v, dtype=np.float32) for k, v in dims.items()})
+    # drop the warm-up frame from both ends' history
+    self.packed[:] = 0
+    self.prev_desire[:] = 0
+    self.full_frames.clear()
+    self._blob_cache.clear()
+    self._need_reset = True
+    cloudlog.warning("jetlink: warmup complete")

--- a/openpilot/sunnypilot/accelerators/jetlink/models.json
+++ b/openpilot/sunnypilot/accelerators/jetlink/models.json
@@ -1,0 +1,76 @@
+{
+  "_comment": [
+    "Large models a Jetson can run, indexed by their git-lfs oid in comma's",
+    "openpilot history. openpilot updates big_driving_supercombo.onnx in place,",
+    "so every commit that touches it leaves a distinct object that both comma's",
+    "and sunnypilot's LFS still serve. That history is the only public source of",
+    "big-model ONNX: every bundle the model manager offers is a tinygrad pkl",
+    "rendered for the comma's QCOM GPU, which TensorRT cannot parse.",
+    "",
+    "Recover an oid without checking anything out:",
+    "  git cat-file -p <commit>:openpilot/selfdrive/modeld/models/big_driving_supercombo.onnx",
+    "",
+    "built_seconds is measured on an Orin Nano Super 8 GB, TensorRT 10.3, and is",
+    "there so the UI can say how long a first provision will take rather than",
+    "leaving someone watching an unmoving bar."
+  ],
+  "models": [
+    {
+      "name": "Cinque Terre",
+      "date": "2026-09-04",
+      "commit": "68b5f8e486",
+      "oid": "e8d821733be15ebe9e27498bc27ad8bbbd741980ece37d77f377294010b8ff28",
+      "size": 765950064,
+      "built_seconds": 102,
+      "default": true
+    },
+    {
+      "name": "BMRLNAPv6",
+      "date": "2026-09-01",
+      "commit": "9d683c0651",
+      "oid": "f3669cb7c8a9a8a13fcd6a8575958dd09a9ec76d9c9072ccdc76fad7cfa3a28d",
+      "size": 765955335,
+      "built_seconds": 163
+    },
+    {
+      "name": "TGC v2",
+      "date": "2026-09-01",
+      "commit": "1e4e01ee0e",
+      "oid": "1791d5940b2c048d0639813426dd2cf1d6f2a6727ed51e17c8bcea8bbe754123",
+      "size": 765950064,
+      "built_seconds": 166
+    },
+    {
+      "name": "BMRLNAP",
+      "date": "2026-08-31",
+      "commit": "4adbb85742",
+      "oid": "a086d5249fc308bb73993d1e64630c669d4c7df5bde85f42ad61902543648525",
+      "size": 765953504,
+      "built_seconds": 166
+    },
+    {
+      "name": "Lebowski",
+      "date": "2026-08-14",
+      "commit": "516ec1e682",
+      "oid": "a501760a9d1d5fef0eab2b8c5d122d06124fc26dc8e0782e0aa94b82a208f0ff",
+      "size": 1757355221,
+      "built_seconds": 294
+    },
+    {
+      "name": "Be Right Here",
+      "date": "2026-08-01",
+      "commit": "bf74ce5447",
+      "oid": "10926f2c0911821ca0e72439c1c3bf3ec11f0a08789aa14b7ee8f25379b2afa4",
+      "size": 1753235978,
+      "built_seconds": 230
+    },
+    {
+      "name": "Nested restructure",
+      "date": "2026-06-21",
+      "commit": "5edc0bd89d",
+      "oid": "471f372751d5931e939320c211e35b7255f8fa8015125b3b3fd48ef43020257e",
+      "size": 195490097,
+      "built_seconds": 131
+    }
+  ]
+}

--- a/openpilot/sunnypilot/accelerators/jetlink/setup.sh
+++ b/openpilot/sunnypilot/accelerators/jetlink/setup.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Presents the comma as a USB gadget so a Jetson can enumerate it.
+#
+# Only when the user has turned the link on: a gadget presented by default
+# turns link_configured() true and routed manager away from the user's bundle.
+# Read through openpilot.common.params so the key type and prefix match; a
+# params library not built yet, or without the key, reads as off.
+set -u
+[ -f /AGNOS ] || exit 0
+BASEDIR="$(cd "$(dirname "$0")/../../../.." && pwd)"
+STATUS=/dev/shm/jetlink-gadget
+
+enabled=$(PYTHONPATH="$BASEDIR" python3 - <<'PY' 2>/dev/null || echo 0
+try:
+  from openpilot.common.params import Params
+  print(1 if Params().get_bool("JetlinkEnabled") else 0)
+except Exception:
+  print(0)
+PY
+)
+[ "$enabled" = "1" ] || exit 0
+
+REPO="$BASEDIR/jetlink_repo"
+if [ ! -d "$REPO/jetlink" ]; then
+  # submodule registered but never fetched; say so where the offroad alert reads
+  echo "error: the jetlink package is not installed; run git submodule update --init jetlink_repo" \
+    > "$STATUS" 2>/dev/null || true
+  exit 0
+fi
+
+# the endpoints must exist before jetlinkd or modeld can open them, and that
+# needs root. setup_gadget.sh leaves the reason in $STATUS for the offroad alert
+sudo -n bash "$REPO/scripts/setup_gadget.sh" >/dev/null ||
+  echo "jetlink: USB gadget setup failed" >&2
+exit 0

--- a/openpilot/sunnypilot/accelerators/jetlink/spec_cache.py
+++ b/openpilot/sunnypilot/accelerators/jetlink/spec_cache.py
@@ -1,0 +1,58 @@
+"""
+Copyright (c) 2026-, Zeph Leggett.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+
+The selected model's spec, cached in a param.
+
+Reading the shapes and output slices means parsing a 766 MB ONNX. jetlinkd does
+that once when it provisions; modeld reads the answer here and never touches
+the file. `source` records the file the spec came from so jetlinkd can tell
+nothing changed without hashing it again.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from openpilot.common.params import Params
+from openpilot.common.swaglog import cloudlog
+
+from openpilot.sunnypilot.accelerators.jetlink import helpers
+
+PARAM = "JetlinkSpec"
+
+
+def _raw() -> dict | None:
+  # _get tolerates a params library older than these keys
+  value = helpers._get(PARAM)
+  return value if isinstance(value, dict) else None
+
+
+def load():
+  """The cached ModelSpec, or None if there is not a usable one."""
+  from jetlink.spec import ModelSpec
+  try:
+    d = _raw()
+    return ModelSpec.from_dict(d) if d else None
+  except Exception:
+    cloudlog.exception("jetlink: cached spec is unreadable")
+    return None
+
+
+def store(spec, source: Path | None = None) -> None:
+  payload = spec.to_dict()
+  if source is not None:
+    st = source.stat()
+    payload['source'] = [str(source), st.st_mtime_ns, st.st_size]
+  Params().put(PARAM, payload)
+
+
+def source() -> tuple[str, int, int] | None:
+  """(path, mtime_ns, size) of the model the cached spec was built from."""
+  try:
+    d = _raw()
+    src = d.get('source') if d else None
+    return (str(src[0]), int(src[1]), int(src[2])) if src else None
+  except Exception:
+    return None

--- a/openpilot/sunnypilot/accelerators/jetlink/status.py
+++ b/openpilot/sunnypilot/accelerators/jetlink/status.py
@@ -1,0 +1,47 @@
+"""
+Copyright (c) 2026-, Zeph Leggett.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+
+modeld's per-frame status callback for the jetlink path.
+
+The same hook as ChestnutState.send: modeld calls it once the frame is on the
+accelerator. It publishes nothing, chestnutState is comma's board on the wire
+and a Jetson's telemetry has no message yet, so it goes to swaglog at 1 Hz.
+The hook has to exist because passing a callback is what makes the client ask
+for telemetry, piggybacked on the previous response at no extra round trip.
+"""
+from __future__ import annotations
+
+import time
+
+from openpilot.common.swaglog import cloudlog
+
+LOG_PERIOD = 1.0
+
+
+class JetlinkStatus:
+  def __init__(self, pm, model):
+    self.pm = pm
+    self.model = model
+    # modeld's chestnut fallback clears this when it takes over; the joining
+    # state owns its own demotion, so it stays true. Kept for the duck type
+    self.big = True
+    self._last_logged = 0.0
+
+  @property
+  def client(self):
+    # per send: a joining state has no client until the Jetson turns up
+    return getattr(self.model, 'client', None)
+
+  def send(self) -> None:
+    client = self.client if self.big else None
+    telemetry = client.last_state if client is not None else None
+    if not telemetry:
+      return
+    now = time.monotonic()
+    if now - self._last_logged < LOG_PERIOD:
+      return
+    self._last_logged = now
+    cloudlog.event("jetlinkTelemetry", dead=bool(client.dead), **telemetry)

--- a/openpilot/sunnypilot/accelerators/jetlink/tests/test_fallback.py
+++ b/openpilot/sunnypilot/accelerators/jetlink/tests/test_fallback.py
@@ -1,0 +1,34 @@
+"""
+Copyright (c) 2026-, Zeph Leggett.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+"""
+from types import SimpleNamespace
+
+import numpy as np
+from tinygrad import Tensor
+
+from openpilot.sunnypilot.accelerators.jetlink.fallback import prepare_reset
+
+
+def test_reset_clears_history_in_place_on_repeated_fallbacks():
+  model = SimpleNamespace(
+    input_queues={k: Tensor.zeros(4, 8, device='CPU').contiguous().realize()
+                  for k in ('img_q', 'big_img_q', 'feat_q', 'desire_q')},
+    prev_desire=np.ones(8), npy={'prev_feat': np.ones(32), 'desire': np.ones(8)})
+  identities = {k: id(v) for k, v in model.input_queues.items()}
+  reset = prepare_reset(model)
+  for _ in range(3):
+    for q in model.input_queues.values():
+      q.assign(7).realize()
+    model.prev_desire.fill(1)
+    for v in model.npy.values():
+      v.fill(1)
+    reset()
+    assert {k: id(v) for k, v in model.input_queues.items()} == identities
+    for q in model.input_queues.values():
+      np.testing.assert_array_equal(q.numpy(), 0)
+    np.testing.assert_array_equal(model.prev_desire, 0)
+    for v in model.npy.values():
+      np.testing.assert_array_equal(v, 0)

--- a/openpilot/sunnypilot/accelerators/jetlink/tests/test_helpers.py
+++ b/openpilot/sunnypilot/accelerators/jetlink/tests/test_helpers.py
@@ -1,0 +1,301 @@
+"""
+Copyright (c) 2026-, Zeph Leggett.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from openpilot.sunnypilot.accelerators.jetlink import helpers
+
+
+class TestGadgetStatus(unittest.TestCase):
+  """The gadget is set up at boot, by root, from launch_chffrplus.sh. This file
+  is the only way the reason for a failure reaches anything a user can see."""
+
+  def setUp(self):
+    self.tmp = tempfile.mkdtemp()
+    self.status = Path(self.tmp) / 'jetlink-gadget'
+    patcher = mock.patch.object(helpers, 'GADGET_STATUS', self.status)
+    self.addCleanup(patcher.stop)
+    patcher.start()
+
+  def test_missing_file_is_not_an_error(self):
+    # A build that never ran the setup at all reads the same as not installed.
+    assert helpers.gadget_error() is None
+
+  def test_ok_is_not_an_error(self):
+    self.status.write_text('ok\n')
+    assert helpers.gadget_error() is None
+
+  def test_empty_is_not_an_error(self):
+    self.status.write_text('')
+    assert helpers.gadget_error() is None
+
+  def test_reason_is_unwrapped(self):
+    self.status.write_text('error: kernel has no USB gadget support\n')
+    assert helpers.gadget_error() == 'kernel has no USB gadget support'
+
+  def test_bare_reason_survives(self):
+    self.status.write_text('something went wrong')
+    assert helpers.gadget_error() == 'something went wrong'
+
+  def test_unreadable_status_is_not_an_error(self):
+    # Path.exists() and read_text() raise rather than return on a root-only
+    # path; an availability check must never take a process down over one.
+    with mock.patch.object(Path, 'read_text', side_effect=PermissionError):
+      assert helpers.gadget_error() is None
+
+
+class TestGadgetAlert(unittest.TestCase):
+  """Only complain to someone who asked for the link. With it off, a device
+  that cannot present the gadget should simply not offer the feature."""
+
+  def alert_with(self, enabled: bool, reason: str | None):
+    with mock.patch.object(helpers, 'enabled', return_value=enabled), \
+         mock.patch.object(helpers, 'gadget_error', return_value=reason):
+      return helpers.gadget_alert()
+
+  def test_silent_when_off(self):
+    assert self.alert_with(False, 'kernel has no USB gadget support') is None
+
+  def test_speaks_up_when_switched_on(self):
+    assert self.alert_with(True, 'kernel has no USB gadget support') == 'kernel has no USB gadget support'
+
+  def test_nothing_to_say_when_healthy(self):
+    assert self.alert_with(True, None) is None
+
+
+class TestDormant(unittest.TestCase):
+  def setUp(self):
+    self.tmp = Path(tempfile.mkdtemp())
+    for name in ('DORMANT', 'SHUTDOWN_REQUEST'):
+      patcher = mock.patch.object(helpers, name, self.tmp / name.lower())
+      self.addCleanup(patcher.stop)
+      patcher.start()
+
+  def test_marker_from_a_live_process_counts(self):
+    helpers.set_dormant(True)
+    assert helpers.dormant()
+    helpers.set_dormant(False)
+    assert not helpers.dormant()
+
+  def test_marker_from_a_dead_process_is_a_leftover(self):
+    helpers.DORMANT.write_text('4194304')  # above pid_max
+    assert not helpers.dormant()
+
+  def test_garbage_is_not_dormant(self):
+    helpers.DORMANT.write_text('not a pid')
+    assert not helpers.dormant()
+
+  def test_dormant_counts_as_present_without_a_host(self):
+    with mock.patch.object(helpers, 'link_endpoint', return_value=None), \
+         mock.patch.object(helpers, 'host_attached', return_value=False), \
+         mock.patch.object(helpers, 'CC_ORIENTATION', self.tmp / 'cc'):
+      (self.tmp / 'cc').write_text('1')
+      helpers._last_configured = 0.0
+      assert not helpers.gadget_present()
+      helpers.set_dormant(True)
+      assert helpers.gadget_present()
+      (self.tmp / 'cc').write_text('0')
+      assert not helpers.gadget_present()
+
+  def test_shutdown_request_round_trip(self):
+    assert helpers.pending_shutdown() is None
+    assert helpers.request_shutdown('car battery')
+    assert helpers.pending_shutdown() == 'car battery'
+    helpers.finish_shutdown()
+    assert helpers.pending_shutdown() is None
+
+  def test_await_shutdown_gives_up_and_cleans_up(self):
+    helpers.request_shutdown('car battery')
+    assert not helpers.await_shutdown(0.3)
+    assert helpers.pending_shutdown() is None
+
+  def test_await_shutdown_returns_when_taken(self):
+    helpers.request_shutdown('car battery')
+    helpers.finish_shutdown()
+    assert helpers.await_shutdown(0.3)
+
+
+class TestUnchunkedSuffix(unittest.TestCase):
+  def test_suffix_is_distinct_from_openpilots(self):
+    """openpilot's own '.unchunked' files are deleted by an atexit handler.
+    Ours must not collide with that or a provision loses its model mid-upload."""
+    assert helpers.UNCHUNKED_SUFFIX != '.unchunked'
+    assert not helpers.UNCHUNKED_SUFFIX.endswith('.unchunked')
+
+
+class TestActiveModelPath(unittest.TestCase):
+  def setUp(self):
+    self.root = tempfile.mkdtemp()
+    patcher = mock.patch('openpilot.sunnypilot.accelerators.jetlink.helpers.Paths')
+    self.addCleanup(patcher.stop)
+    patcher.start().model_root.return_value = self.root
+
+  def bundle_with(self, *file_names):
+    models = []
+    for name in file_names:
+      artifact = mock.Mock()
+      artifact.fileName = name
+      models.append(mock.Mock(artifact=artifact))
+    return mock.Mock(models=models)
+
+  def test_no_bundle_falls_through_to_the_pinned_model(self):
+    # no chestnut bundle ships an ONNX, so what runs is the model openpilot
+    # pins; None here would leave a provisioned device on the small model
+    pinned = Path(self.root) / helpers.BIG_MODEL_NAME
+    with mock.patch.object(helpers, 'active_bundle', return_value=None), \
+         mock.patch.object(helpers, 'shipped_model_path', return_value=pinned):
+      assert helpers.active_model_path() == pinned
+
+  def test_no_bundle_and_nothing_pinned_is_no_path(self):
+    with mock.patch.object(helpers, 'active_bundle', return_value=None), \
+         mock.patch.object(helpers, 'shipped_model_path', return_value=None):
+      assert helpers.active_model_path() is None
+
+  def test_finds_a_plain_onnx(self):
+    onnx = Path(self.root) / 'big.onnx'
+    onnx.write_bytes(b'\0' * 2_000_000)
+    with mock.patch.object(helpers, 'active_bundle', return_value=self.bundle_with('big.onnx')):
+      assert helpers.active_model_path() == onnx
+
+  def test_ignores_a_truncated_download(self):
+    (Path(self.root) / 'big.onnx').write_bytes(b'\0' * 16)
+    with mock.patch.object(helpers, 'active_bundle', return_value=self.bundle_with('big.onnx')), \
+         mock.patch('openpilot.selfdrive.modeld.helpers.MODELS_DIR', Path(self.root)):
+      assert helpers.active_model_path() is None
+
+  def test_ignores_non_onnx_artifacts(self):
+    (Path(self.root) / 'small.pkl').write_bytes(b'\0' * 2_000_000)
+    with mock.patch.object(helpers, 'active_bundle', return_value=self.bundle_with('small.pkl')), \
+         mock.patch('openpilot.selfdrive.modeld.helpers.MODELS_DIR', Path(self.root)):
+      assert helpers.active_model_path() is None
+
+  def test_cleanup_keeps_the_one_in_use(self):
+    keep = Path(self.root) / f'a.onnx{helpers.UNCHUNKED_SUFFIX}'
+    drop = Path(self.root) / f'b.onnx{helpers.UNCHUNKED_SUFFIX}'
+    keep.write_bytes(b'k')
+    drop.write_bytes(b'd')
+    helpers.cleanup_unchunked(keep=keep)
+    assert keep.is_file()
+    assert not drop.exists()
+
+
+if __name__ == '__main__':
+  unittest.main()
+
+
+class TestModelIndex(unittest.TestCase):
+  """comma overwrites one ONNX file, so every earlier big model exists only as a
+  git-lfs object no manifest lists. The index is how we keep hold of them."""
+
+  def test_the_shipped_index_parses(self):
+    models = helpers.model_index()
+    assert models, "no models in models.json"
+
+  def test_every_entry_is_complete(self):
+    for m in helpers.model_index():
+      for field in ('name', 'oid', 'size', 'commit', 'date'):
+        assert m.get(field), f"{m.get('name')!r} is missing {field}"
+      assert len(m['oid']) == 64, f"{m['name']}: oid is not a sha256"
+      assert m['size'] > 1_000_000, f"{m['name']}: implausible size"
+
+  def test_names_and_oids_are_unique(self):
+    models = helpers.model_index()
+    assert len({m['name'] for m in models}) == len(models)
+    assert len({m['oid'] for m in models}) == len(models)
+
+  def test_exactly_one_default(self):
+    # Two defaults, or none, and selected_model() silently picks by list order.
+    assert sum(1 for m in helpers.model_index() if m.get('default')) == 1
+
+  def test_file_names_do_not_collide(self):
+    names = [helpers.model_file_name(m) for m in helpers.model_index()]
+    assert len(set(names)) == len(names)
+
+
+class TestSelectedModel(unittest.TestCase):
+  INDEX = [
+    {'name': 'Alpha', 'oid': 'a' * 64, 'size': 10, 'commit': 'c1', 'date': 'd'},
+    {'name': 'Beta', 'oid': 'b' * 64, 'size': 20, 'commit': 'c2', 'date': 'd', 'default': True},
+  ]
+
+  def select_with(self, param):
+    with mock.patch.object(helpers, 'model_index', return_value=self.INDEX), \
+         mock.patch.object(helpers, '_get', return_value=param):
+      return helpers.selected_model()
+
+  def test_unset_takes_the_default(self):
+    assert self.select_with(None)['name'] == 'Beta'
+
+  def test_a_name_selects_it(self):
+    assert self.select_with('Alpha')['name'] == 'Alpha'
+
+  def test_an_unknown_name_falls_back(self):
+    # The index can shrink under a param that outlived it; leaving the device
+    # with no model at all would be worse than quietly using the default.
+    assert self.select_with('Gone')['name'] == 'Beta'
+
+  def test_an_empty_index_is_no_model(self):
+    with mock.patch.object(helpers, 'model_index', return_value=[]):
+      assert helpers.selected_model() is None
+
+
+class TestSelectedModelReadiness(unittest.TestCase):
+  def test_old_cached_engine_is_not_the_new_selection(self):
+    from types import SimpleNamespace
+    from openpilot.sunnypilot.accelerators.jetlink import backend
+
+    with mock.patch.object(helpers, 'enabled', return_value=True), \
+         mock.patch.object(helpers, 'engine_ready_for', return_value=True), \
+         mock.patch.object(backend.spec_cache, 'load', return_value=SimpleNamespace(sha256='a' * 64)), \
+         mock.patch.object(helpers, 'selected_model', return_value={'oid': 'b' * 64}) as selected:
+      self.assertFalse(backend.ready())
+      client = mock.Mock()
+      with self.assertRaisesRegex(RuntimeError, 'not been provisioned'):
+        backend._open_link(client)
+      client.close.assert_called_once()
+      selected.return_value = {'oid': 'a' * 64}
+      self.assertTrue(backend.ready())
+
+
+class TestShippedModelPath(unittest.TestCase):
+  """A file counts only when it is the model we mean, at the size we expect.
+  Models live one file per oid so switching back does not re-download."""
+
+  MODEL = {'name': 'Alpha', 'oid': 'a' * 64, 'size': 4096, 'commit': 'c', 'date': 'd'}
+
+  def setUp(self):
+    self.root = tempfile.mkdtemp()
+    paths = mock.patch('openpilot.sunnypilot.accelerators.jetlink.helpers.Paths')
+    self.addCleanup(paths.stop)
+    paths.start().model_root.return_value = self.root
+    chosen = mock.patch.object(helpers, 'selected_model', return_value=self.MODEL)
+    self.addCleanup(chosen.stop)
+    chosen.start()
+
+  def fetched(self, size: int) -> Path:
+    path = Path(self.root) / helpers.model_file_name(self.MODEL)
+    path.write_bytes(b'\0' * size)
+    return path
+
+  def test_nothing_fetched_yet(self):
+    assert helpers.shipped_model_path() is None
+
+  def test_the_chosen_model_is_accepted(self):
+    fetched = self.fetched(4096)
+    assert helpers.shipped_model_path() == fetched
+
+  def test_a_truncated_download_is_rejected(self):
+    # Half a model is exactly what must not reach TensorRT.
+    self.fetched(2048)
+    assert helpers.shipped_model_path() is None
+
+  def test_no_model_chosen_is_no_path(self):
+    with mock.patch.object(helpers, 'selected_model', return_value=None):
+      assert helpers.shipped_model_path() is None

--- a/openpilot/sunnypilot/accelerators/jetlink/tests/test_jetlinkd.py
+++ b/openpilot/sunnypilot/accelerators/jetlink/tests/test_jetlinkd.py
@@ -80,11 +80,8 @@ def serving_client(spec=None):
 class TestProvisionCost(unittest.TestCase):
   """What provisioning is allowed to cost when nothing needs doing.
 
-  The identity comes from models.json - the git-lfs `oid` is the sha256 and
-  `size` is the byte count - so a parked car asks the Jetson what it already
-  has without reading, hashing or even having the ONNX. Deriving it from the
-  file instead meant the comma had to hold 766 MB to ask a question the
-  registry could answer, and re-hashed it whenever the file changed.
+  The identity comes from models.json, so a parked car asks the Jetson what it
+  already has without reading, hashing or even having the ONNX.
   """
 
   ENTRY = {'name': 'Fake', 'oid': 'deadbeef', 'size': 4096}
@@ -120,8 +117,7 @@ class TestProvisionCost(unittest.TestCase):
     assert args[0] == self.ENTRY['oid'] and args[1] == self.ENTRY['size']
 
   def test_a_server_that_already_has_it_never_reads_the_file(self):
-    # The steady state of a parked car: hashing 766 MB per retry used to be
-    # the cost of asking, and it is now not paid at all.
+    # the steady state of a parked car: the 766 MB hash is not paid per retry
     d = jetlinkd.Jetlinkd()
     d.client = serving_client()
     d.client.ensure_engine.return_value = FakeSpec()
@@ -201,9 +197,7 @@ class TestProvisionCost(unittest.TestCase):
     assert self.hashed == []
 
   def test_a_ready_param_is_checked_with_the_server_once_per_attach(self):
-    # The Jetson's cache can be pruned, re-flashed or swapped under a param
-    # that says ready; trusting it blindly used to cost every drive until
-    # someone cleared the param by hand.
+    # the Jetson's cache can be pruned or re-flashed under a param that says ready
     self.cache.store(FakeSpec(), self.model)
     d = jetlinkd.Jetlinkd()
     d.client = serving_client()
@@ -261,9 +255,8 @@ class TestStepOnFailure(unittest.TestCase):
     d.step()
 
   def test_a_timeout_keeps_the_gadget_presented(self):
-    # Unbinding makes the host re-enumerate. Doing that on every retry is what
-    # produced hours of connect/disconnect against a Jetson that was simply
-    # not running the server.
+    # unbinding makes the host re-enumerate; on every retry that was hours of
+    # connect/disconnect against a Jetson not running the server
     d = jetlinkd.Jetlinkd()
     d.client = object()
     with mock.patch.object(jetlinkd, '_timed_out', return_value=True):
@@ -460,11 +453,7 @@ class TestTimedOut(unittest.TestCase):
 
 
 class TestWarpFallback(TestParked):
-  """scons builds the warp now; build_warp only covers one that is missing.
-
-  It inherits TestParked's fixture for the patched helpers and the mocked
-  accelerators module, and just turns warp_built back off.
-  """
+  """scons builds the warp; build_warp only covers one that is missing."""
 
   def warp_daemon(self):
     d = self.daemon()
@@ -503,14 +492,15 @@ class TestWarpFallback(TestParked):
 
 
 class TestVmTuning(unittest.TestCase):
-  """The sysctls are jetlinkd's now, not the boot script's.
+  """A device with the link off runs stock values, one that turns it off gets
+  them back, and a plain exit keeps them for the drive that follows."""
 
-  A device with the link off must run stock values, and a device that turns it
-  off must get them back. A plain exit keeps them: manager stops this daemon
-  at ignition, and the values are for the drive that follows.
-  """
-
-  STOCK = {'vm.dirty_bytes': '0', 'vm.dirty_background_bytes': '0', 'vm.min_free_kbytes': '7274'}
+  # Stock AGNOS: ratio mode, so both *_bytes read 0 and the ratios carry the limit.
+  STOCK = {'vm.dirty_bytes': '0', 'vm.dirty_background_bytes': '0', 'vm.min_free_kbytes': '7274',
+           'vm.dirty_ratio': '20', 'vm.dirty_background_ratio': '5'}
+  # What a restore of STOCK has to write: the kernel drops a 0 written to a
+  # *_bytes key, and writing the ratio key is what zeroes it.
+  RESTORED = ['vm.dirty_ratio=20', 'vm.dirty_background_ratio=5', 'vm.min_free_kbytes=7274']
 
   def setUp(self):
     self.tmp = Path(tempfile.mkdtemp())
@@ -547,8 +537,8 @@ class TestVmTuning(unittest.TestCase):
     d.stop = True
     with mock.patch.object(jetlinkd.helpers, 'enabled', return_value=True):
       d.run()
-    for key in self.STOCK:
-      (jetlinkd.PROC_SYS / key.replace('.', '/')).write_text(jetlinkd.VM_SYSCTLS[key])
+    for key, value in jetlinkd.VM_SYSCTLS.items():
+      (jetlinkd.PROC_SYS / key.replace('.', '/')).write_text(value)
     self.run_mock.reset_mock()
     d = jetlinkd.Jetlinkd()
     d.stop = True
@@ -567,12 +557,12 @@ class TestVmTuning(unittest.TestCase):
     # A previous run that was SIGKILLed left our values in /proc; reading them
     # now would record them as the stock ones and restore to them forever.
     self.record.write_text(json.dumps(self.STOCK))
-    for key in self.STOCK:
-      (jetlinkd.PROC_SYS / key.replace('.', '/')).write_text(jetlinkd.VM_SYSCTLS[key])
+    for key, value in jetlinkd.VM_SYSCTLS.items():
+      (jetlinkd.PROC_SYS / key.replace('.', '/')).write_text(value)
     jetlinkd.apply_vm_tuning()
     assert json.loads(self.record.read_text()) == self.STOCK
     jetlinkd.restore_vm_tuning()
-    assert self.applied()[-len(self.STOCK):] == [f'{k}={v}' for k, v in self.STOCK.items()]
+    assert self.applied()[-len(self.RESTORED):] == self.RESTORED
 
   def test_nothing_happens_when_disabled(self):
     d = jetlinkd.Jetlinkd()
@@ -596,6 +586,27 @@ class TestVmTuning(unittest.TestCase):
     assert not self.record.exists()
     assert self.applied()[-1] == 'vm.min_free_kbytes=' + self.STOCK['vm.min_free_kbytes']
 
+  def test_the_ratios_are_captured_in_the_record(self):
+    jetlinkd.apply_vm_tuning()
+    record = json.loads(self.record.read_text())
+    assert record['vm.dirty_ratio'] == '20'
+    assert record['vm.dirty_background_ratio'] == '5'
+
+  def test_ratio_mode_is_restored_through_the_ratio_keys(self):
+    # Measured on the comma: after our apply, `sysctl -w vm.dirty_bytes=0` and
+    # a direct /proc write both return 0 and leave 16777216 in place.
+    self.record.write_text(json.dumps(self.STOCK))
+    jetlinkd.restore_vm_tuning()
+    assert self.applied() == self.RESTORED
+    assert not any(a.endswith('_bytes=0') for a in self.applied())
+
+  def test_bytes_mode_is_restored_directly(self):
+    prev = dict(self.STOCK, **{'vm.dirty_bytes': '33554432', 'vm.dirty_background_bytes': '4194304'})
+    self.record.write_text(json.dumps(prev))
+    jetlinkd.restore_vm_tuning()
+    assert self.applied() == ['vm.dirty_bytes=33554432', 'vm.dirty_background_bytes=4194304',
+                              'vm.min_free_kbytes=7274']
+
   def test_a_root_run_writes_proc_directly(self):
     with mock.patch.object(jetlinkd.os, 'geteuid', return_value=0):
       jetlinkd.apply_vm_tuning()
@@ -604,9 +615,8 @@ class TestVmTuning(unittest.TestCase):
 
 
 class BuildEtaTest(unittest.TestCase):
-  """models.json has carried built_seconds all along so the UI could say how
-  long a first provision takes, and nothing read it. A driver watching
-  "build 12%" cannot tell five minutes from thirty."""
+  """built_seconds is what tells a driver watching "build 12%" whether that is
+  five minutes or thirty."""
 
   def test_the_build_stage_gets_a_time_remaining(self):
     from openpilot.sunnypilot.accelerators.jetlink import jetlinkd as J

--- a/openpilot/sunnypilot/accelerators/jetlink/tests/test_jetlinkd.py
+++ b/openpilot/sunnypilot/accelerators/jetlink/tests/test_jetlinkd.py
@@ -1,0 +1,640 @@
+"""
+Copyright (c) 2026-, Zeph Leggett.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+
+What jetlinkd does when the far end is attached but not serving.
+
+That is the expensive state, not the one where no Jetson is plugged in: the
+daemon has a host to talk to and keeps trying, so anything it repeats per
+attempt it repeats for as long as the car is parked.
+"""
+
+import json
+import sys
+import tempfile
+import time
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from openpilot.sunnypilot.accelerators.jetlink import jetlinkd
+
+
+class FakeSpec:
+  def __init__(self, sha256: str = 'deadbeef', nbytes: int = 1 << 20):
+    self.sha256 = sha256
+    self.nbytes = nbytes
+
+
+class FakeSpecCache:
+  """spec_cache backed by memory rather than a param."""
+
+  def __init__(self):
+    self.spec = None
+    self.src = None
+    self.stores = 0
+
+  def load(self):
+    return self.spec
+
+  def source(self):
+    return self.src
+
+  def store(self, spec, source: Path | None = None) -> None:
+    self.stores += 1
+    self.spec = spec
+    if source is not None:
+      st = source.stat()
+      self.src = (str(source), st.st_mtime_ns, st.st_size)
+
+
+def fake_jetlink_spec_module(counter: list):
+  """A stand-in for jetlink.spec, which is not importable without the package."""
+  mod = types.ModuleType('jetlink.spec')
+
+  def sha256_file(path, *a, **kw):
+    counter.append(path)
+    return 'deadbeef', 1 << 20
+
+  mod.sha256_file = sha256_file
+
+  client = types.ModuleType('jetlink.client')
+
+  class EngineMissing(Exception):
+    pass
+
+  client.EngineMissing = EngineMissing
+  return {'jetlink': types.ModuleType('jetlink'), 'jetlink.spec': mod, 'jetlink.client': client}
+
+
+def serving_client(spec=None):
+  """A client whose server already has the engine."""
+  client = mock.Mock()
+  client.ensure_engine.return_value = spec or FakeSpec()
+  return client
+
+
+class TestProvisionCost(unittest.TestCase):
+  """What provisioning is allowed to cost when nothing needs doing.
+
+  The identity comes from models.json - the git-lfs `oid` is the sha256 and
+  `size` is the byte count - so a parked car asks the Jetson what it already
+  has without reading, hashing or even having the ONNX. Deriving it from the
+  file instead meant the comma had to hold 766 MB to ask a question the
+  registry could answer, and re-hashed it whenever the file changed.
+  """
+
+  ENTRY = {'name': 'Fake', 'oid': 'deadbeef', 'size': 4096}
+
+  def setUp(self):
+    self.model = Path(tempfile.mkdtemp()) / 'big_driving_supercombo.onnx'
+    self.model.write_bytes(b'x' * 4096)
+    self.cache = FakeSpecCache()
+    self.hashed: list[str] = []
+    p = mock.patch.object(jetlinkd, 'Params')
+    self.addCleanup(p.stop)
+    p.start()
+
+    for target, new in (('spec_cache', self.cache), ('accelerators', mock.Mock())):
+      p = mock.patch.object(jetlinkd, target, new)
+      self.addCleanup(p.stop)
+      p.start()
+    for name, value in (('active_model_path', self.model), ('engine_ready_for', False),
+                        ('selected_model', dict(self.ENTRY))):
+      p = mock.patch.object(jetlinkd.helpers, name, return_value=value)
+      self.addCleanup(p.stop)
+      p.start()
+    p = mock.patch.dict(sys.modules, fake_jetlink_spec_module(self.hashed))
+    self.addCleanup(p.stop)
+    p.start()
+
+  def test_the_identity_comes_from_the_registry_not_the_file(self):
+    d = jetlinkd.Jetlinkd()
+    d.client = serving_client()
+    with mock.patch.object(jetlinkd.helpers, 'set_engine_ready'):
+      assert d.provision() is True
+    args = d.client.ensure_engine.call_args.args
+    assert args[0] == self.ENTRY['oid'] and args[1] == self.ENTRY['size']
+
+  def test_a_server_that_already_has_it_never_reads_the_file(self):
+    # The steady state of a parked car: hashing 766 MB per retry used to be
+    # the cost of asking, and it is now not paid at all.
+    d = jetlinkd.Jetlinkd()
+    d.client = serving_client()
+    d.client.ensure_engine.return_value = FakeSpec()
+    with mock.patch.object(jetlinkd.helpers, 'set_engine_ready'):
+      for _ in range(3):
+        d.verified = False
+        assert d.provision() is True
+    assert self.hashed == [], "hashed the model to ask a question the registry answers"
+
+  def test_it_asks_even_with_no_model_on_disk(self):
+    # The Jetson keeps its own copy of every ONNX and never prunes them, so a
+    # comma that has deleted its own can still use an engine already built.
+    d = jetlinkd.Jetlinkd()
+    d.client = serving_client()
+    with mock.patch.object(jetlinkd.helpers, 'active_model_path', return_value=None), \
+         mock.patch.object(jetlinkd.helpers, 'set_engine_ready'):
+      assert d.provision() is True
+    assert d.client.ensure_engine.call_args.kwargs['onnx_path'] is None
+
+  def test_a_server_that_wants_the_bytes_gets_them_fetched(self):
+    from jetlink.client import EngineMissing
+    d = jetlinkd.Jetlinkd()
+    d.client = serving_client()
+    d.client.ensure_engine.side_effect = EngineMissing('no engine')
+    with mock.patch.object(jetlinkd.helpers, 'active_model_path', return_value=None), \
+         mock.patch.object(d, 'fetch_model', return_value=self.model) as fetch:
+      # False, not an exception: the download takes minutes and the link is
+      # not held through it; the next poll tries again.
+      assert d.provision() is False
+    fetch.assert_called_once()
+
+  def _wants_the_bytes(self):
+    from jetlink.client import EngineMissing
+    d = jetlinkd.Jetlinkd()
+    d.client = serving_client()
+    d.client.ensure_engine.side_effect = EngineMissing('no engine')
+    return d, EngineMissing
+
+  def test_a_file_that_is_not_the_registry_model_is_never_uploaded(self):
+    # Trusting models.json for the identity is right for asking and wrong for
+    # answering: uploading under a sha the bytes do not have would leave the
+    # Jetson with a plan whose name lies about its contents.
+    d, EngineMissing = self._wants_the_bytes()
+    with mock.patch.object(jetlinkd.helpers, 'selected_model',
+                           return_value={**self.ENTRY, 'oid': 'not-what-the-file-hashes-to'}), \
+         mock.patch.object(jetlinkd.helpers, 'set_engine_ready'), \
+         self.assertRaises(EngineMissing):
+      d.provision()
+    assert all(c.kwargs['onnx_path'] is None for c in d.client.ensure_engine.call_args_list)
+
+  def test_a_file_of_the_wrong_size_is_never_uploaded(self):
+    d, EngineMissing = self._wants_the_bytes()
+    with mock.patch.object(jetlinkd.helpers, 'selected_model',
+                           return_value={**self.ENTRY, 'size': 999999}), \
+         mock.patch.object(jetlinkd.helpers, 'set_engine_ready'), \
+         self.assertRaises(EngineMissing):
+      d.provision()
+    assert all(c.kwargs['onnx_path'] is None for c in d.client.ensure_engine.call_args_list)
+    assert self.hashed == [], "size is the cheap check and comes first"
+
+  def test_the_file_is_uploaded_once_it_is_proven_to_be_the_model(self):
+    d, _ = self._wants_the_bytes()
+    d.client.ensure_engine.side_effect = [d.client.ensure_engine.side_effect, FakeSpec()]
+    with mock.patch.object(jetlinkd.helpers, 'set_engine_ready'):
+      assert d.provision() is True
+    calls = d.client.ensure_engine.call_args_list
+    assert calls[0].kwargs['onnx_path'] is None, "asked without the file first"
+    assert calls[1].kwargs['onnx_path'] == self.model
+    assert self.hashed == [str(self.model)], "hashed once, on the path the bytes leave by"
+
+  def test_a_ready_engine_short_circuits_without_touching_the_file(self):
+    self.cache.store(FakeSpec(), self.model)
+    d = jetlinkd.Jetlinkd()
+    d.verified = True
+    with mock.patch.object(jetlinkd.helpers, 'engine_ready_for', return_value=True):
+      assert d.provision() is True
+    assert self.hashed == []
+
+  def test_a_ready_param_is_checked_with_the_server_once_per_attach(self):
+    # The Jetson's cache can be pruned, re-flashed or swapped under a param
+    # that says ready; trusting it blindly used to cost every drive until
+    # someone cleared the param by hand.
+    self.cache.store(FakeSpec(), self.model)
+    d = jetlinkd.Jetlinkd()
+    d.client = serving_client()
+    with mock.patch.object(jetlinkd.helpers, 'engine_ready_for', return_value=True), \
+         mock.patch.object(jetlinkd.helpers, 'set_engine_ready') as ready:
+      assert d.provision() is True
+      assert d.client.ensure_engine.call_count == 1
+      assert d.verified
+      assert d.provision() is True
+      assert d.client.ensure_engine.call_count == 1, "verified once, then the param is trusted"
+    ready.assert_called_with('deadbeef')
+
+  def test_the_shapes_come_from_the_server_not_the_file(self):
+    d = jetlinkd.Jetlinkd()
+    d.client = serving_client(FakeSpec(sha256='deadbeef', nbytes=1 << 20))
+    with mock.patch.object(jetlinkd.helpers, 'set_engine_ready'):
+      assert d.provision() is True
+    d.client.ensure_engine.assert_called_once()
+    kwargs = d.client.ensure_engine.call_args.kwargs
+    assert callable(kwargs['should_stop'])
+    assert self.cache.stores == 1 and self.cache.spec.sha256 == 'deadbeef'
+
+  def test_stop_is_polled_through_the_long_wait(self):
+    d = jetlinkd.Jetlinkd()
+    d.client = serving_client()
+    with mock.patch.object(jetlinkd.helpers, 'set_engine_ready'):
+      d.provision()
+    should_stop = d.client.ensure_engine.call_args.kwargs['should_stop']
+    assert should_stop() is False
+    d.request_stop()
+    assert should_stop() is True
+
+
+class TestBackoff(unittest.TestCase):
+  def test_it_doubles_and_then_stops(self):
+    d = jetlinkd.Jetlinkd()
+    seen = []
+    for _ in range(8):
+      d.failures += 1
+      seen.append(d.backoff())
+    assert seen[:5] == [30.0, 60.0, 120.0, 240.0, 480.0]
+    assert seen[-1] == jetlinkd.RETRY_BACKOFF_MAX
+
+
+class TestStepOnFailure(unittest.TestCase):
+  def _step(self, d, provision):
+    for p in (mock.patch.object(jetlinkd, 'accelerators', mock.Mock()),
+              mock.patch.object(jetlinkd.helpers, 'enabled', return_value=True),
+              mock.patch.object(jetlinkd.helpers, 'host_attached', return_value=True),
+              mock.patch.object(d, 'open_link', return_value=True),
+              mock.patch.object(d, 'provision', provision),
+              mock.patch.object(d, 'close_link', mock.Mock())):
+      self.addCleanup(p.stop)
+      p.start()
+    d.step()
+
+  def test_a_timeout_keeps_the_gadget_presented(self):
+    # Unbinding makes the host re-enumerate. Doing that on every retry is what
+    # produced hours of connect/disconnect against a Jetson that was simply
+    # not running the server.
+    d = jetlinkd.Jetlinkd()
+    d.client = object()
+    with mock.patch.object(jetlinkd, '_timed_out', return_value=True):
+      self._step(d, mock.Mock(side_effect=RuntimeError('no reply')))
+    assert d.close_link.call_count == 0
+    assert d.failures == 1
+    assert d.next_provision > time.monotonic()
+
+  def test_anything_else_reopens_the_link(self):
+    d = jetlinkd.Jetlinkd()
+    d.client = object()
+    with mock.patch.object(jetlinkd, '_timed_out', return_value=False):
+      self._step(d, mock.Mock(side_effect=RuntimeError('desynced')))
+    assert d.close_link.call_count == 1
+    assert d.failures == 1
+
+  def test_a_host_that_arrives_does_not_serve_out_the_old_backoff(self):
+    d = jetlinkd.Jetlinkd()
+    d.failures = 6
+    d.next_provision = time.monotonic() + jetlinkd.RETRY_BACKOFF_MAX
+    provision = mock.Mock(return_value=True)
+    self._step(d, provision)
+    assert provision.call_count == 1
+    assert d.failures == 0
+    assert d.ready is True
+
+
+class TestParked(unittest.TestCase):
+  """Releasing the gadget once there is nothing to do, and taking it back."""
+
+  def setUp(self):
+    self.tmp = Path(tempfile.mkdtemp())
+    self.cache = FakeSpecCache()
+    self.cache.spec = FakeSpec()
+    self.model = self.tmp / 'big_driving_supercombo.onnx'
+    self.model.write_bytes(b'x' * 4096)
+    st = self.model.stat()
+    self.cache.src = (str(self.model), st.st_mtime_ns, st.st_size)
+    for target, new in (('spec_cache', self.cache), ('accelerators', mock.Mock())):
+      p = mock.patch.object(jetlinkd, target, new)
+      self.addCleanup(p.stop)
+      p.start()
+    for name, value in (('DORMANT', self.tmp / 'dormant'), ('SHUTDOWN_REQUEST', self.tmp / 'shutdown')):
+      p = mock.patch.object(jetlinkd.helpers, name, value)
+      self.addCleanup(p.stop)
+      p.start()
+    for name, value in (('enabled', True), ('host_attached', True), ('engine_ready_for', True),
+                        ('selected_model', {'oid': self.cache.spec.sha256}),
+                        ('active_model_path', self.model)):
+      p = mock.patch.object(jetlinkd.helpers, name, return_value=value)
+      self.addCleanup(p.stop)
+      p.start()
+
+  def daemon(self, ready=True):
+    d = jetlinkd.Jetlinkd()
+    d.client = mock.Mock()
+    d.warp_built = True
+    for name in ('open_link', 'close_link'):
+      p = mock.patch.object(d, name, mock.Mock(return_value=True))
+      self.addCleanup(p.stop)
+      p.start()
+    p = mock.patch.object(d, 'provision', mock.Mock(return_value=ready))
+    self.addCleanup(p.stop)
+    p.start()
+    return d
+
+  def test_holds_the_gadget_until_the_hold_has_passed(self):
+    d = self.daemon()
+    d.step()
+    assert not d.dormant
+    assert d.close_link.call_count == 0
+
+  def test_releases_the_gadget_once_ready_and_parked_long_enough(self):
+    d = self.daemon()
+    d.started = time.monotonic() - jetlinkd.DORMANT_HOLD
+    d.step()
+    assert d.dormant
+    assert d.close_link.call_count == 1
+    assert jetlinkd.helpers.dormant()
+    # and stays off the link while there is nothing to do
+    d.step()
+    assert d.open_link.call_count == 1  # only the first step presented it
+
+  def test_not_ready_means_not_dormant(self):
+    d = self.daemon(ready=False)
+    d.started = time.monotonic() - jetlinkd.DORMANT_HOLD
+    d.step()
+    assert not d.dormant
+
+  def test_a_cleared_readiness_wakes_it(self):
+    d = self.daemon()
+    d.started = time.monotonic() - jetlinkd.DORMANT_HOLD
+    d.step()
+    assert d.dormant
+    d.started = time.monotonic()  # so the re-provision below does not put it straight back
+    with mock.patch.object(jetlinkd.helpers, 'engine_ready_for', return_value=False):
+      d.step()
+    assert not d.dormant
+    assert not jetlinkd.helpers.dormant()
+    assert d.open_link.call_count == 2  # presented it again
+    assert d.provision.call_count == 2  # and asked the server again
+
+  def test_a_changed_model_wakes_it(self):
+    d = self.daemon()
+    d.started = time.monotonic() - jetlinkd.DORMANT_HOLD
+    d.step()
+    d.started = time.monotonic()
+    with mock.patch.object(jetlinkd.helpers, 'selected_model', return_value={'oid': 'other'}), \
+         mock.patch.object(jetlinkd.helpers, 'active_model_path', return_value=None):
+      d.step()
+    assert not d.dormant
+
+  def test_waking_for_work_that_is_done_goes_straight_back(self):
+    d = self.daemon()
+    d.started = time.monotonic() - jetlinkd.DORMANT_HOLD
+    d.step()
+    with mock.patch.object(jetlinkd.helpers, 'engine_ready_for', return_value=False):
+      d.step()
+    assert d.dormant
+    assert d.open_link.call_count == 2
+    assert d.close_link.call_count == 2
+
+  def test_nothing_selected_is_not_work(self):
+    d = self.daemon()
+    d.started = time.monotonic() - jetlinkd.DORMANT_HOLD
+    d.step()
+    with mock.patch.object(jetlinkd.helpers, 'active_model_path', return_value=None):
+      d.step()
+    assert d.dormant
+
+  def test_disabling_clears_the_marker(self):
+    d = self.daemon()
+    d.started = time.monotonic() - jetlinkd.DORMANT_HOLD
+    d.step()
+    # Disabling drops JetlinkEngineReady. Mocked so this can never reach a
+    # live params directory, conftest or no conftest.
+    with mock.patch.object(jetlinkd.helpers, 'enabled', return_value=False), \
+         mock.patch.object(jetlinkd.helpers, 'set_engine_ready'):
+      d.step()
+    assert not d.dormant
+    assert not jetlinkd.helpers.dormant()
+
+  def test_a_shutdown_request_is_carried_to_the_jetson(self):
+    d = self.daemon()
+    d.started = time.monotonic() - jetlinkd.DORMANT_HOLD
+    d.step()
+    assert d.dormant
+    jetlinkd.helpers.request_shutdown('car battery')
+    d.step()
+    assert not d.dormant
+    assert d.open_link.call_count == 2  # presented it again to wake it
+    d.client.shutdown.assert_called_once_with('car battery', timeout=5.0)
+    assert jetlinkd.helpers.pending_shutdown() is None
+
+  def test_a_shutdown_request_is_consumed_even_when_it_fails(self):
+    d = self.daemon()
+    d.client.shutdown.side_effect = RuntimeError('link died')
+    jetlinkd.helpers.request_shutdown('car battery')
+    d.step()
+    assert jetlinkd.helpers.pending_shutdown() is None
+
+  def test_a_shutdown_request_waits_for_the_jetson_to_wake(self):
+    d = self.daemon()
+    attached = iter([False, False, True])
+    with mock.patch.object(jetlinkd.helpers, 'host_attached', side_effect=lambda: next(attached)):
+      jetlinkd.helpers.request_shutdown('car battery')
+      d.step()
+    d.client.shutdown.assert_called_once()
+
+
+class TestTimedOut(unittest.TestCase):
+  def test_without_the_package_it_assumes_the_worst(self):
+    # No jetlink installed means no way to tell a timeout from a desync, and
+    # reopening a healthy link is cheaper than reusing a broken one.
+    assert jetlinkd._timed_out(RuntimeError('boom')) is False
+
+  def test_it_follows_jetlink_own_distinction(self):
+    base = types.ModuleType('jetlink.transport.base')
+
+    class LinkError(IOError):
+      pass
+
+    class LinkTimeout(LinkError):
+      pass
+
+    base.LinkError, base.LinkTimeout = LinkError, LinkTimeout
+    mods = {'jetlink': types.ModuleType('jetlink'),
+            'jetlink.transport': types.ModuleType('jetlink.transport'),
+            'jetlink.transport.base': base}
+    with mock.patch.dict(sys.modules, mods):
+      assert jetlinkd._timed_out(LinkTimeout('no reply in time')) is True
+      assert jetlinkd._timed_out(LinkError('stream desynced')) is False
+
+
+
+class TestWarpFallback(TestParked):
+  """scons builds the warp now; build_warp only covers one that is missing.
+
+  It inherits TestParked's fixture for the patched helpers and the mocked
+  accelerators module, and just turns warp_built back off.
+  """
+
+  def warp_daemon(self):
+    d = self.daemon()
+    d.warp_built = False
+    jetlinkd.accelerators.report_progress.reset_mock()
+    return d
+
+  def test_a_warp_the_build_made_is_left_alone(self):
+    # Reporting before checking put a "compiling the camera warp" through the
+    # UI on every start for a warp that was already on disk.
+    d = self.warp_daemon()
+    with mock.patch.object(jetlinkd.warp_cache, 'is_cached', return_value=True), \
+         mock.patch.object(jetlinkd.warp_cache, 'ensure') as ensure:
+      d.build_warp()
+    ensure.assert_not_called()
+    assert jetlinkd.accelerators.report_progress.call_count == 0
+    assert d.warp_thread is None
+
+  def test_a_missing_warp_is_still_built(self):
+    d = self.warp_daemon()
+    with mock.patch.object(jetlinkd.warp_cache, 'is_cached', return_value=False), \
+         mock.patch.object(jetlinkd.warp_cache, 'ensure', return_value=True) as ensure:
+      d.build_warp()
+      assert d.warp_thread is not None
+      d.warp_thread.join(30)
+    assert not d.warp_thread.is_alive()
+    ensure.assert_called_once()
+    assert jetlinkd.accelerators.report_progress.call_args.args[0] == 'warp'
+
+  def test_it_is_attempted_once_per_run(self):
+    d = self.warp_daemon()
+    with mock.patch.object(jetlinkd.warp_cache, 'is_cached', return_value=True) as cached:
+      d.build_warp()
+      d.build_warp()
+    cached.assert_called_once()
+
+
+class TestVmTuning(unittest.TestCase):
+  """The sysctls are jetlinkd's now, not the boot script's.
+
+  A device with the link off must run stock values, and a device that turns it
+  off must get them back. A plain exit keeps them: manager stops this daemon
+  at ignition, and the values are for the drive that follows.
+  """
+
+  STOCK = {'vm.dirty_bytes': '0', 'vm.dirty_background_bytes': '0', 'vm.min_free_kbytes': '7274'}
+
+  def setUp(self):
+    self.tmp = Path(tempfile.mkdtemp())
+    proc = self.tmp / 'proc'
+    for key, value in self.STOCK.items():
+      path = proc / key.replace('.', '/')
+      path.parent.mkdir(parents=True, exist_ok=True)
+      path.write_text(value + '\n')
+    self.record = self.tmp / 'prev'
+    self.run_mock = mock.Mock()
+    for p in (mock.patch.object(jetlinkd, 'PROC_SYS', proc),
+              mock.patch.object(jetlinkd, 'SYSCTL_PREV', self.record),
+              mock.patch.object(jetlinkd.subprocess, 'run', self.run_mock),
+              mock.patch.object(jetlinkd.os, 'geteuid', return_value=1000),
+              mock.patch.object(jetlinkd.helpers, 'DORMANT', self.tmp / 'dormant'),
+              mock.patch.object(jetlinkd, 'accelerators', mock.Mock())):
+      self.addCleanup(p.stop)
+      p.start()
+
+  def applied(self) -> list[str]:
+    return [c.args[0][-1] for c in self.run_mock.call_args_list]
+
+  def test_applied_on_start_and_kept_on_exit(self):
+    d = jetlinkd.Jetlinkd()
+    d.stop = True
+    with mock.patch.object(jetlinkd.helpers, 'enabled', return_value=True):
+      d.run()
+    ours = [f'{k}={v}' for k, v in jetlinkd.VM_SYSCTLS.items()]
+    assert self.applied() == ours, "an exit is the ignition handoff; restoring here strips the drive of them"
+    assert json.loads(self.record.read_text()) == self.STOCK, "the record is what a later disable restores to"
+
+  def test_the_next_start_reapplies_without_touching_the_record(self):
+    d = jetlinkd.Jetlinkd()
+    d.stop = True
+    with mock.patch.object(jetlinkd.helpers, 'enabled', return_value=True):
+      d.run()
+    for key in self.STOCK:
+      (jetlinkd.PROC_SYS / key.replace('.', '/')).write_text(jetlinkd.VM_SYSCTLS[key])
+    self.run_mock.reset_mock()
+    d = jetlinkd.Jetlinkd()
+    d.stop = True
+    with mock.patch.object(jetlinkd.helpers, 'enabled', return_value=True):
+      d.run()
+    assert self.applied() == [f'{k}={v}' for k, v in jetlinkd.VM_SYSCTLS.items()]
+    assert json.loads(self.record.read_text()) == self.STOCK
+
+  def test_the_record_is_written_before_anything_changes(self):
+    with mock.patch.object(jetlinkd, '_write_sysctls') as write:
+      jetlinkd.apply_vm_tuning()
+    assert json.loads(self.record.read_text()) == self.STOCK
+    write.assert_called_once_with(jetlinkd.VM_SYSCTLS)
+
+  def test_an_existing_record_is_not_clobbered(self):
+    # A previous run that was SIGKILLed left our values in /proc; reading them
+    # now would record them as the stock ones and restore to them forever.
+    self.record.write_text(json.dumps(self.STOCK))
+    for key in self.STOCK:
+      (jetlinkd.PROC_SYS / key.replace('.', '/')).write_text(jetlinkd.VM_SYSCTLS[key])
+    jetlinkd.apply_vm_tuning()
+    assert json.loads(self.record.read_text()) == self.STOCK
+    jetlinkd.restore_vm_tuning()
+    assert self.applied()[-len(self.STOCK):] == [f'{k}={v}' for k, v in self.STOCK.items()]
+
+  def test_nothing_happens_when_disabled(self):
+    d = jetlinkd.Jetlinkd()
+    d.stop = True
+    with mock.patch.object(jetlinkd.helpers, 'enabled', return_value=False):
+      d.run()
+    assert self.run_mock.call_count == 0
+    assert not self.record.exists()
+
+  def test_disabling_mid_run_restores(self):
+    d = jetlinkd.Jetlinkd()
+    with mock.patch.object(jetlinkd.helpers, 'enabled', return_value=True), \
+         mock.patch.object(d, 'build_warp'), \
+         mock.patch.object(d, 'open_link', return_value=False):
+      d.step()
+    assert d.vm_tuned
+    with mock.patch.object(jetlinkd.helpers, 'enabled', return_value=False), \
+         mock.patch.object(jetlinkd.helpers, 'set_engine_ready'):
+      d.step()
+    assert not d.vm_tuned
+    assert not self.record.exists()
+    assert self.applied()[-1] == 'vm.min_free_kbytes=' + self.STOCK['vm.min_free_kbytes']
+
+  def test_a_root_run_writes_proc_directly(self):
+    with mock.patch.object(jetlinkd.os, 'geteuid', return_value=0):
+      jetlinkd.apply_vm_tuning()
+    assert self.run_mock.call_count == 0
+    assert (jetlinkd.PROC_SYS / 'vm/min_free_kbytes').read_text() == '131072'
+
+
+class BuildEtaTest(unittest.TestCase):
+  """models.json has carried built_seconds all along so the UI could say how
+  long a first provision takes, and nothing read it. A driver watching
+  "build 12%" cannot tell five minutes from thirty."""
+
+  def test_the_build_stage_gets_a_time_remaining(self):
+    from openpilot.sunnypilot.accelerators.jetlink import jetlinkd as J
+    seen = []
+    with mock.patch.object(J.helpers, 'selected_model', return_value={'built_seconds': 300}), \
+         mock.patch.object(J.accelerators, 'report_progress', lambda *a: seen.append(a)):
+      J.Jetlinkd._report_with_eta(J.Jetlinkd, 'build', 0.0, 'building the engine')
+      J.Jetlinkd._report_with_eta(J.Jetlinkd, 'build', 0.8, 'building the engine')
+    self.assertEqual(seen[0][2], "about 5 min left")
+    self.assertEqual(seen[1][2], "about 60s left")
+
+  def test_other_stages_keep_their_own_message(self):
+    from openpilot.sunnypilot.accelerators.jetlink import jetlinkd as J
+    seen = []
+    # The upload already counts MB of MB, and a connect has nothing to predict.
+    with mock.patch.object(J.helpers, 'selected_model', return_value={'built_seconds': 300}), \
+         mock.patch.object(J.accelerators, 'report_progress', lambda *a: seen.append(a)):
+      J.Jetlinkd._report_with_eta(J.Jetlinkd, 'upload', 0.5, '380/766 MB')
+    self.assertEqual(seen[0][2], '380/766 MB')
+
+  def test_a_model_with_no_measured_build_time_is_survived(self):
+    from openpilot.sunnypilot.accelerators.jetlink import jetlinkd as J
+    seen = []
+    with mock.patch.object(J.helpers, 'selected_model', return_value={}), \
+         mock.patch.object(J.accelerators, 'report_progress', lambda *a: seen.append(a)):
+      J.Jetlinkd._report_with_eta(J.Jetlinkd, 'build', 0.3, 'building the engine')
+    self.assertEqual(seen[0][2], 'building the engine')
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/openpilot/sunnypilot/accelerators/jetlink/tests/test_joining.py
+++ b/openpilot/sunnypilot/accelerators/jetlink/tests/test_joining.py
@@ -1,0 +1,502 @@
+"""
+Copyright (c) 2026-, Zeph Leggett.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+
+The rules the late join has to keep.
+
+Both model states are fakes; the joining state is plumbing around them. What
+is pinned: modeld gets a working model immediately, a swap never lands on an
+engaged frame, a large model that dies mid-drive falls back without losing the
+frame, and a small-model failure still belongs to modeld.
+"""
+import re
+import threading
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from openpilot.common.basedir import BASEDIR
+
+from openpilot.sunnypilot.accelerators.jetlink.joining import STABLE_SECONDS, JoiningModelState
+
+
+class FakeModel:
+  def __init__(self, name, chestnut=False, client=None):
+    self.name = name
+    self.chestnut = chestnut
+    self.client = client
+    self.lat_delay = 0.0
+    self.vision_input_names = ['img', 'big_img']
+    self.calls = 0
+    self.raises = None
+    self.closed = False
+    self.warmed = False
+
+  def run(self, bufs, transforms, inputs, after_enqueue=None):
+    self.calls += 1
+    if self.raises is not None:
+      raise self.raises
+    return {'from': self.name}
+
+  def warmup(self):
+    self.warmed = True
+
+  def close(self):
+    self.closed = True
+
+
+class JoiningTest(unittest.TestCase):
+  def setUp(self):
+    # The engagement watcher is the one part that needs msgq. Drive the flag by
+    # hand instead; what it reads is covered by selfdrived's own tests.
+    patcher = mock.patch.object(JoiningModelState, '_watch_engagement', lambda self: None)
+    patcher.start()
+    self.addCleanup(patcher.stop)
+
+    # The join reports progress through a param. Mocked so this can never
+    # reach a live params directory, conftest or no conftest.
+    self.progress = mock.Mock()
+    patcher = mock.patch('openpilot.sunnypilot.accelerators.jetlink.joining.accelerators', self.progress)
+    patcher.start()
+    self.addCleanup(patcher.stop)
+
+    self.small = FakeModel('small')
+    self.big = FakeModel('big', chestnut=True, client=object())
+    self.joined = threading.Event()
+    self.connect_calls = 0
+    self.connect_error = None
+
+  def _connect(self):
+    self.connect_calls += 1
+    if self.connect_error is not None:
+      raise self.connect_error
+    self.joined.set()
+    # A link the joining state may have to close on its own, when it is torn
+    # down holding a join that never found a disengaged frame to land on.
+    return (mock.MagicMock(name='client'), 'spec')
+
+  def _build(self, client, spec):
+    return self.big
+
+  def _state(self):
+    s = JoiningModelState(1928, 1208, self.small, self._connect, self._build)
+    self.addCleanup(s.close)
+    return s
+
+  def _wait_joined(self, s, timeout=5.0):
+    # connect() returning is not publication: wait for the owner to hand off.
+    deadline = time.monotonic() + timeout
+    while s._joined is None and time.monotonic() < deadline:
+      time.sleep(0.001)
+    self.assertIsNotNone(s._joined)
+
+  def _run(self, s):
+    s._engagement_updated = time.monotonic()
+    return s.run({}, {}, {})
+
+  def test_stalled_watcher_cannot_leave_a_swap_window_open(self):
+    s = self._state()
+    s._engaged, s._standstill = False, True
+    s._engagement_updated = time.monotonic() - 1.0
+    self.assertFalse(s._window_open)
+
+  def test_missing_or_invalid_messages_close_both_swap_windows(self):
+    from types import SimpleNamespace
+    sm = mock.MagicMock()
+    states = {'selfdriveState': SimpleNamespace(enabled=False), 'carState': SimpleNamespace(standstill=True),
+              'carControl': SimpleNamespace(latActive=False, longActive=False)}
+    sm.__getitem__.side_effect = states.__getitem__
+    s = self._state()
+    for failed in states:
+      for check in ('seen', 'alive', 'valid'):
+        sm.seen = dict.fromkeys(states, True)
+        sm.alive = sm.seen.copy()
+        sm.valid = sm.seen.copy()
+        s._update_engagement(sm)
+        self.assertTrue(s._window_open)
+        getattr(sm, check)[failed] = False
+        # No updated flag: liveness expiry must still close the window.
+        s._update_engagement(sm)
+        self.assertFalse(s._window_open)
+    sm.seen = dict.fromkeys(states, True)
+    sm.alive = sm.seen.copy()
+    sm.valid = sm.seen.copy()
+    states['carState'].standstill = False
+    for active in ('latActive', 'longActive'):
+      states['carControl'].latActive = active == 'latActive'
+      states['carControl'].longActive = active == 'longActive'
+      s._update_engagement(sm)
+      self.assertFalse(s._window_open)
+
+  def test_runs_the_small_model_immediately(self):
+    s = self._state()
+    # No waiting on a link: this is the whole point.
+    self.assertEqual(self._run(s), {'from': 'small'})
+    self.assertFalse(s.chestnut)
+    self.assertIsNone(s.client)
+
+  def test_does_not_swap_while_engaged_and_moving(self):
+    s = self._state()
+    self._wait_joined(s)
+    s._engaged, s._standstill = True, False
+    for _ in range(3):
+      self.assertEqual(self._run(s), {'from': 'small'})
+    self.assertFalse(s.chestnut)
+    self.assertFalse(self.big.warmed)
+
+  def test_does_not_swap_at_a_standstill_while_engaged(self):
+    # Even stopped, longitudinal control can hold the brake or request motion.
+    s = self._state()
+    self._wait_joined(s)
+    s._engaged, s._standstill = True, True
+    self.assertEqual(self._run(s), {'from': 'small'})
+    self.assertFalse(s.chestnut)
+
+  def test_a_standstill_the_car_stopped_reporting_is_not_a_window(self):
+    # sm.alive goes false when carState stops arriving. A stale "stopped" must
+    # not open a window on a car that is actually moving.
+    s = self._state()
+    self._wait_joined(s)
+    s._engaged, s._standstill = True, False
+    self.assertEqual(self._run(s), {'from': 'small'})
+
+  def test_late_boot_announces_availability_without_switching(self):
+    booted = threading.Event()
+    connect = self._connect
+
+    def after_boot():
+      if not booted.wait(5):
+        raise RuntimeError('test boot timeout')
+      return connect()
+
+    self._connect = after_boot
+    s = self._state()
+    self.addCleanup(booted.set)
+    self.assertFalse(s.big_model_available)
+    self.assertEqual(self._run(s), {'from': 'small'})
+    booted.set()
+    self._wait_joined(s)
+    self.assertTrue(s.big_model_available)
+    self.assertEqual(self._run(s), {'from': 'small'})
+    self.assertTrue(s.loading)
+    self.assertEqual(s.big_model_state, 'joining')
+    s._engaged = False
+    self.assertEqual(self._run(s), {'from': 'big'})
+    self.assertFalse(s.big_model_available)
+    self.assertEqual(s.big_model_state, 'running')
+
+  def test_availability_survives_ping_but_not_link_loss(self):
+    pinging, release = threading.Event(), threading.Event()
+    client = mock.MagicMock()
+
+    def ping(**kwargs):
+      pinging.set()
+      release.wait(5)
+      raise RuntimeError('link lost while waiting to switch')
+
+    client.ping.side_effect = ping
+    self._connect = lambda: (client, 'spec')
+    with mock.patch('openpilot.sunnypilot.accelerators.jetlink.joining.KEEPALIVE_PERIOD', 0.01):
+      s = self._state()
+      self.addCleanup(release.set)
+      self.assertTrue(pinging.wait(5))
+      self.assertIsNone(s._joined)
+      self.assertTrue(s.big_model_available)
+      self.assertEqual(self._run(s), {'from': 'small'})
+      release.set()
+      deadline = time.monotonic() + 2
+      while s.big_model_available and time.monotonic() < deadline:
+        time.sleep(0.001)
+      self.assertFalse(s.big_model_available)
+      self.assertFalse(s.chestnut)
+
+  def test_ping_taking_the_pending_link_during_swap_check_keeps_availability(self):
+    s = self._state()
+    self._wait_joined(s)
+    joined = s._joined
+    s._engaged = False
+    # The frame sees _joined before locking, then the keepalive takes it.
+    with mock.patch.object(s, '_lock') as lock:
+      lock.__enter__.side_effect = lambda: setattr(s, '_joined', None)
+      self.assertEqual(self._run(s), {'from': 'small'})
+      self.assertTrue(s.big_model_available)
+    s._joined = joined
+
+  def test_close_with_pending_model_clears_availability(self):
+    s = self._state()
+    self._wait_joined(s)
+    self.assertTrue(s.big_model_available)
+    s.close()
+    self.assertFalse(s.big_model_available)
+
+  def test_swaps_on_a_disengaged_frame(self):
+    s = self._state()
+    self._wait_joined(s)
+    s._engaged = False
+    self.assertEqual(self._run(s), {'from': 'big'})
+    self.assertTrue(s.chestnut)
+    self.assertIs(s.client, self.big.client)
+    # No warmup at the swap: the warp was prepared in __init__ and a frame
+    # over the link here was two dropped camera frames on the car.
+    self.assertFalse(self.big.warmed)
+
+  def test_large_model_failure_demotes_and_keeps_the_frame(self):
+    s = self._state()
+    self._wait_joined(s)
+    s._engaged = False
+    self._run(s)
+    self.assertTrue(s.chestnut)
+
+    self.big.raises = RuntimeError("link gone")
+    # modeld still gets an output for this frame, from the small model.
+    self.assertEqual(self._run(s), {'from': 'small'})
+    self.assertFalse(s.chestnut)
+    for _ in range(100):
+      if self.big.closed:
+        break
+      time.sleep(0.01)
+    self.assertTrue(self.big.closed)
+    # And it tries again rather than staying small for the rest of the drive.
+    self.assertTrue(s._rejoin_at > time.monotonic() or self.connect_calls > 1)
+
+  def test_failed_first_inference_never_announces_ready(self):
+    s = self._state()
+    self._wait_joined(s)
+    s._engaged = False
+    self.big.raises = RuntimeError('first inference failed')
+    self.assertEqual(self._run(s), {'from': 'small'})
+    self.assertTrue(s.loading)
+    self.assertEqual(s.big_model_state, 'retrying')
+    self.assertFalse(s.big_model_available)
+    self.progress.clear_progress.assert_not_called()
+
+  def test_fallback_resets_history_without_waiting_for_teardown(self):
+    entered, release = threading.Event(), threading.Event()
+    reset = mock.Mock()
+
+    def close():
+      entered.set()
+      release.wait(2)
+
+    self.big.close = close
+    s = JoiningModelState(1928, 1208, self.small, self._connect, self._build, reset_small=reset)
+    self.addCleanup(s.close)
+    self.addCleanup(release.set)
+    self._wait_joined(s)
+    s._engaged = False
+    self._run(s)
+    self.big.raises = RuntimeError('failed')
+    run = self.small.run
+
+    def small_run(*args):
+      reset.assert_called_once()
+      return run(*args)
+
+    self.small.run = small_run
+    self.assertEqual(self._run(s), {'from': 'small'})
+    self.assertTrue(entered.wait(1))
+    self.assertFalse(release.is_set())
+
+  def test_ready_is_announced_only_after_inference_returns(self):
+    s = self._state()
+    self._wait_joined(s)
+    s._engaged = False
+    run = self.big.run
+
+    def inspect(*args):
+      # Swapped in, but not announced: the first frame has not returned yet.
+      self.assertTrue(s._loading)
+      self.progress.clear_progress.assert_not_called()
+      return run(*args)
+
+    self.big.run = inspect
+    self.assertEqual(self._run(s), {'from': 'big'})
+    self.assertFalse(s._loading)
+    self.progress.clear_progress.assert_called_once()
+
+  def test_prepare_failure_uses_startup_fallback_not_a_slow_swap(self):
+    order = []
+    self.connect_calls = 0
+
+    def prepare():
+      order.append('prepare')
+      raise RuntimeError("no warp today")
+
+    with self.assertRaisesRegex(RuntimeError, 'no warp today'):
+      JoiningModelState(1928, 1208, self.small, self._connect, self._build, prepare)
+    # Ran, and ran before anything else: modeld's main thread is blocked for
+    # exactly as long as the constructor takes, so this is the only place the
+    # GPU work can go without costing a frame.
+    self.assertEqual(order, ['prepare'])
+    self.assertEqual(self.connect_calls, 0)
+    self.assertFalse(self.big.warmed)
+
+  def test_loading_has_no_deadline(self):
+    # no 60 s edge: selfdrived gates on it only while nothing publishes modelV2,
+    # so a Jetson that takes a whole drive stays "getting ready"
+    self.connect_error = RuntimeError("jetson still booting")
+    s = self._state()
+    self._run(s)
+    with mock.patch('openpilot.sunnypilot.accelerators.jetlink.joining.time.monotonic',
+                    return_value=time.monotonic() + 600.0):
+      self._run(s)
+    self.assertTrue(s.loading)
+    self.assertEqual(s.big_model_state, 'joining')
+    # A join that succeeds later still swaps.
+    self.connect_error = None
+    s._rejoin.set()
+    self._wait_joined(s, 10.0)
+    s._engaged = False
+    for _ in range(20):
+      if self._run(s) == {'from': 'big'}:
+        break
+      time.sleep(0.05)
+    self.assertTrue(s.chestnut)
+    self.assertFalse(s.loading)
+
+  def test_state_travels_in_the_message_not_in_params(self):
+    # a chestnut's load is over once; this never is, so selfdrived's edge is
+    # modelV2.big turning true and the UI reads acceleratorState
+    s = self._state()
+    self.assertTrue(s.loading)
+    self.assertEqual(s.big_model_state, 'joining')
+
+    self._wait_joined(s)
+    s._engaged = False
+    self._run(s)
+    self.assertFalse(s.loading)
+    self.assertTrue(s.chestnut)
+    self.assertEqual(s.big_model_state, 'running')
+
+    self.big.raises = RuntimeError("link gone")
+    self._run(s)
+    self.assertTrue(s.loading)
+    self.assertFalse(s.chestnut)
+    self.assertEqual(s.big_model_state, 'retrying')
+    self.progress.report_progress.assert_called_with('connect', 0.0, 'lost the jetson, reconnecting')
+
+    s.close()
+    self.assertEqual(s.big_model_state, 'unavailable')
+
+  def test_build_failure_backs_off(self):
+    self._build = mock.Mock(side_effect=RuntimeError("no warp"))
+    s = JoiningModelState(1928, 1208, self.small, self._connect, self._build)
+    self.addCleanup(s.close)
+    self._wait_joined(s)
+    s._engaged = False
+    self.assertEqual(self._run(s), {'from': 'small'})
+    # Not straight back onto the link: the next attempt waits REJOIN_DELAY.
+    self.assertGreater(s._rejoin_at, time.monotonic() + 1.0)
+    self.assertTrue(s.loading)
+    self.assertEqual(s.big_model_state, 'retrying')
+
+  def test_a_link_that_dies_before_the_swap_is_reopened(self):
+    # a link waits in _joined for a window, which on a drive with no stop is the
+    # whole drive; a Jetson that reboots in there must be caught before the swap
+    clients = []
+
+    def connect():
+      c = mock.MagicMock(name='client')
+      clients.append(c)
+      self.connect_calls += 1
+      self.joined.set()
+      return (c, 'spec')
+
+    self._connect = connect
+    with mock.patch('openpilot.sunnypilot.accelerators.jetlink.joining.KEEPALIVE_PERIOD', 0.05), \
+         mock.patch('openpilot.sunnypilot.accelerators.jetlink.joining.REJOIN_DELAY', 0.05):
+      s = self._state()
+      self._wait_joined(s)
+      # Never a window, so nothing consumes it; the ping is what notices.
+      s._engaged, s._standstill = True, False
+      clients[0].ping.side_effect = RuntimeError("jetson rebooted")
+      for _ in range(100):
+        if len(clients) > 1:
+          break
+        time.sleep(0.05)
+      self.assertGreater(len(clients), 1, "a dead pending link was never reopened")
+      clients[0].close.assert_called()
+      # And the fresh one is what the window eventually gets.
+      s._engaged = False
+      for _ in range(40):
+        if self._run(s) == {'from': 'big'}:
+          break
+        time.sleep(0.05)
+      self.assertTrue(s.chestnut)
+
+  def test_failures_back_off_and_a_stable_join_starts_over(self):
+    # A link that dies on its first frame every time used to cost a swap, a
+    # demote, a soft disable and a chime every REJOIN_DELAY for the drive.
+    s = self._state()
+    s._joined_at = 0.0
+    delays = []
+    for _ in range(5):
+      t = time.monotonic()
+      s._back_off()
+      delays.append(round(s._rejoin_at - t))
+    self.assertEqual(delays, [5, 10, 20, 40, 60])
+
+    # A join that held is not that link, and must not inherit its delay: a
+    # Jetson that reboots once an hour should be picked up in REJOIN_DELAY.
+    s._joined_at = time.monotonic() - (STABLE_SECONDS + 1)
+    t = time.monotonic()
+    s._back_off()
+    self.assertEqual(round(s._rejoin_at - t), 5)
+
+  def test_small_model_failure_is_modelds(self):
+    s = self._state()
+    self.small.raises = RuntimeError("vipc gone")
+    with self.assertRaises(RuntimeError):
+      self._run(s)
+
+  def test_lat_delay_reaches_both_models(self):
+    s = self._state()
+    s.lat_delay = 0.25
+    self.assertEqual(self.small.lat_delay, 0.25)
+    self._wait_joined(s)
+    s._engaged = False
+    self._run(s)
+    self.assertEqual(self.big.lat_delay, 0.25)
+
+
+  def test_reports_loading_until_it_joins(self):
+    # the UI reads this to tell "not up yet" from "failed"; modelV2.big is
+    # false for the whole join
+    s = self._state()
+    self._run(s)
+    self.assertTrue(s.loading)
+
+    self._wait_joined(s)
+    s._engaged = False
+    self._run(s)
+    self.assertFalse(s.loading)
+
+    self.big.raises = RuntimeError("link gone")
+    self._run(s)
+    self.assertTrue(s.loading)
+
+
+class ContractTest(unittest.TestCase):
+  """Whatever modeld touches on the object make_model_state returns.
+
+  Read out of modeld rather than kept by hand: `warmup` was missed once, and
+  modeld reads the AttributeError as "big model load failed".
+  """
+
+  def test_provides_everything_modeld_touches(self):
+    src = Path(BASEDIR) / 'openpilot' / 'selfdrive' / 'modeld' / 'modeld.py'
+    text = src.read_text()
+    # `model` is the one in the frame loop, `m` the one load_big just built.
+    # \b keeps small_model/big_model/sm out of it.
+    names = set(re.findall(r'\bmodel\.([a-zA-Z_][a-zA-Z0-9_]*)', text))
+    names |= set(re.findall(r'\bm\.([a-zA-Z_][a-zA-Z0-9_]*)', text))
+    self.assertIn('warmup', names, "modeld stopped calling warmup; check this test still finds the right names")
+    missing = sorted(n for n in names if not hasattr(JoiningModelState, n))
+    self.assertEqual(missing, [], f"JoiningModelState is missing {missing}, which modeld calls on it")
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/openpilot/sunnypilot/accelerators/jetlink/tests/test_lfs.py
+++ b/openpilot/sunnypilot/accelerators/jetlink/tests/test_lfs.py
@@ -1,0 +1,196 @@
+"""
+Copyright (c) 2026-, Zeph Leggett.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+"""
+
+import hashlib
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from openpilot.sunnypilot.accelerators.jetlink import lfs
+
+BODY = b'onnx' * 4096
+OID = hashlib.sha256(BODY).hexdigest()
+SIZE = len(BODY)
+
+POINTER = f"""version https://git-lfs.github.com/spec/v1
+oid sha256:{OID}
+size {SIZE}
+"""
+
+
+class FakeResponse:
+  def __init__(self, payload: bytes):
+    self._payload = payload
+    self._pos = 0
+
+  def read(self, n=None):
+    if n is None:
+      n, self._pos = len(self._payload) - self._pos, len(self._payload)
+      return self._payload[-n:] if n else b''
+    chunk = self._payload[self._pos:self._pos + n]
+    self._pos += len(chunk)
+    return chunk
+
+  def __enter__(self):
+    return self
+
+  def __exit__(self, *_):
+    return False
+
+
+class TestParsePointer(unittest.TestCase):
+  def setUp(self):
+    self.tmp = Path(tempfile.mkdtemp())
+
+  def write(self, name: str, data) -> Path:
+    path = self.tmp / name
+    path.write_bytes(data if isinstance(data, bytes) else data.encode())
+    return path
+
+  def test_reads_oid_and_size(self):
+    assert lfs.parse_pointer(self.write('p', POINTER)) == (OID, SIZE)
+
+  def test_a_real_object_is_not_a_pointer(self):
+    # The worktree holds the object once it has been fetched, and it must not
+    # be mistaken for something still to download.
+    assert lfs.parse_pointer(self.write('big', b'\0' * 8192)) is None
+
+  def test_binary_that_is_small_is_not_a_pointer(self):
+    assert lfs.parse_pointer(self.write('junk', b'\x00\x01\x02')) is None
+
+  def test_missing_file_is_not_a_pointer(self):
+    assert lfs.parse_pointer(self.tmp / 'absent') is None
+
+  def test_incomplete_pointer_is_rejected(self):
+    assert lfs.parse_pointer(self.write('p', 'version x\noid sha256:abc\n')) is None
+
+  def test_non_numeric_size_is_rejected(self):
+    assert lfs.parse_pointer(self.write('p', f'oid sha256:{OID}\nsize huge\n')) is None
+
+
+class TestEndpoints(unittest.TestCase):
+  def setUp(self):
+    self.root = Path(tempfile.mkdtemp())
+
+  def test_configured_endpoint_comes_first(self):
+    (self.root / '.lfsconfig').write_text('[lfs]\n\turl = https://example.com/info/lfs\n')
+    assert lfs.endpoints(self.root) == ['https://example.com/info/lfs', lfs.COMMA_LFS]
+
+  def test_commas_endpoint_is_always_there(self):
+    # sunnypilot substitutes its own big model, but comma's server is still the
+    # only one that has comma's.
+    assert lfs.endpoints(self.root) == [lfs.COMMA_LFS]
+
+  def test_no_duplicate_when_already_commas(self):
+    (self.root / '.lfsconfig').write_text(f'[lfs]\n\turl = {lfs.COMMA_LFS}\n')
+    assert lfs.endpoints(self.root) == [lfs.COMMA_LFS]
+
+
+class TestResolve(unittest.TestCase):
+  def urlopen_returning(self, payload: dict):
+    return mock.patch.object(lfs.urllib.request, 'urlopen',
+                             return_value=FakeResponse(json.dumps(payload).encode()))
+
+  def test_returns_the_href(self):
+    with self.urlopen_returning({'objects': [{'oid': OID, 'actions': {'download': {'href': 'https://x/y'}}}]}):
+      assert lfs.resolve('https://e/info/lfs', OID, SIZE) == 'https://x/y'
+
+  def test_an_error_object_is_a_miss_not_a_raise(self):
+    with self.urlopen_returning({'objects': [{'oid': OID, 'error': {'code': 404, 'message': 'nope'}}]}):
+      assert lfs.resolve('https://e/info/lfs', OID, SIZE) is None
+
+  def test_a_different_oid_is_a_miss(self):
+    with self.urlopen_returning({'objects': [{'oid': 'deadbeef', 'actions': {'download': {'href': 'https://x/y'}}}]}):
+      assert lfs.resolve('https://e/info/lfs', OID, SIZE) is None
+
+  def test_a_dead_server_is_a_miss_not_a_raise(self):
+    # One unreachable endpoint must not stop us asking the next.
+    with mock.patch.object(lfs.urllib.request, 'urlopen', side_effect=OSError('refused')):
+      assert lfs.resolve('https://e/info/lfs', OID, SIZE) is None
+
+
+class TestDownload(unittest.TestCase):
+  def setUp(self):
+    self.tmp = Path(tempfile.mkdtemp())
+    self.dest = self.tmp / 'big.onnx'
+
+  def urlopen_returning(self, payload: bytes):
+    return mock.patch.object(lfs.urllib.request, 'urlopen', return_value=FakeResponse(payload))
+
+  def test_writes_and_verifies(self):
+    with self.urlopen_returning(BODY):
+      assert lfs.download('https://x/y', OID, SIZE, self.dest) == self.dest
+    assert self.dest.read_bytes() == BODY
+
+  def test_a_corrupt_body_leaves_nothing_behind(self):
+    # half a model that TensorRT would try to parse is the one outcome worth being paranoid about
+    corrupt = b'x' * SIZE
+    with self.urlopen_returning(corrupt), self.assertRaises(lfs.LfsError):
+      lfs.download('https://x/y', OID, SIZE, self.dest)
+    assert not self.dest.exists()
+    assert not list(self.tmp.glob('*.part'))
+
+  def test_a_short_body_leaves_nothing_behind(self):
+    with self.urlopen_returning(BODY[:100]), self.assertRaises(lfs.LfsError):
+      lfs.download('https://x/y', OID, SIZE, self.dest)
+    assert not self.dest.exists()
+    assert not list(self.tmp.glob('*.part'))
+
+  def test_stopping_leaves_nothing_behind(self):
+    with self.urlopen_returning(BODY), self.assertRaises(lfs.LfsError):
+      lfs.download('https://x/y', OID, SIZE, self.dest, should_stop=lambda: True)
+    assert not list(self.tmp.glob('*.part'))
+
+  def test_refuses_without_room(self):
+    with mock.patch.object(lfs.shutil, 'disk_usage') as usage:
+      usage.return_value = mock.Mock(free=1024)
+      with self.assertRaises(lfs.LfsError):
+        lfs.download('https://x/y', OID, 1 << 30, self.dest)
+
+  def test_progress_reaches_one(self):
+    seen = []
+    with self.urlopen_returning(BODY):
+      lfs.download('https://x/y', OID, SIZE, self.dest, progress=seen.append)
+    assert seen and seen[-1] == 1.0
+    assert seen == sorted(seen)
+
+
+class TestFetch(unittest.TestCase):
+  def setUp(self):
+    self.tmp = Path(tempfile.mkdtemp())
+    self.pointer = self.tmp / 'big.onnx'
+    self.dest = self.tmp / 'out.onnx'
+
+  def test_a_real_object_needs_no_fetch(self):
+    self.pointer.write_bytes(b'\0' * 8192)
+    assert lfs.fetch(self.pointer, self.dest, self.tmp) is None
+
+  def test_already_fetched_is_returned_as_is(self):
+    self.pointer.write_text(POINTER)
+    self.dest.write_bytes(BODY)
+    with mock.patch.object(lfs, 'resolve') as resolve:
+      assert lfs.fetch(self.pointer, self.dest, self.tmp) == self.dest
+      resolve.assert_not_called()
+
+  def test_falls_through_to_the_next_endpoint(self):
+    self.pointer.write_text(POINTER)
+    (self.tmp / '.lfsconfig').write_text('[lfs]\n\turl = https://dead.example/info/lfs\n')
+    with mock.patch.object(lfs, 'resolve', side_effect=[None, 'https://x/y']) as resolve, \
+         mock.patch.object(lfs.urllib.request, 'urlopen', return_value=FakeResponse(BODY)):
+      assert lfs.fetch(self.pointer, self.dest, self.tmp) == self.dest
+    assert [call.args[0] for call in resolve.call_args_list] == ['https://dead.example/info/lfs', lfs.COMMA_LFS]
+
+  def test_nowhere_to_get_it_raises(self):
+    self.pointer.write_text(POINTER)
+    with mock.patch.object(lfs, 'resolve', return_value=None), self.assertRaises(lfs.LfsError):
+      lfs.fetch(self.pointer, self.dest, self.tmp)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/openpilot/sunnypilot/accelerators/jetlink/tests/test_warp_cache.py
+++ b/openpilot/sunnypilot/accelerators/jetlink/tests/test_warp_cache.py
@@ -1,0 +1,222 @@
+"""
+Copyright (c) 2026-, Zeph Leggett.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+
+When the warp JIT is trusted, and when it is not.
+
+The compile needs a GPU and is not exercised here. Staleness is scons' job now,
+so what is left is the file on disk being wrong: a TinyJit from another
+tinygrad, or one pickled before it captured, loads into something that does not
+compute the warp. Each is a raise out of load_warp into the small-model fallback.
+"""
+import importlib
+import pickle
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from openpilot.sunnypilot.accelerators.jetlink import warp_cache
+
+GEOM = (1928, 1208, 512, 256)
+
+
+class FakeCaptured:
+  def __init__(self, names):
+    self.expected_names = names
+
+
+class FakeJit:
+  """Just enough of a TinyJit to be pickled and inspected."""
+
+  def __init__(self, names):
+    self.captured = FakeCaptured(names) if names is not None else None
+
+
+class WarpCacheTest(unittest.TestCase):
+  def setUp(self):
+    self.tmp = tempfile.TemporaryDirectory()
+    self.addCleanup(self.tmp.cleanup)
+    patcher = mock.patch.object(warp_cache, 'CACHE_DIR', Path(self.tmp.name))
+    patcher.start()
+    self.addCleanup(patcher.stop)
+
+  def write(self, geom=GEOM, body=b'pickle'):
+    pkl = warp_cache.warp_path(*geom)
+    pkl.parent.mkdir(parents=True, exist_ok=True)
+    pkl.write_bytes(body)
+    return pkl
+
+
+class TestValidity(WarpCacheTest):
+  def test_a_warp_that_is_there_is_used(self):
+    self.write()
+    self.assertTrue(warp_cache.is_cached(*GEOM))
+
+  def test_nothing_cached_is_a_miss(self):
+    self.assertFalse(warp_cache.is_cached(*GEOM))
+
+  def test_a_bare_pickle_needs_no_sidecar(self):
+    """What scons writes, and all it writes; asking for a sidecar would reject every warp the build produces."""
+    self.write()
+    self.assertFalse(warp_cache.warp_path(*GEOM).with_suffix('.json').exists())
+    self.assertTrue(warp_cache.is_cached(*GEOM))
+
+  def test_the_cache_is_in_the_tree_where_scons_can_write_it(self):
+    """Not under comma_home: on AGNOS that is a tmpfs overlay that loses the
+    pickle every boot, and OPENPILOT_PREFIX moves it out from under a replay."""
+    with mock.patch.dict('os.environ', {'OPENPILOT_PREFIX': 'replaytest'}):
+      importlib.reload(warp_cache)
+    self.addCleanup(importlib.reload, warp_cache)
+    self.assertEqual(warp_cache.CACHE_DIR.name, 'models')
+    self.assertEqual(warp_cache.CACHE_DIR.parent.name, 'jetlink')
+
+  def test_another_camera_does_not_answer_for_this_one(self):
+    """A device that changed camera, or a cache copied between devices. The
+    warp is baked against the frame geometry, so the wrong one is silently
+    wrong rather than an error."""
+    self.write(geom=(1344, 760, 512, 256))
+    self.assertFalse(warp_cache.is_cached(*GEOM))
+
+  def test_another_model_input_size_does_not_answer_either(self):
+    self.write(geom=(1928, 1208, 256, 128))
+    self.assertFalse(warp_cache.is_cached(*GEOM))
+
+
+class TestLoad(WarpCacheTest):
+  def test_a_miss_raises_rather_than_returning_none(self):
+    """modeld's big-model load is wrapped in the one-way fallback to the small
+    model. Raising lands there; returning None would reach the car."""
+    with self.assertRaises(RuntimeError):
+      warp_cache.load_warp(*GEOM)
+
+  def test_a_pickle_that_will_not_load_raises(self):
+    """The incompatible-tinygrad case: unpickling fails and modeld's big-model load falls back."""
+    self.write(body=b'not a pickle at all')
+    with self.assertRaises(pickle.UnpicklingError):
+      warp_cache.load_warp(*GEOM)
+
+
+class TestLoadValidation(WarpCacheTest):
+  """A pickle that loads is not yet a warp that can be trusted."""
+
+  def test_a_good_warp_loads(self):
+    self.write(body=pickle.dumps(FakeJit(warp_cache.WARP_INPUT_NAMES)))
+    self.assertIsInstance(warp_cache.load_warp(*GEOM), FakeJit)
+
+  def test_the_wrong_call_convention_is_refused_at_load(self):
+    # This is the shape of the bug that reached the car: captured positionally,
+    # called by keyword, JitError on the first frame of the drive.
+    self.write(body=pickle.dumps(FakeJit([0, 1, 2, 3])))
+    with self.assertRaises(RuntimeError) as e:
+      warp_cache.load_warp(*GEOM)
+    self.assertIn('call_warp passes', str(e.exception))
+
+  def test_an_uncaptured_jit_is_refused(self):
+    # Pickled before TinyJit captured: loads fine, computes nothing.
+    self.write(body=pickle.dumps(FakeJit(None)))
+    with self.assertRaises(RuntimeError) as e:
+      warp_cache.load_warp(*GEOM)
+    self.assertIn('computes nothing', str(e.exception))
+
+
+class TestEnsure(WarpCacheTest):
+  def test_a_cached_warp_is_not_rebuilt(self):
+    self.write()
+    with mock.patch.object(warp_cache, 'compile_warp') as compile_warp:
+      self.assertTrue(warp_cache.ensure(*GEOM))
+    compile_warp.assert_not_called()
+
+  def test_a_failed_compile_is_reported_not_raised(self):
+    """jetlinkd's loop must survive this: no warp costs the large model, and
+    taking the daemon down with it would also drop the USB gadget."""
+    with mock.patch.object(warp_cache, 'compile_warp', side_effect=RuntimeError("no gpu")):
+      self.assertFalse(warp_cache.ensure(*GEOM))
+
+  def test_a_successful_build_prunes_the_others(self):
+    stale = self.write(geom=(1344, 760, 512, 256))
+    fresh = warp_cache.warp_path(*GEOM)
+    with mock.patch.object(warp_cache, 'compile_warp', side_effect=lambda *a: self.write()):
+      self.assertTrue(warp_cache.ensure(*GEOM))
+    self.assertTrue(fresh.is_file())
+    self.assertFalse(stale.is_file())
+
+
+class TestGeometry(WarpCacheTest):
+  def test_mici_and_tici_want_different_warps(self):
+    """The same split accelerators/SConscript makes, so the build produces what
+    modeld asks for. If these ever drift, load_warp misses and the drive is
+    small-model."""
+    with mock.patch("openpilot.common.hardware.HARDWARE.get_device_type", return_value="mici"):
+      mici = warp_cache.device_geometry()
+    with mock.patch("openpilot.common.hardware.HARDWARE.get_device_type", return_value="tici"):
+      tici = warp_cache.device_geometry()
+    self.assertNotEqual(mici[:2], tici[:2])
+    # both warp to MEDMODEL_INPUT_SIZE, which is what the model input needs
+    self.assertEqual(mici[2:], tici[2:])
+    self.assertEqual(tici[2:], (512, 256))
+
+
+class TestInitDevice(unittest.TestCase):
+  """prepare() runs this before modeld goes realtime: tinygrad's compile pool
+  is otherwise created on the warp's first call, and its handler threads then
+  sit at FIFO 54 on the frame loop's core."""
+
+  def setUp(self):
+    self.pool = mock.Mock(name='get_worker_pool')
+    worker = types.ModuleType('tinygrad.engine.worker')
+    worker.get_worker_pool = self.pool
+    modules = {'tinygrad': mock.MagicMock(), 'tinygrad.tensor': mock.MagicMock(),
+               'tinygrad.engine': mock.MagicMock(), 'tinygrad.engine.worker': worker}
+    patcher = mock.patch.dict(sys.modules, modules)
+    patcher.start()
+    self.addCleanup(patcher.stop)
+
+  def test_the_compile_pool_is_created_with_the_device(self):
+    warp_cache.init_device()
+    self.pool.assert_called_once_with()
+
+  def test_a_pool_that_will_not_start_is_logged_not_raised(self):
+    # An older tinygrad without the module, or PARALLEL=0, must not veto the accelerator.
+    self.pool.side_effect = RuntimeError('no pool')
+    with mock.patch.object(warp_cache.cloudlog, 'exception') as log:
+      warp_cache.init_device()
+    log.assert_called_once()
+
+
+class TestCallConvention(unittest.TestCase):
+  """The compile and the per-frame call have to name the JIT's inputs the same way.
+
+  TinyJit refuses a call whose names differ from the capture, so a positional
+  compile and a keyword call raise JitError on the first frame of a drive.
+  """
+
+  def test_call_warp_passes_everything_by_keyword(self):
+    seen = {}
+
+    def recorder(*args, **kwargs):
+      seen['args'], seen['kwargs'] = args, kwargs
+      return 'warped'
+
+    out = warp_cache.call_warp(recorder, 'T', 'BT', 'F', 'BF')
+    self.assertEqual(out, 'warped')
+    self.assertEqual(seen['args'], (), "positional args make TinyJit capture [0, 1, 2, 3]")
+    self.assertEqual(seen['kwargs'], {'tfm': 'T', 'big_tfm': 'BT', 'frame': 'F', 'big_frame': 'BF'})
+
+  def test_both_call_sites_go_through_the_helper(self):
+    # a second direct call site would diverge again. Read the sources: importing
+    # model_state pulls in tinygrad and msgq, and this runs off the device
+    pkg = Path(warp_cache.__file__).parent
+    for name in ('warp_cache.py', 'model_state.py'):
+      for line in (pkg / name).read_text().splitlines():
+        stripped = line.strip()
+        if ('warp_jit(' in stripped or 'self.warp(' in stripped) and 'call_warp' not in stripped:
+          self.fail(f"{name} calls the warp JIT directly: {stripped}")
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/openpilot/sunnypilot/accelerators/jetlink/warp_cache.py
+++ b/openpilot/sunnypilot/accelerators/jetlink/warp_cache.py
@@ -1,0 +1,210 @@
+"""
+Copyright (c) 2026-, Zeph Leggett.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+
+The comma-side warp JIT: what builds it, and what loads it.
+
+The warp stays on the comma (see model_state), and upstream's fused run_model
+JIT (#38684) has no warp to borrow, so compile_modeld.make_warp is JIT-compiled
+as a scons target; see accelerators/SConscript. Not in modeld, where the ~9 s
+compile would hold back the first frame on every ignition, and not in jetlinkd,
+which only runs offroad and can lose the compile to ignition.
+
+jetlinkd still builds one that is missing outright (`ensure`), for a prebuilt
+image made without the target. load_warp is what stands between a bad pickle
+and the car.
+"""
+from __future__ import annotations
+
+import pickle
+from pathlib import Path
+
+from openpilot.common.swaglog import cloudlog
+
+# in the source tree, next to upstream's dm_warp_*.pkl and under the *.pkl
+# ignore. Not Paths.comma_home(): on AGNOS that is a tmpfs overlay, the pickle
+# was gone every boot and jetlinkd lost the ~9 s compile race to ignition
+CACHE_DIR = Path(__file__).resolve().with_name('models')
+
+
+# what TinyJit records for the keyword call in call_warp: sorted(kwargs)
+WARP_INPUT_NAMES = ['big_frame', 'big_tfm', 'frame', 'tfm']
+
+
+def call_warp(warp, tfm, big_tfm, frame, big_frame):
+  """Call a warp JIT. Every caller goes through here, capture included.
+
+  TinyJit names inputs from enumerate(args) plus sorted(kwargs) and refuses a
+  call whose names differ from the capture. A positional compile and a keyword
+  call raised JitError on the first frame of a drive.
+  """
+  return warp(tfm=tfm, big_tfm=big_tfm, frame=frame, big_frame=big_frame)
+
+
+def init_device() -> None:
+  """Bring the GPU up now, on the caller's thread.
+
+  tinygrad initialises the device on its first kernel run and spawns a libusb
+  event thread doing it. A thread created after config_realtime_process(7, 54)
+  inherits SCHED_FIFO 54 and the core-7 pin and preempts the frame loop; that
+  cost 5% of frames once. Failure is not a reason to refuse the accelerator.
+  """
+  try:
+    from tinygrad.tensor import Tensor
+    Tensor([0.0]).realize()
+  except Exception:
+    cloudlog.exception("jetlink: could not bring the gpu up before modeld goes realtime")
+  # the same trap for tinygrad's compile pool (engine/worker.py): created on
+  # the first compile, after modeld goes realtime, its handler threads sat at
+  # SCHED_FIFO 54 on core 7. An older tinygrad or PARALLEL=0 is not a failure
+  try:
+    from tinygrad.engine.worker import get_worker_pool
+    get_worker_pool()
+  except Exception:
+    cloudlog.exception("jetlink: could not start tinygrad's compile pool before modeld goes realtime")
+
+
+def device_geometry() -> tuple[int, int, int, int]:
+  """(cam_w, cam_h, model_w, model_h) for this device.
+
+  The same choice modeld/SConscript makes, so the warp built is the one modeld
+  asks for. If they disagree, load_warp raises and the drive is small-model.
+  """
+  from openpilot.common.hardware import HARDWARE
+  from openpilot.common.transformations.camera import _ar_ox_fisheye, _os_fisheye
+  from openpilot.common.transformations.model import MEDMODEL_INPUT_SIZE
+
+  camera = _os_fisheye if HARDWARE.get_device_type() == "mici" else _ar_ox_fisheye
+  return camera.width, camera.height, *MEDMODEL_INPUT_SIZE
+
+
+def ensure(cam_w: int, cam_h: int, model_w: int, model_h: int) -> bool:
+  """Build the warp if there is none at all. Offroad only. Never raises.
+
+  The build normally makes it, so this only runs on a prebuilt image made
+  without the target. False means the small model, not a dead daemon.
+  """
+  if is_cached(cam_w, cam_h, model_w, model_h):
+    return True
+  try:
+    pkl = compile_warp(cam_w, cam_h, model_w, model_h)
+  except Exception:
+    cloudlog.exception("jetlink: could not compile the warp")
+    return False
+  prune(keep={pkl})
+  return True
+
+
+def warp_path(cam_w: int, cam_h: int, model_w: int, model_h: int) -> Path:
+  return CACHE_DIR / f'warp_{cam_w}x{cam_h}_{model_w}x{model_h}_tinygrad.pkl'
+
+
+def is_cached(cam_w: int, cam_h: int, model_w: int, model_h: int) -> bool:
+  """Is there a warp for this geometry?
+
+  Presence only. Staleness is scons' job: the target depends on tinygrad and
+  the capture sources. A pickle from an incompatible tinygrad raises in load_warp.
+  """
+  return warp_path(cam_w, cam_h, model_w, model_h).is_file()
+
+
+def compile_warp(cam_w: int, cam_h: int, model_w: int, model_h: int, out: Path | None = None) -> Path:
+  """Build the warp JIT and pickle it. Offroad only: this holds the GPU.
+
+  `out` is for scons; jetlinkd's fallback defaults to warp_path. Three runs
+  before pickling: TinyJit captures on the second call, and a pickle taken
+  earlier is an empty jit that silently does nothing.
+  """
+  import numpy as np
+  from tinygrad.device import Device
+  from tinygrad.engine.jit import TinyJit
+  from tinygrad.tensor import Tensor
+
+  from openpilot.selfdrive.modeld.compile_modeld import NV12Frame, make_warp
+  from openpilot.system.camerad.cameras.nv12_info import get_nv12_info
+
+  nv12 = NV12Frame(cam_w, cam_h, *get_nv12_info(cam_w, cam_h))
+  warp_jit = TinyJit(make_warp(nv12, model_w, model_h), prune=True)
+
+  # one set of input tensors: TinyJit captures against the buffers it is
+  # first handed. Random so nothing constant-folds
+  rng = np.random.default_rng(42)
+  tfm_npy, big_tfm_npy = np.eye(3, dtype=np.float32), np.eye(3, dtype=np.float32)
+  tfm = Tensor(tfm_npy, device='NPY')
+  big_tfm = Tensor(big_tfm_npy, device='NPY')
+  frame = Tensor.randint(nv12.size, low=0, high=256, dtype='uint8', device=Device.DEFAULT).realize()
+  big_frame = Tensor.randint(nv12.size, low=0, high=256, dtype='uint8', device=Device.DEFAULT).realize()
+  for _ in range(3):
+    tfm_npy[:] = rng.standard_normal((3, 3)).astype(np.float32)
+    big_tfm_npy[:] = rng.standard_normal((3, 3)).astype(np.float32)
+    call_warp(warp_jit, tfm, big_tfm, frame, big_frame).realize()
+  Device.default.synchronize()
+
+  pkl = warp_path(cam_w, cam_h, model_w, model_h) if out is None else Path(out)
+  pkl.parent.mkdir(parents=True, exist_ok=True)
+  # through a temporary: modeld may read this while jetlinkd writes it
+  tmp = pkl.with_suffix('.pkl.tmp')
+  with open(tmp, 'wb') as f:
+    pickle.dump(warp_jit, f)
+  tmp.replace(pkl)
+  cloudlog.warning("jetlink: compiled the warp for %dx%d -> %dx%d", cam_w, cam_h, model_w, model_h)
+  return pkl
+
+
+def load_warp(cam_w: int, cam_h: int, model_w: int, model_h: int):
+  """The cached warp JIT. Raises if it is not there or is stale.
+
+  modeld's big-model load is wrapped in the one-way fallback to the small
+  model, and a warp that cannot be trusted must not reach the car.
+  """
+  if not is_cached(cam_w, cam_h, model_w, model_h):
+    raise RuntimeError(f"no warp built for {cam_w}x{cam_h} -> {model_w}x{model_h}; "
+                       + "the build makes it, jetlinkd rebuilds one that is missing")
+  with open(warp_path(cam_w, cam_h, model_w, model_h), 'rb') as f:
+    warp = pickle.load(f)
+
+  # a JIT pickled before TinyJit captured loads fine and computes nothing; one
+  # captured with a different call convention raises JitError on the first
+  # frame of a drive. Both have happened
+  captured = getattr(warp, 'captured', None)
+  if captured is None:
+    raise RuntimeError("cached warp was pickled before it captured; it computes nothing")
+  names = list(getattr(captured, 'expected_names', []))
+  if names != WARP_INPUT_NAMES:
+    raise RuntimeError(f"cached warp expects {names}, call_warp passes {WARP_INPUT_NAMES}")
+  return warp
+
+
+def warm(warp, cam_w: int, cam_h: int) -> None:
+  """Run a loaded warp JIT until it is cheap to call.
+
+  Measured: load_warp 0.3 s, the first call 1.9 s, the second 5 ms. Paid on
+  modeld's frame loop that was ~26 dropped frames and 16 s of modeldLagging
+  after every join.
+  """
+  import numpy as np
+  from tinygrad.device import Device
+  from tinygrad.tensor import Tensor
+
+  from openpilot.system.camerad.cameras.nv12_info import get_nv12_info
+
+  size = get_nv12_info(cam_w, cam_h)[3]
+  frames = [np.zeros(size, dtype=np.uint8) for _ in range(2)]
+  blobs = [Tensor.from_blob(f.ctypes.data, (size,), dtype='uint8', device=Device.DEFAULT) for f in frames]
+  eye = [np.eye(3, dtype=np.float32) for _ in range(2)]
+  tfm, big_tfm = (Tensor(e, device='NPY').realize() for e in eye)
+  for _ in range(2):
+    call_warp(warp, tfm, big_tfm, blobs[0], blobs[1]).realize()
+  Device.default.synchronize()
+
+
+def prune(keep: set[Path]) -> None:
+  """Drop warps for a geometry this device does not have.
+
+  jetlinkd's fallback only; removing a file scons built just makes it build again.
+  """
+  for p in CACHE_DIR.glob('warp_*_tinygrad.pkl'):
+    if p not in keep:
+      p.unlink(missing_ok=True)

--- a/openpilot/sunnypilot/accelerators/scripts/merge_replay.sh
+++ b/openpilot/sunnypilot/accelerators/scripts/merge_replay.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026-, Zeph Leggett.
+#
+# This file is part of sunnypilot and is licensed under the MIT License.
+# See the LICENSE.md file in the root directory for more details.
+#
+# Replay the two upstream changes most likely to land on top of us.
+#
+# The accelerator work sits in modeld.py beside comma's chestnut, the file
+# upstream keeps rewriting. Apply the two known changes to a throwaway
+# worktree and report where they land.
+#
+#   38760  e3def37695  reverts 38742: moves the chestnut poller wait,
+#                      helpers.chestnut_ready and one param key
+#   38684  cb85ac1f0e  fused warp and policy into one run_model JIT
+#
+# A conflict inside openpilot/sunnypilot/ is ours to rebase. A conflict anywhere
+# else means we changed a line upstream owns, and only that exits non-zero.
+#
+# Usage: merge_replay.sh [branch]   (default HEAD)
+
+set -uo pipefail
+
+REVERT=e3def37695   # revert 38742 (#38760)
+FUSED=cb85ac1f0e    # amd warp (#38684)
+
+# the revert also touches files this fork carries differently; only modeld
+# and the param key matter
+REVERT_PATHS=(openpilot/selfdrive/modeld openpilot/common/params_keys.h)
+
+BRANCH="${1:-HEAD}"
+REPO="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)" || exit 2
+
+SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/jetlink-merge-replay.XXXXXX")" || exit 2
+TREE="$SCRATCH/worktree"
+
+cleanup() {
+  git -C "$REPO" worktree remove --force "$TREE" >/dev/null 2>&1
+  rm -rf "$SCRATCH"
+  git -C "$REPO" worktree prune >/dev/null 2>&1
+}
+trap cleanup EXIT
+
+for commit in "$REVERT" "$FUSED"; do
+  if ! git -C "$REPO" cat-file -e "${commit}^{commit}" 2>/dev/null; then
+    echo "merge_replay: $commit is not in this checkout; fetch upstream first" >&2
+    exit 2
+  fi
+done
+
+# detached, so a branch checked out in another worktree still replays
+if ! git -C "$REPO" worktree add --detach "$TREE" "$BRANCH" >/dev/null 2>&1; then
+  echo "merge_replay: could not create a worktree for $BRANCH" >&2
+  exit 2
+fi
+
+git -C "$REPO" format-patch -1 --stdout "$REVERT" -- "${REVERT_PATHS[@]}" > "$SCRATCH/revert.patch" || exit 2
+git -C "$REPO" format-patch -1 --stdout "$FUSED" > "$SCRATCH/fused.patch" || exit 2
+
+head_sha="$(git -C "$TREE" rev-parse --short HEAD)"
+echo "merge replay of $BRANCH ($head_sha)"
+echo
+
+failures=0
+
+replay() {
+  local name="$1" patch="$2" out rc files outside conflicted file
+
+  echo "=== $name ==="
+  out="$(git -C "$TREE" apply --check --verbose "$patch" 2>&1)"
+  rc=$?
+  printf '%s\n' "$out"
+
+  if [ "$rc" -eq 0 ]; then
+    echo "-> clean"
+    echo
+    return
+  fi
+
+  # both shapes git uses: a hunk that would not apply, and a file it gave up on
+  files="$(printf '%s\n' "$out" |
+    sed -n -E -e 's/^error: patch failed: (.+):[0-9]+$/\1/p' \
+              -e 's/^error: (.+): patch does not apply$/\1/p' \
+              -e 's/^error: (.+): does not exist in index$/\1/p' |
+    sort -u)"
+
+  echo "-> failing hunks in:"
+  printf '%s\n' "$files" | sed 's/^/     /'
+
+  # applied for real: --check --3way returns 0 on a patch whose three-way
+  # apply leaves conflict markers
+  git -C "$TREE" apply --3way "$patch" >/dev/null 2>&1
+  conflicted="$(git -C "$TREE" diff --name-only --diff-filter=U)"
+  if [ -z "$conflicted" ]; then
+    echo "-> --3way merges it cleanly: context drift, not a real conflict"
+  else
+    # region count: run against the parent branch too, the difference is what
+    # this fork adds to a rebase
+    echo "-> --3way still conflicts in:"
+    while IFS= read -r file; do
+      echo "     $file ($(grep -c '^<<<<<<<' "$TREE/$file") region(s))"
+    done <<< "$conflicted"
+  fi
+  git -C "$TREE" reset --hard >/dev/null 2>&1
+  git -C "$TREE" clean -fdq >/dev/null 2>&1
+
+  outside="$(printf '%s\n' "$files" | grep -v '^openpilot/sunnypilot/' | grep -v '^$')"
+  if [ -n "$outside" ]; then
+    echo "-> OUTSIDE openpilot/sunnypilot/, which is upstream's to own:"
+    printf '%s\n' "$outside" | sed 's/^/     /'
+    failures=$((failures + 1))
+  else
+    echo "-> confined to openpilot/sunnypilot/, ours to rebase"
+  fi
+  echo
+}
+
+replay "38760 revert ($REVERT), modeld and params only" "$SCRATCH/revert.patch"
+replay "38684 fused warp ($FUSED)" "$SCRATCH/fused.patch"
+
+if [ "$failures" -ne 0 ]; then
+  echo "merge replay: $failures patch(es) conflict outside openpilot/sunnypilot/"
+  echo "run it against the parent branch too: a hunk that fails there as well is not ours"
+  exit 1
+fi
+echo "merge replay: nothing upstream owns conflicts"

--- a/openpilot/sunnypilot/accelerators/setup.sh
+++ b/openpilot/sunnypilot/accelerators/setup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Boot-time hardware init for the accelerator backends, run from the launcher
+# before manager starts. A backend that needs root uses sudo -n itself.
+# Never fails the launch: a backend that cannot come up reports through
+# unavailable_reason(), which becomes an offroad alert.
+cd "$(dirname "$0")" || exit 0
+for setup in */setup.sh; do
+  [ -f "$setup" ] || continue
+  bash "$setup" || echo "accelerators: ${setup%/setup.sh} setup failed" >&2
+done
+exit 0

--- a/openpilot/sunnypilot/accelerators/tests/test_accelerators.py
+++ b/openpilot/sunnypilot/accelerators/tests/test_accelerators.py
@@ -1,0 +1,204 @@
+"""
+Copyright (c) 2026-, Zeph Leggett.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+
+The answers core openpilot gets from the accelerators module.
+
+modeld, manager, hardwared and the UI all reach the Jetson through this
+module, so what is pinned here is selection: what a device with the feature
+off, on but not provisioned, and ready gets told, and that a missing package
+or a backend that hangs costs the large model and nothing else. No hardware.
+"""
+import sys
+import threading
+import time
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from openpilot.sunnypilot import accelerators
+from openpilot.sunnypilot.accelerators import Daemon
+from openpilot.sunnypilot.accelerators.jetlink import backend, helpers
+
+
+class SelectionTest(unittest.TestCase):
+  """ready() is params only, and every answer follows from three params."""
+
+  def configure(self, enabled=None, model=None, ready_sha=None, spec_sha=None, gadget_error=None):
+    params = {helpers.P_ENABLED: enabled, helpers.P_MODEL: model, helpers.P_READY: ready_sha}
+    for p in (mock.patch.object(helpers, '_get', side_effect=lambda k, d=None: params.get(k, d)),
+              mock.patch.object(helpers, 'gadget_error', return_value=gadget_error),
+              mock.patch.object(helpers, 'host_attached', return_value=False),
+              mock.patch.object(helpers, 'dormant', return_value=False),
+              mock.patch.object(helpers, 'selected_model',
+                                return_value={'name': model, 'oid': 'a' * 64} if model else None),
+              mock.patch.object(backend.spec_cache, 'load',
+                                return_value=SimpleNamespace(sha256=spec_sha) if spec_sha else None)):
+      p.start()
+      self.addCleanup(p.stop)
+    helpers._last_configured = 0.0
+
+  def test_disabled_by_absence(self):
+    self.configure(enabled=None, model='m', ready_sha='a' * 64, spec_sha='a' * 64)
+    self.assertFalse(accelerators.present())
+    self.assertFalse(accelerators.ready())
+    self.assertIsNone(accelerators.unavailable_reason())
+    self.assertFalse(accelerators.uses_stock_runner())
+
+  def test_disabled_explicitly(self):
+    self.configure(enabled=False, model='m', ready_sha='a' * 64, spec_sha='a' * 64, gadget_error='no gadget')
+    self.assertFalse(accelerators.present())
+    self.assertFalse(accelerators.ready())
+    # A device with the feature off is never nagged about its kernel.
+    self.assertIsNone(accelerators.unavailable_reason())
+    self.assertFalse(accelerators.uses_stock_runner())
+
+  def test_enabled_but_not_provisioned(self):
+    self.configure(enabled=True, model='m', ready_sha=None, spec_sha=None)
+    self.assertFalse(accelerators.ready())
+    self.assertIsNone(accelerators.unavailable_reason())
+    self.assertIsNone(accelerators.active_model_name())
+
+  def test_enabled_with_a_broken_gadget_says_why(self):
+    self.configure(enabled=True, model='m', ready_sha='a' * 64, spec_sha='a' * 64, gadget_error='no gadget')
+    self.assertFalse(accelerators.ready())
+    self.assertEqual(accelerators.unavailable_reason(), 'no gadget')
+
+  def test_ready(self):
+    self.configure(enabled=True, model='m', ready_sha='a' * 64, spec_sha='a' * 64)
+    self.assertTrue(accelerators.ready())
+    self.assertIsNone(accelerators.unavailable_reason())
+    self.assertTrue(accelerators.uses_stock_runner())
+
+  def test_an_old_engine_is_not_the_new_selection(self):
+    self.configure(enabled=True, model='m', ready_sha='b' * 64, spec_sha='b' * 64)
+    self.assertFalse(accelerators.ready())
+
+  def test_stock_runner_is_the_toggle_alone(self):
+    # configuration only, never link state or ready(): a late boot cannot move
+    # manager between modelds mid-drive. The model defaults through
+    # selected_model(), so it is not part of it either
+    self.configure(enabled=True, model=None)
+    self.assertTrue(accelerators.uses_stock_runner())
+    self.configure(enabled=True, model='m')
+    with mock.patch.object(helpers, 'link_configured', return_value=False):
+      self.assertTrue(accelerators.uses_stock_runner())
+    self.configure(enabled=None, model='m')
+    with mock.patch.object(helpers, 'link_configured', return_value=True):
+      self.assertFalse(accelerators.uses_stock_runner())
+
+  def test_present_is_usb_independent_while_dormant(self):
+    self.configure(enabled=True, model='m')
+    with mock.patch.object(helpers, 'dormant', return_value=True), \
+         mock.patch.object(helpers, 'CC_ORIENTATION', mock.Mock(read_text=lambda: '1')):
+      self.assertTrue(accelerators.present())
+
+
+class MissingPackageTest(unittest.TestCase):
+  """The jetlink client package can be absent; nothing may raise for it."""
+
+  def hide_package(self):
+    p = mock.patch.dict(sys.modules, {'jetlink': None, 'jetlink.client': None})
+    p.start()
+    self.addCleanup(p.stop)
+    backend._missing_reported = False
+
+  def test_prepare_answers_false(self):
+    self.hide_package()
+    with mock.patch.object(backend.cloudlog, 'warning') as warn:
+      self.assertFalse(accelerators.prepare())
+      self.assertFalse(accelerators.prepare())
+    # Once, not per poll.
+    self.assertEqual(warn.call_count, 1)
+
+  def test_make_model_state_answers_none(self):
+    self.hide_package()
+    self.assertIsNone(accelerators.make_model_state(1928, 1208, object()))
+
+  def test_the_cheap_questions_still_import_and_answer(self):
+    self.hide_package()
+    with mock.patch.object(helpers, '_get', return_value=None):
+      self.assertFalse(accelerators.ready())
+      self.assertFalse(accelerators.uses_stock_runner())
+
+
+class DaemonTest(unittest.TestCase):
+  def test_jetlinkd_is_offered_and_gated_on_enabled(self):
+    (d,) = accelerators.daemons()
+    self.assertIsInstance(d, Daemon)
+    self.assertEqual(d.name, 'jetlinkd')
+    __import__(d.module)
+    with mock.patch.object(helpers, 'enabled', return_value=False):
+      self.assertFalse(d.should_run(False, None, None))
+    with mock.patch.object(helpers, 'enabled', return_value=True):
+      self.assertTrue(d.should_run(False, None, None))
+
+
+class TestProgress(unittest.TestCase):
+  def test_a_missing_param_is_no_progress(self):
+    with mock.patch.object(accelerators, 'Params') as params:
+      params.return_value.get.return_value = None
+      self.assertIsNone(accelerators.progress())
+
+  def test_a_dict_comes_through(self):
+    payload = {'stage': 'build', 'frac': 0.5, 'msg': ''}
+    with mock.patch.object(accelerators, 'Params') as params:
+      params.return_value.get.return_value = payload
+      self.assertEqual(accelerators.progress(), payload)
+
+  def test_a_non_dict_is_ignored(self):
+    with mock.patch.object(accelerators, 'Params') as params:
+      params.return_value.get.return_value = "build 50%"
+      self.assertIsNone(accelerators.progress())
+
+  def test_an_unknown_key_does_not_take_down_the_ui(self):
+    # A params library older than this key raises rather than returning None.
+    with mock.patch.object(accelerators, 'Params') as params:
+      params.return_value.get.side_effect = RuntimeError("UnknownKeyName")
+      self.assertIsNone(accelerators.progress())
+
+  def test_reporting_never_raises(self):
+    # Called from except handlers in the daemons.
+    with mock.patch.object(accelerators, 'Params') as params:
+      params.return_value.put.side_effect = RuntimeError("params gone")
+      accelerators.report_progress('build', 0.5)
+      params.return_value.remove.side_effect = RuntimeError("params gone")
+      accelerators.clear_progress()
+
+
+class TestShutdown(unittest.TestCase):
+  def test_disabled_costs_one_param_read_and_nothing_else(self):
+    with mock.patch.object(helpers, 'enabled', return_value=False), \
+         mock.patch.object(backend, 'shutdown') as request:
+      accelerators.shutdown('car battery')
+    request.assert_not_called()
+
+  def test_the_request_is_forwarded_with_the_bound(self):
+    with mock.patch.object(helpers, 'enabled', return_value=True), \
+         mock.patch.object(backend, 'shutdown') as request:
+      accelerators.shutdown('car battery', timeout=3.0)
+    request.assert_called_once_with('car battery', 3.0)
+
+  def test_a_backend_that_hangs_cannot_hold_hardwared(self):
+    release = threading.Event()
+    self.addCleanup(release.set)
+    with mock.patch.object(helpers, 'enabled', return_value=True), \
+         mock.patch.object(backend, 'shutdown', side_effect=lambda *a: release.wait(30)), \
+         mock.patch.object(accelerators.cloudlog, 'warning') as warn:
+      t0 = time.monotonic()
+      accelerators.shutdown('car battery', timeout=0.2)
+      self.assertLess(time.monotonic() - t0, 2.0)
+    warn.assert_called_once()
+
+  def test_a_backend_that_raises_is_logged_not_propagated(self):
+    with mock.patch.object(helpers, 'enabled', return_value=True), \
+         mock.patch.object(backend, 'shutdown', side_effect=RuntimeError('no')), \
+         mock.patch.object(accelerators.cloudlog, 'exception') as log:
+      accelerators.shutdown('car battery', timeout=1.0)
+    log.assert_called_once()
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/openpilot/sunnypilot/accelerators/tests/test_native_equivalence.py
+++ b/openpilot/sunnypilot/accelerators/tests/test_native_equivalence.py
@@ -1,0 +1,364 @@
+"""
+Copyright (c) 2026-, Zeph Leggett.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+
+A device with comma's board fitted must behave exactly as it does on develop.
+
+The upstreaming plan rests on one claim: chestnut is native, at its own lines,
+and jetlink is five sites beside it a chestnut device never reaches. This reads
+modeld.py rather than importing it (that costs tinygrad, usb1 and a vision
+stream) and runs the decide, load and status-publisher statements verbatim
+under fakes.
+
+Two calls that must not happen: a fitted board with PCIe trained asks
+accelerators nothing, because `not CHESTNUT` is the first term; no board and
+the link off stops at ready(), so prepare() never opens a link. The rest pins
+the footprint: chestnut statements are develop's byte for byte, and the module
+is reachable from four call sites in five hunks.
+"""
+import ast
+import subprocess
+import textwrap
+import threading
+import time
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+from openpilot.common.params import Params
+from openpilot.sunnypilot import accelerators
+from openpilot.sunnypilot.accelerators.jetlink import helpers
+
+MODELD = Path(__file__).resolve().parents[3] / 'selfdrive' / 'modeld' / 'modeld.py'
+
+# the zoompilot parent carries comma's chestnut unmodified, so it is the
+# baseline rather than any older upstream tag
+BASELINE = 'develop'
+
+# everything core openpilot may call on the module; a name added here without
+# a plan entry is a widened seam
+ACCELERATOR_CALLS = {'ready', 'prepare', 'make_model_state', 'make_status_publisher'}
+
+
+def _parse(src: str) -> list[ast.stmt]:
+  tree = ast.parse(src)
+  main = next(n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == 'main')
+  return main.body
+
+
+def _assigns(stmt: ast.stmt, name: str) -> bool:
+  return isinstance(stmt, ast.Assign) and any(isinstance(t, ast.Name) and t.id == name for t in stmt.targets)
+
+
+def _index(body: list[ast.stmt], pred, what: str) -> int:
+  for i, stmt in enumerate(body):
+    if pred(stmt):
+      return i
+  raise AssertionError(f"modeld.py main() no longer has {what}; this test is describing a file that moved on")
+
+
+def _tests_name(stmt: ast.stmt, name: str) -> bool:
+  return isinstance(stmt, ast.If) and isinstance(stmt.test, ast.Name) and stmt.test.id == name
+
+
+def _run(src: str, stmts: list[ast.stmt]) -> str:
+  """The verbatim source of a run of statements, dedented so it can be exec'd."""
+  lines = src.splitlines()
+  return textwrap.dedent('\n'.join(lines[stmts[0].lineno - 1:stmts[-1].end_lineno]))
+
+
+def _git_show(ref: str, path: str) -> str | None:
+  """The file at a ref, or None off a checkout that has it. Never raises."""
+  try:
+    out = subprocess.run(['git', 'show', f'{ref}:{path}'], cwd=MODELD.parents[3],
+                         capture_output=True, text=True, timeout=30, check=False)
+  except (OSError, subprocess.SubprocessError):
+    return None
+  return out.stdout if out.returncode == 0 else None
+
+
+class FakeAccelerators:
+  """The accelerators module as modeld sees it, recording every call.
+
+  prepare() answers the most permissive thing it can, so a call that should
+  never have happened fails twice over: on the recording, and on JETLINK being
+  true where the plan says a chestnut owns the drive.
+  """
+
+  def __init__(self, ready=None):
+    self.calls: list[str] = []
+    self._ready = ready if ready is not None else (lambda: True)
+
+  def ready(self) -> bool:
+    self.calls.append('ready')
+    return self._ready()
+
+  def prepare(self) -> bool:
+    self.calls.append('prepare')
+    return True
+
+  def make_model_state(self, cam_w, cam_h, small=None):
+    self.calls.append('make_model_state')
+    return SimpleNamespace(chestnut=True, big_model_available=True, big_model_state='joining')
+
+  def make_status_publisher(self, pm, model):
+    self.calls.append('make_status_publisher')
+    return SimpleNamespace(send=lambda *a: None, big=False)
+
+
+class FakeParams:
+  """Params for the block under test only. The real ones belong to a car."""
+
+  def __init__(self):
+    self.store: dict[str, bool] = {}
+
+  def put_bool(self, key, value):
+    self.store[key] = bool(value)
+
+  def get_bool(self, key):
+    return bool(self.store.get(key))
+
+  def remove(self, key):
+    self.store.pop(key, None)
+
+
+class FakeMessaging:
+  """One chestnutState and then silence, which is the poller wait's fast path."""
+
+  def __init__(self):
+    self.polled = 0
+
+  # Capitalised because messaging's is.
+  def Poller(self):
+    return self
+
+  def poll(self, timeout_ms):
+    self.polled += 1
+    return [object()] if self.polled == 1 else []
+
+  def sub_sock(self, name, poller=None, conflate=False):
+    return object()
+
+  def recv_one_or_none(self, sock):
+    return SimpleNamespace(valid=True, chestnutState=object())
+
+
+class FakeModelState:
+  def __init__(self, cam_w, cam_h, chestnut):
+    self.chestnut = chestnut
+
+  def warmup(self):
+    pass
+
+
+class ModeldSeam:
+  """modeld's own statements, lifted out of main() and runnable with no hardware."""
+
+  def __init__(self):
+    self.src = MODELD.read_text()
+    self.body = _parse(self.src)
+
+    decide_start = _index(self.body, lambda s: _assigns(s, 'chestnut_available'), 'the chestnut_available assignment')
+    self.decide_end = _index(self.body, lambda s: _assigns(s, 'JETLINK'), 'the JETLINK assignment')
+    self.decide = _run(self.src, self.body[decide_start:self.decide_end + 1])
+
+    load_start = _index(self.body, lambda s: _assigns(s, 'model') and isinstance(s.value, ast.Constant) and s.value.value is None,
+                        'the `model = None` that opens the load')
+    load_end = _index(self.body, lambda s: isinstance(s, ast.Assert) and s.lineno > self.body[load_start].lineno,
+                      'the `assert model is not None` that closes the load')
+    self.load = _run(self.src, self.body[load_start:load_end + 1])
+
+    pub_start = _index(self.body, lambda s: _assigns(s, 'chestnut_state'), 'the chestnut_state assignment')
+    self.publish = _run(self.src, self.body[pub_start:pub_start + 2])
+
+    self.realtime = _index(self.body, lambda s: isinstance(s, ast.Expr) and isinstance(s.value, ast.Call)
+                           and isinstance(s.value.func, ast.Name) and s.value.func.id == 'config_realtime_process',
+                           'the config_realtime_process call')
+
+  def decide_and_load(self, accel, present: bool, compiled: bool, trained: bool) -> dict:
+    """Run the three blocks in order, exactly as main() does, and hand back its locals."""
+    env: dict[str, str] = {}
+    scope = {
+      'chestnut_present': lambda: present,
+      'chestnut_compiled': lambda: compiled,
+      'chestnut_ready': lambda state: trained,
+      'messaging': FakeMessaging(),
+      # A short deadline: a board that never trains would otherwise wait out
+      # deviceState's real period for a message the fake stops sending.
+      'SERVICE_LIST': {'deviceState': SimpleNamespace(frequency=20)},
+      'time': time,
+      'threading': threading,
+      'os': SimpleNamespace(environ=env),
+      'Params': FakeParams,
+      'accelerators': accel,
+      'cloudlog': SimpleNamespace(warning=lambda *a, **k: None, exception=lambda *a, **k: None),
+      'ModelState': FakeModelState,
+      'ChestnutState': lambda pm, chestnut: SimpleNamespace(send=lambda *a: None, big=chestnut),
+      'BIG_MODEL_TIMEOUT': 5,
+      'vipc_client_main': SimpleNamespace(width=1928, height=1208),
+      'pm': object(),
+    }
+    for block in (self.decide, self.load, self.publish):
+      # in a function: the chestnut load declares `nonlocal big_model`. What
+      # each block binds becomes a global for the next, which is how JETLINK
+      # reaches the load
+      wrapped = 'def _block():\n' + textwrap.indent(block, '  ') + '\n  return locals()\n'
+      # exec of modeld's own source is the point of this file.
+      exec(compile(wrapped, str(MODELD), 'exec'), scope)
+      scope.update(scope.pop('_block')())
+    scope['environ'] = env
+    return scope
+
+
+class NativeEquivalence(unittest.TestCase):
+  """What a device gets asked, for the two configurations that must ask nothing."""
+
+  @classmethod
+  def setUpClass(cls):
+    cls.seam = ModeldSeam()
+
+  def test_a_trained_chestnut_never_asks_the_accelerator_module(self):
+    accel = FakeAccelerators()
+    scope = self.seam.decide_and_load(accel, present=True, compiled=True, trained=True)
+
+    self.assertTrue(scope['CHESTNUT'])
+    self.assertFalse(scope['JETLINK'])
+    # not "prepare was not called": nothing was, because `not CHESTNUT` is
+    # the first term
+    self.assertEqual(accel.calls, [], "a fitted chestnut asked the accelerator module something")
+    self.assertEqual(scope['environ'].get('HCQDEV_WAIT_TIMEOUT_MS'), '3000')
+    self.assertTrue(scope['model'].chestnut)
+    self.assertIsNotNone(scope['chestnut_state'])
+
+  def test_no_board_and_the_link_off_stops_at_ready(self):
+    # the real module with the link off: ready() reads one param and nothing
+    # opens a gadget
+    Params().remove(helpers.P_ENABLED)
+    self.assertFalse(accelerators.ready())
+
+    accel = FakeAccelerators(ready=accelerators.ready)
+    scope = self.seam.decide_and_load(accel, present=False, compiled=False, trained=False)
+
+    self.assertFalse(scope['CHESTNUT'])
+    self.assertFalse(scope['JETLINK'])
+    self.assertEqual(accel.calls, ['ready'], "the disabled link was asked more than whether it is ready")
+    self.assertNotIn('prepare', accel.calls)
+    self.assertNotIn('make_model_state', accel.calls)
+    self.assertNotIn('make_status_publisher', accel.calls)
+    # The small model drives, and nothing publishes accelerator status.
+    self.assertFalse(scope['model'].chestnut)
+    self.assertIsNone(scope['chestnut_state'])
+
+  def test_a_board_that_never_trains_falls_through_to_the_question(self):
+    # a chestnut device does ask, once, when the board is fitted but PCIe never
+    # trains inside the poller wait: CHESTNUT is false, same as a bare device
+    accel = FakeAccelerators(ready=lambda: False)
+    scope = self.seam.decide_and_load(accel, present=True, compiled=True, trained=False)
+
+    self.assertFalse(scope['CHESTNUT'])
+    self.assertFalse(scope['JETLINK'])
+    self.assertEqual(accel.calls, ['ready'])
+
+  def test_the_link_is_decided_before_the_process_goes_realtime(self):
+    # prepare() starts tinygrad's device thread; after config_realtime_process
+    # it would inherit SCHED_FIFO 54 on core 7 and preempt the frame loop
+    self.assertLess(self.seam.decide_end, self.seam.realtime,
+                    "the JETLINK decision moved after config_realtime_process")
+
+
+class UpstreamFootprint(unittest.TestCase):
+  """modeld.py stays five hunks wide, and chestnut's lines stay develop's."""
+
+  @classmethod
+  def setUpClass(cls):
+    cls.src = MODELD.read_text()
+    cls.tree = ast.parse(cls.src)
+    cls.body = _parse(cls.src)
+
+  def _baseline_body(self) -> list[ast.stmt] | None:
+    src = _git_show(BASELINE, 'openpilot/selfdrive/modeld/modeld.py')
+    if src is None:
+      return None
+    self.baseline_src = src
+    return _parse(src)
+
+  def _skip_without_baseline(self, body):
+    if body is None:
+      self.skipTest(f"no {BASELINE} here: not a checkout of this fork, or the branch is gone")
+
+  def test_the_module_is_reachable_from_four_calls_in_five_hunks(self):
+    lines = self.src.splitlines()
+    calls = [(n.lineno, n.attr) for n in ast.walk(self.tree)
+             if isinstance(n, ast.Attribute) and isinstance(n.value, ast.Name) and n.value.id == 'accelerators']
+    sites = [f"  modeld.py:{lineno} {lines[lineno - 1].strip()}" for lineno, _ in calls]
+
+    # the five hunks: decision, load, status publisher, fallback re-raise and
+    # the modelDataV2SP fields. Lines closer than a hunk's context are one
+    # hunk, so `if not JETLINK:` is part of the load
+    jetlink = sorted({n.lineno for n in ast.walk(self.tree) if isinstance(n, ast.Name) and n.id == 'JETLINK'}
+                     | {lineno for lineno, _ in calls})
+    hunk_starts = [line for i, line in enumerate(jetlink) if i == 0 or line - jetlink[i - 1] > 8]
+    detail = '\n'.join(sites + [f"  hunks start at lines {hunk_starts}"])
+
+    self.assertEqual({attr for _, attr in calls}, ACCELERATOR_CALLS, f"the seam widened:\n{detail}")
+    self.assertEqual(len(calls), 4, f"expected ready/prepare/make_model_state/make_status_publisher and nothing else:\n{detail}")
+    self.assertEqual(len(hunk_starts), 5, f"modeld.py's jetlink path is no longer five hunks:\n{detail}")
+
+  def test_the_chestnut_block_never_mentions_the_accelerator_module(self):
+    for stmt in ast.walk(self.tree):
+      if not _tests_name(stmt, 'CHESTNUT'):
+        continue
+      # body only: the orelse of the load is the `elif JETLINK` hunk.
+      names = {n.id for stmt_ in stmt.body for n in ast.walk(stmt_) if isinstance(n, ast.Name)}
+      self.assertNotIn('accelerators', names, f"an `if CHESTNUT:` block at line {stmt.lineno} reaches the accelerator module")
+      self.assertNotIn('JETLINK', names, f"an `if CHESTNUT:` block at line {stmt.lineno} reads JETLINK")
+
+  def test_chestnut_state_is_the_baselines(self):
+    body = self._baseline_body()
+    self._skip_without_baseline(body)
+    ours = next((n for n in self.tree.body if isinstance(n, ast.ClassDef) and n.name == 'ChestnutState'), None)
+    theirs = next((n for n in ast.parse(self.baseline_src).body if isinstance(n, ast.ClassDef) and n.name == 'ChestnutState'), None)
+    self.assertIsNotNone(ours, "ChestnutState left modeld.py again")
+    self.assertIsNotNone(theirs)
+    self.assertEqual(ast.get_source_segment(self.src, ours), ast.get_source_segment(self.baseline_src, theirs),
+                     f"class ChestnutState differs from {BASELINE}")
+
+  def test_the_poller_wait_and_the_chestnut_load_are_the_baselines(self):
+    body = self._baseline_body()
+    self._skip_without_baseline(body)
+
+    def wait(b):
+      return next(s for s in b if _tests_name(s, 'chestnut_available'))
+
+    def load(b):
+      return next(s for s in b if _tests_name(s, 'CHESTNUT') and len(s.body) > 2)
+
+    self.assertEqual(_run(self.src, [wait(self.body)]), _run(self.baseline_src, [wait(body)]),
+                     f"the chestnutState poller wait differs from {BASELINE}")
+    # The body only. Our orelse is the `elif JETLINK:` hunk, which is the point.
+    self.assertEqual(_run(self.src, load(self.body).body), _run(self.baseline_src, load(body).body),
+                     f"the `if CHESTNUT:` load differs from {BASELINE}")
+
+  def test_the_fallback_is_the_baseline_behind_one_guard(self):
+    body = self._baseline_body()
+    self._skip_without_baseline(body)
+
+    def handler(b):
+      return next(h for n in b for x in ast.walk(n) if isinstance(x, ast.Try)
+                  for h in x.handlers if any('ChestnutActive' in ast.dump(s) for s in ast.walk(h)))
+
+    ours = handler(self.body)
+    theirs = handler(body)
+    guard = ours.body[0]
+    self.assertTrue(_tests_name(guard, 'JETLINK') and isinstance(guard.body[0], ast.Raise),
+                    "the fallback no longer opens with `if JETLINK: raise`")
+    # everything after the guard is develop's handler: a small-model fault is
+    # still fatal and a chestnut still demotes itself
+    self.assertEqual(_run(self.src, ours.body[1:]), _run(self.baseline_src, theirs.body),
+                     f"the big-model fallback differs from {BASELINE}")
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/openpilot/sunnypilot/accelerators/tests/test_selfdrived_traces.py
+++ b/openpilot/sunnypilot/accelerators/tests/test_selfdrived_traces.py
@@ -1,0 +1,182 @@
+"""
+Copyright (c) 2026-, Zeph Leggett.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+
+Every event a big model raises, in order, for three drives.
+
+Asserted as the whole list at every step, native and sunnypilot together,
+because the failures that reached the car were extra events: a "Big Model
+Ready" chime after a failed load, and a jetlink drive raising the native
+bigModelFailed beside the link-lost alert.
+
+Three traces, all through the real SelfdriveD.update_events with the
+accelerator adapter in place:
+
+  (a) a chestnut that loads:   loading, then one chime on the first big frame
+  (b) a chestnut that fails:   loading, one failure, and never a chime
+  (c) a jetlink that joins:    loading while modelV2 is held back, one chime
+                               when it promotes, and on a fall while engaged
+                               the native bigModelFailed beside bigModelLinkLost
+                               on every tick until the driver disengages
+
+The pair in (c) is deliberate. The main state machine consumes native events
+only and cancels a soft disable the tick its event goes away, so a one-tick
+sunnypilot event never disabled anything and the car stayed engaged on a 5 m
+plan. bigModelLinkLost is what MADS reads and carries the guidance.
+
+update_events runs as far as its initialization gate, past the big model
+block and the adapter call and short of everything needing a car.
+"""
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from openpilot.cereal import custom, messaging
+from openpilot.selfdrive.selfdrived.events import EVENT_NAME, Events
+from openpilot.selfdrive.selfdrived.selfdrived import SelfdriveD
+from openpilot.sunnypilot.selfdrive.selfdrived.accelerator_events import AcceleratorEvents
+from openpilot.sunnypilot.selfdrive.selfdrived.events import EVENT_NAME_SP, EventsSP
+
+AcceleratorState = custom.ModelDataV2SP.AcceleratorState
+
+# added at the gate on every step, so it is in every expected list rather
+# than filtered out
+INIT = 'selfdriveInitializing'
+
+SERVICES = ['modelV2', 'modelDataV2SP', 'controlsState', 'deviceState', 'lateralManeuverPlan', 'alertDebug']
+
+
+def make_selfdrived(chestnut_present: bool, enabled: bool) -> SelfdriveD:
+  """A SelfdriveD with no processes, no live params and no car.
+
+  The same fixture exists as setUp methods under two selfdrived test trees;
+  importing a TestCase to reuse one would re-run its tests here.
+  """
+  sd = SelfdriveD.__new__(SelfdriveD)
+  sd.sm = messaging.SubMaster(SERVICES)
+  for service in ('modelV2', 'modelDataV2SP', 'deviceState'):
+    sd.sm.data[service] = sd.sm[service].as_builder()
+    sd.sm.valid[service] = True
+  sd.sm.seen['deviceState'] = sd.sm.alive['deviceState'] = True
+  sd.sm['deviceState'].chestnutPresent = chestnut_present
+  sd.events = Events()
+  sd.events_sp = EventsSP()
+  sd.accelerator_events = AcceleratorEvents()
+  sd.params = Mock()
+  sd.big_model_loading = sd.big_model_active = sd.big_model_failed = sd.big_model_running = False
+  sd.big_model_ready_t = 0.
+  sd.enabled = enabled
+  sd.initialized = False
+  sd.startup_event = None
+  return sd
+
+
+class TraceTest(unittest.TestCase):
+  def step(self, loading=False, active=None, big=False, alive=True,
+           state=AcceleratorState.none, available=False) -> tuple[list[str], list[str]]:
+    """One update_events, and everything it raised."""
+    sd = self.sd
+    sd.params.get_bool.return_value = loading
+    sd.params.get.return_value = active
+    # modelV2 and modelDataV2SP are published together; the native block reads
+    # a board as failed only once a modelV2 it had has gone away
+    for service in ('modelV2', 'modelDataV2SP'):
+      sd.sm.alive[service] = alive
+      sd.sm.seen[service] = sd.sm.seen[service] or alive
+    sd.sm['modelV2'].big = big
+    sd.sm['modelDataV2SP'].acceleratorState = state
+    sd.sm['modelDataV2SP'].bigModelAvailable = available
+    sd.update_events(SimpleNamespace())
+    return ([EVENT_NAME[n] for n in sd.events.names], [EVENT_NAME_SP[n] for n in sd.events_sp.names])
+
+
+class ChestnutTraces(TraceTest):
+  """comma's board, which is loaded before modelV2 exists and never rejoins."""
+
+  def setUp(self):
+    self.sd = make_selfdrived(chestnut_present=True, enabled=True)
+
+  def test_trace_a_a_load_that_works_chimes_once(self):
+    # modeld holds modelV2 back for the load, so the driver is kept out.
+    self.assertEqual(self.step(loading=True, alive=False), ([INIT, 'bigModelLoading'], []))
+    # ChestnutLoading clears, but nothing big has been published yet.
+    self.assertEqual(self.step(loading=False, active=True, alive=False), ([INIT], []))
+    # The first big frame, and the only chime in the drive.
+    self.assertEqual(self.step(loading=False, active=True, big=True), ([INIT], ['bigModelReady']))
+    for _ in range(10):
+      self.assertEqual(self.step(loading=False, active=True, big=True), ([INIT], []))
+
+  def test_trace_b_a_load_that_fails_never_chimes(self):
+    self.assertEqual(self.step(loading=True, alive=False), ([INIT, 'bigModelLoading'], []))
+    # modeld writes ChestnutActive=False first: the load timed out or threw.
+    self.assertEqual(self.step(loading=True, active=False, alive=False), ([INIT, 'bigModelLoading', 'bigModelFailed'], []))
+    # and clears ChestnutLoading once the small model is up; that second edge
+    # used to chime "Big Model Ready" over "Big Model Failed"
+    self.assertEqual(self.step(loading=False, active=False), ([INIT], []))
+    for _ in range(10):
+      self.assertEqual(self.step(loading=False, active=False), ([INIT], []))
+
+  def test_a_board_that_falls_back_mid_drive_is_the_native_failure_alone(self):
+    self.assertEqual(self.step(loading=False, active=True, big=True), ([INIT], ['bigModelReady']))
+    # The adapter must not double this: acceleratorState is none for a board.
+    self.assertEqual(self.step(loading=False, active=False, big=False), ([INIT, 'bigModelFailed'], []))
+
+
+class JetlinkTrace(TraceTest):
+  """A Jetson on its own power: it joins onto a modelV2 the small model owns.
+
+  Nothing in this trace writes ChestnutLoading or ChestnutActive - the joining
+  state stopped doing that - so the native block sees a device with no board
+  and stays silent for the whole drive. Everything said is said by the
+  adapter, from modelV2.big and the additive modelDataV2SP fields.
+  """
+
+  def setUp(self):
+    self.sd = make_selfdrived(chestnut_present=False, enabled=True)
+
+  def test_trace_c_join_promote_and_lose_the_link(self):
+    # Joining before camerad and modeld have a frame out: the same block on
+    # the driver as a chestnut load, and for the same reason.
+    self.assertEqual(self.step(state=AcceleratorState.joining, alive=False), ([INIT, 'bigModelLoading'], []))
+    # modelV2 starts publishing on the small model. The join carries on in the
+    # background and stops blocking the moment there is something to drive on.
+    self.assertEqual(self.step(state=AcceleratorState.joining), ([INIT], []))
+    # The promotion gate: a big model is there, waiting for a disengagement.
+    self.assertEqual(self.step(state=AcceleratorState.joining, available=True), ([INIT], ['bigModelAvailable']))
+    self.assertEqual(self.step(state=AcceleratorState.joining, available=True), ([INIT], []))
+    # It swaps. One chime, from modelV2.big and nothing else.
+    self.assertEqual(self.step(state=AcceleratorState.running, big=True), ([INIT], ['bigModelReady']))
+    for _ in range(10):
+      self.assertEqual(self.step(state=AcceleratorState.running, big=True), ([INIT], []))
+    # the link drops while engaged: both events on every tick, both from the
+    # adapter. The native one walks the main state machine through its 3 s
+    # soft disable; a single tick of either would be cancelled the next
+    for _ in range(10):
+      self.assertEqual(self.step(state=AcceleratorState.retrying), ([INIT, 'bigModelFailed'], ['bigModelLinkLost']))
+    # The soft disable lands and the driver is out. Nothing more is said.
+    self.sd.enabled = False
+    for _ in range(10):
+      self.assertEqual(self.step(state=AcceleratorState.retrying), ([INIT], []))
+    # And it comes back, which a chestnut never does.
+    self.assertEqual(self.step(state=AcceleratorState.running, big=True), ([INIT], ['bigModelReady']))
+    self.sd.enabled = True
+    self.assertEqual(self.step(state=AcceleratorState.running, big=True), ([INIT], []))
+
+  def test_a_link_that_drops_while_disengaged_says_nothing(self):
+    self.sd.enabled = False
+    self.assertEqual(self.step(state=AcceleratorState.running, big=True), ([INIT], ['bigModelReady']))
+    # the small model carries on; engaging afterwards does not replay a fall
+    # the driver never felt
+    self.assertEqual(self.step(state=AcceleratorState.retrying), ([INIT], []))
+    self.sd.enabled = True
+    self.assertEqual(self.step(state=AcceleratorState.retrying), ([INIT], []))
+
+  def test_nothing_is_said_on_a_device_with_no_accelerator_at_all(self):
+    for _ in range(10):
+      self.assertEqual(self.step(), ([INIT], []))
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/openpilot/sunnypilot/modeld_v2/tests/test_combined_pkl_loader.py
+++ b/openpilot/sunnypilot/modeld_v2/tests/test_combined_pkl_loader.py
@@ -33,7 +33,9 @@ class TestFindDrivingPkl(OpenpilotTestCase):
     bundle = DummyBundle(models=[])
     assert _find_driving_pkl(bundle) is None
 
-  def test_returns_none_when_pkl_not_on_disk(self):
+  def test_returns_none_when_pkl_not_on_disk(self, tmp_path, monkeypatch):
+    from openpilot.common.hardware import hw
+    monkeypatch.setattr(hw.Paths, 'model_root', staticmethod(lambda: str(tmp_path)))
     bundle = DummyBundle(models=[
       DummyModel('vision', 'driving_fof_tinygrad.pkl'),
       DummyModel('policy', 'driving_fof_tinygrad.pkl'),

--- a/openpilot/sunnypilot/modeld_v2/tests/test_fallback.py
+++ b/openpilot/sunnypilot/modeld_v2/tests/test_fallback.py
@@ -6,16 +6,14 @@ See the LICENSE.md file in the root directory for more details.
 """
 
 import io
-import requests
 
-from openpilot.common.file_chunker import get_chunk_name
+from openpilot.common.file_chunker import get_chunk_name, get_manifest_path
 from openpilot.common.hardware import hw
 from openpilot.common.test import OpenpilotTestCase
 from openpilot.selfdrive.modeld.helpers import dump_oob
 import openpilot.sunnypilot.modeld_v2.modeld as modeld_module
 from openpilot.sunnypilot.modeld_v2.tests import helpers as tests_helpers
 from openpilot.sunnypilot.modeld_v2.tests.helpers import DummyModel, DummyBundle, CAM_W, CAM_H
-from openpilot.sunnypilot.models.fetcher import ModelParser, ModelFetcher
 
 tmp_path = tests_helpers.tmp_path
 
@@ -36,12 +34,12 @@ class TestFallback(OpenpilotTestCase):
     assert big_pkl is not None and lebowski_file in big_pkl
     assert small_pkl is not None and tsfdo_file in small_pkl
 
-  def test_download_models_and_init_modelstate_fallback(self, tmp_path, monkeypatch):
+  def test_chunked_models_and_init_modelstate_fallback(self, tmp_path, monkeypatch):
     monkeypatch.setattr(hw.Paths, 'model_root', staticmethod(lambda: str(tmp_path)))
-    big_json = requests.get(ModelFetcher.MODEL_URL_CHESTNUT).json()
-    big_bundle = ModelParser.parse_models(big_json)[-1]
-    small_json = requests.get(ModelFetcher.MODEL_URL).json()
-    small_bundle = ModelParser.parse_models(small_json)[-1]
+    # Loader behavior must not depend on whichever model a live catalog lists
+    # last today. Keep both artifacts local, combined and chunked.
+    big_bundle = DummyBundle(models=[DummyModel('supercombo', 'driving_test_big_tinygrad.pkl')])
+    small_bundle = DummyBundle(models=[DummyModel('supercombo', 'driving_test_small_tinygrad.pkl')])
 
     buf = io.BytesIO()
     dump_oob(tests_helpers.make_pkl_data(tests_helpers.ARCHETYPES['supercombo_non20hz']), buf)
@@ -49,8 +47,9 @@ class TestFallback(OpenpilotTestCase):
 
     for bundle in (big_bundle, small_bundle):
       artifact = bundle.models[0].artifact
-      for i in range(len(artifact.chunks)):
-        (tmp_path / get_chunk_name(artifact.fileName, i, len(artifact.chunks))).write_bytes(oob_bytes if i == 0 else b"")
+      (tmp_path / get_manifest_path(artifact.fileName)).write_text('2')
+      for i in range(2):
+        (tmp_path / get_chunk_name(artifact.fileName, i, 2)).write_bytes(oob_bytes if i == 0 else b"")
 
     monkeypatch.setattr(modeld_module, 'get_active_bundle', lambda params=None, *, chestnut=None: small_bundle)
     assert modeld_module.ModelState(CAM_W, CAM_H, chestnut=False).chestnut is False

--- a/openpilot/sunnypilot/models/fetcher.py
+++ b/openpilot/sunnypilot/models/fetcher.py
@@ -12,6 +12,7 @@ from requests.exceptions import (SSLError, RequestException, HTTPError)
 from openpilot.common.params import Params
 from openpilot.common.swaglog import cloudlog
 from openpilot.common.hardware.hw import Paths
+from openpilot.common.file_chunker import get_chunk_name, get_manifest_path
 from openpilot.sunnypilot.models.helpers import is_bundle_version_compatible
 from openpilot.cereal import custom
 
@@ -42,20 +43,34 @@ class ModelParser:
     if "chunks" in artifact_data:
       artifact.chunks = [ModelParser._parse_chunk(chunk_data) for chunk_data in artifact_data["chunks"]]
 
-      try:
-        model_dir = Paths.model_root()
-        os.makedirs(model_dir, exist_ok=True)
-        manifest_path = os.path.join(model_dir, f"{artifact.fileName}.chunkmanifest")
-        num_chunks = str(len(artifact.chunks))
-
-        if not os.path.exists(manifest_path) or open(manifest_path).read().strip() != num_chunks:
-          with open(manifest_path, "w") as f:
-            f.write(num_chunks)
-          cloudlog.info(f"Wrote chunk manifest for {artifact.fileName}: {num_chunks} chunks")
-      except Exception as e:
-        cloudlog.warning(f"Failed to write chunk manifest for {artifact.fileName}: {e}")
+      ModelParser._repair_chunk_manifest(artifact)
 
     return artifact
+
+  @staticmethod
+  def _repair_chunk_manifest(artifact: custom.ModelManagerSP.Artifact) -> None:
+    """Record the chunk count of an artifact already on disk. Every catalog parses each
+    tick and qcom and chestnut list the same file with different counts, so only the source
+    whose first chunk exists writes; a download writes its own manifest when it finishes."""
+    try:
+      model_dir = Paths.model_root()
+      os.makedirs(model_dir, exist_ok=True)
+      base_path = os.path.join(model_dir, artifact.fileName)
+      num_chunks = len(artifact.chunks)
+
+      if not os.path.isfile(get_chunk_name(base_path, 0, num_chunks)):
+        return
+
+      manifest_path = get_manifest_path(base_path)
+      expected = str(num_chunks)
+      if os.path.exists(manifest_path) and open(manifest_path).read().strip() == expected:
+        return
+
+      with open(manifest_path, "w") as f:
+        f.write(expected)
+      cloudlog.info(f"Wrote chunk manifest for {artifact.fileName}: {expected} chunks")
+    except Exception as e:
+      cloudlog.warning(f"Failed to write chunk manifest for {artifact.fileName}: {e}")
 
   @staticmethod
   def _parse_model(model_data) -> custom.ModelManagerSP.Model:

--- a/openpilot/sunnypilot/models/helpers.py
+++ b/openpilot/sunnypilot/models/helpers.py
@@ -14,6 +14,7 @@ from openpilot.common.params import Params
 from openpilot.common.swaglog import cloudlog
 from openpilot.common.hardware.hw import Paths
 from openpilot.selfdrive.modeld.helpers import chestnut_present
+from openpilot.sunnypilot import accelerators
 
 # SET ME TO THE EXACT JSON VERSION WE SET IN SUNNYPILOT_MODELS REPO
 REQUIRED_JSON_VERSION = 19
@@ -122,6 +123,13 @@ def get_selected_bundle(params: Params | None = None, source: str = "qcom") -> "
   return _parse_active_bundle(params.get(ACTIVE_BUNDLE_KEYS[source]))
 
 
+def effective_small_bundle(params: Params | None = None) -> "custom.ModelManagerSP.ModelBundle | None":
+  # under the accelerator override stock modeld runs the default small model, not the stored qcom bundle
+  if accelerators.uses_stock_runner():
+    return None
+  return get_selected_bundle(params, "qcom")
+
+
 def get_active_source(chestnut: bool | None = None, chestnut_active: bool | None = None,
                       chestnut_loading: bool | None = None, offroad: bool | None = None) -> str:
   if chestnut is None:
@@ -135,6 +143,10 @@ def get_active_bundle(params: Params | None = None, *, chestnut: bool | None = N
   # no cross-slot fallback: an empty active slot means the hardware default, which
   # only stock modeld can run - modeld_v2 requires a real bundle
   params = params or Params()
+  # the accelerator override ignores every stored bundle; an explicit chestnut is the
+  # manager describing its slots, which still resolve
+  if chestnut is None and accelerators.uses_stock_runner():
+    return None
   return get_selected_bundle(params, get_active_source(chestnut=chestnut))
 
 

--- a/openpilot/sunnypilot/models/tests/test_manager_download.py
+++ b/openpilot/sunnypilot/models/tests/test_manager_download.py
@@ -24,7 +24,7 @@ from openpilot.common.test import OpenpilotTestCase
 from openpilot.common.file_chunker import get_chunk_name, get_manifest_path
 from openpilot.selfdrive.test.helpers import http_server_context
 from openpilot.sunnypilot.models import manager as manager_module
-from openpilot.sunnypilot.models.fetcher import ModelFetcher, get_cached_bundles
+from openpilot.sunnypilot.models.fetcher import ModelFetcher, ModelParser, get_cached_bundles
 from openpilot.sunnypilot.models import helpers
 from openpilot.sunnypilot.models.helpers import (get_active_bundle, get_active_source, get_selected_bundle,
                                                   resolve_bundle_by_ref, validate_active_bundles)
@@ -811,3 +811,63 @@ class TestLiveModelManifest(OpenpilotTestCase):
 
 if __name__ == '__main__':
   unittest.main()
+
+
+class TestChunkManifestRepair(OpenpilotTestCase):
+  """qcom and chestnut list the same file with different chunk counts; the manifest must
+  describe the chunks on disk, not whichever was parsed last"""
+
+  CHUNKED_NAME = "shared_model.pkl"
+
+  def setUp(self):
+    super().setUp()
+    self.model_root = tempfile.mkdtemp()
+    patcher = mock.patch('openpilot.sunnypilot.models.fetcher.Paths')
+    self.addCleanup(patcher.stop)
+    patcher.start().model_root.return_value = self.model_root
+
+  def artifact_data(self, num_chunks: int, file_name: str | None = None) -> dict:
+    name = file_name or self.CHUNKED_NAME
+    return {
+      "file_name": name,
+      "download_uri": {"url": f"https://example.com/{name}", "sha256": "s"},
+      "chunks": [{"file_name": get_chunk_name(name, i, num_chunks), "sha256": "s"}
+                 for i in range(num_chunks)],
+    }
+
+  def manifest_text(self) -> str | None:
+    path = get_manifest_path(os.path.join(self.model_root, self.CHUNKED_NAME))
+    if not os.path.isfile(path):
+      return None
+    with open(path) as f:
+      return f.read().strip()
+
+  def place_chunks(self, num_chunks: int) -> None:
+    base = os.path.join(self.model_root, self.CHUNKED_NAME)
+    for i in range(num_chunks):
+      with open(get_chunk_name(base, i, num_chunks), 'wb') as f:
+        f.write(b'x')
+
+  def test_no_manifest_for_an_undownloaded_artifact(self):
+    ModelParser._parse_artifact(self.artifact_data(4))
+    assert self.manifest_text() is None, "wrote a manifest for chunks that are not on disk"
+
+  def test_manifest_repaired_for_a_downloaded_artifact(self):
+    self.place_chunks(4)
+    ModelParser._parse_artifact(self.artifact_data(4))
+    assert self.manifest_text() == "4"
+
+  def test_two_sources_disagreeing_do_not_thrash(self):
+    # qcom says 4 chunks, chestnut says 5, and only qcom's were downloaded
+    self.place_chunks(4)
+    for _ in range(3):
+      ModelParser._parse_artifact(self.artifact_data(4))
+      ModelParser._parse_artifact(self.artifact_data(5))
+      assert self.manifest_text() == "4", "the other source overwrote the manifest"
+
+  def test_unchunked_artifact_writes_nothing(self):
+    ModelParser._parse_artifact({
+      "file_name": self.CHUNKED_NAME,
+      "download_uri": {"url": "https://example.com/x", "sha256": "s"},
+    })
+    assert self.manifest_text() is None

--- a/openpilot/sunnypilot/models/tests/test_manager_download.py
+++ b/openpilot/sunnypilot/models/tests/test_manager_download.py
@@ -693,6 +693,12 @@ class TestActiveBundleSelection(OpenpilotTestCase):
   present, qcom otherwise. An empty active slot means the hardware default (stock
   runner), never the other slot's pick - modeld_v2 requires a real bundle."""
 
+  def setUp(self):
+    super().setUp()
+    patcher = mock.patch('openpilot.sunnypilot.accelerators.uses_stock_runner', return_value=False)
+    patcher.start()
+    self.addCleanup(patcher.stop)
+
   @staticmethod
   def _raw_bundle(ref: str) -> dict:
     bundle = custom.ModelManagerSP.ModelBundle.new_message()
@@ -718,6 +724,18 @@ class TestActiveBundleSelection(OpenpilotTestCase):
     assert get_selected_bundle(params, "qcom").ref == "small"
     assert get_selected_bundle(params, "chestnut").ref == "big"
 
+  def test_jetlink_override_preserves_both_bundle_slots(self):
+    params = self._params(qcom=self._raw_bundle('small'), chestnut=self._raw_bundle('big'))
+    with mock.patch('openpilot.sunnypilot.accelerators.uses_stock_runner', return_value=True):
+      assert get_active_bundle(params) is None
+      assert helpers.get_active_model_runner(params, force_check=True) == custom.ModelManagerSP.Runner.stock
+      assert get_selected_bundle(params, 'qcom').ref == 'small'
+      assert get_selected_bundle(params, 'chestnut').ref == 'big'
+    params.remove.assert_not_called()
+    with mock.patch('openpilot.sunnypilot.accelerators.uses_stock_runner', return_value=False), \
+         mock.patch('openpilot.sunnypilot.models.helpers.chestnut_present', return_value=False):
+      assert get_active_bundle(params).ref == 'small'
+
   def test_no_gpu_uses_qcom_slot(self):
     params = self._params(qcom=self._raw_bundle("small"), chestnut=self._raw_bundle("big"))
     with mock.patch("openpilot.sunnypilot.models.helpers.chestnut_present", return_value=False):
@@ -739,6 +757,12 @@ class TestEffectiveSource(OpenpilotTestCase):
   attached); display callers (mici) pass the ui_state flags, which additionally
   require the big model to be loading, active, or the device offroad. The active
   bundle is simply the selected bundle of that source."""
+
+  def setUp(self):
+    super().setUp()
+    patcher = mock.patch('openpilot.sunnypilot.accelerators.uses_stock_runner', return_value=False)
+    patcher.start()
+    self.addCleanup(patcher.stop)
 
   @staticmethod
   def _raw_bundle(ref: str) -> dict:
@@ -809,8 +833,50 @@ class TestLiveModelManifest(OpenpilotTestCase):
     assert not dead, "unreachable model URLs:\n" + "\n".join(dead)
 
 
-if __name__ == '__main__':
-  unittest.main()
+class TestEffectiveSmallBundle(OpenpilotTestCase):
+  """Under the jetlink override manager runs stock modeld, which loads the default
+  small model and never reads the stored qcom bundle, so the UI must not name it."""
+
+  @staticmethod
+  def _params(qcom: dict | None) -> mock.MagicMock:
+    params = mock.MagicMock()
+    params.get.side_effect = lambda key: {"ModelManager_ActiveBundle": qcom}.get(key)
+    return params
+
+  @staticmethod
+  def _raw_bundle(ref: str) -> dict:
+    bundle = custom.ModelManagerSP.ModelBundle.new_message()
+    bundle.ref = ref
+    bundle.minimumSelectorVersion = helpers.REQUIRED_JSON_VERSION
+    bundle.internalName = ref
+    bundle.displayName = ref
+    bundle.runner = custom.ModelManagerSP.Runner.tinygrad
+    return bundle.to_dict()
+
+  def test_override_hides_the_stored_bundle(self):
+    params = self._params(self._raw_bundle("custom_small"))
+    with mock.patch("openpilot.sunnypilot.accelerators.uses_stock_runner", return_value=True):
+      assert helpers.effective_small_bundle(params) is None
+
+  def test_without_override_reports_the_stored_bundle(self):
+    params = self._params(self._raw_bundle("custom_small"))
+    with mock.patch("openpilot.sunnypilot.accelerators.uses_stock_runner", return_value=False):
+      assert helpers.effective_small_bundle(params).ref == "custom_small"
+
+  def test_override_is_exactly_the_toggle(self):
+    # JetlinkEnabled true, nothing about the model (it defaults), link state or readiness
+    from openpilot.sunnypilot.accelerators.jetlink import helpers as jetlink_helpers
+    params = self._params(self._raw_bundle("custom_small"))
+
+    def stub(values):
+      return mock.patch.object(jetlink_helpers, "_get", side_effect=lambda key, default=None: values.get(key, default))
+
+    with stub({"JetlinkEnabled": True, "JetlinkModel": "m"}):
+      assert helpers.effective_small_bundle(params) is None
+    with stub({"JetlinkEnabled": True}):
+      assert helpers.effective_small_bundle(params) is None
+    with stub({"JetlinkModel": "m"}):
+      assert helpers.effective_small_bundle(params).ref == "custom_small"
 
 
 class TestChunkManifestRepair(OpenpilotTestCase):
@@ -871,3 +937,7 @@ class TestChunkManifestRepair(OpenpilotTestCase):
       "download_uri": {"url": "https://example.com/x", "sha256": "s"},
     })
     assert self.manifest_text() is None
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/openpilot/sunnypilot/selfdrive/selfdrived/accelerator_events.py
+++ b/openpilot/sunnypilot/selfdrive/selfdrived/accelerator_events.py
@@ -1,0 +1,53 @@
+"""
+Copyright (c) 2026-, Zeph Leggett.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+
+Onroad events for an accelerator that joins mid-drive. The native big model block
+expects a board loaded before the first modelV2; an off-board one joins onto a
+modelV2 the small model already publishes and can leave and come back.
+"""
+import openpilot.cereal.messaging as messaging
+from openpilot.cereal import custom
+from openpilot.selfdrive.selfdrived.events import Events, EventName
+from openpilot.sunnypilot.selfdrive.selfdrived.events import EventsSP
+
+EventNameSP = custom.OnroadEventSP.EventName
+AcceleratorState = custom.ModelDataV2SP.AcceleratorState
+
+
+class AcceleratorEvents:
+  def __init__(self):
+    self.big_model_available = False
+    self.big_model_running = False
+    self.link_lost = False
+
+  def update(self, sm: messaging.SubMaster, enabled: bool, events: Events, events_sp: EventsSP) -> None:
+    status = sm['modelDataV2SP']
+
+    # stale status does not rearm the chime; only a fresh unavailable state does
+    if all(sm.seen[s] and sm.alive[s] and sm.valid[s] for s in ('modelV2', 'modelDataV2SP')):
+      available = status.bigModelAvailable and not sm['modelV2'].big
+      if available and not self.big_model_available:
+        events_sp.add(EventNameSP.bigModelAvailable)
+      self.big_model_available = available
+
+    # a join holding modelV2 back keeps the driver out, as the native load does; a late join never blocks
+    if status.acceleratorState == AcceleratorState.joining and not sm.alive['modelV2']:
+      events.add(EventName.bigModelLoading)
+
+    # a chestnut dropping modelV2.big already raises the native bigModelFailed
+    running_big = sm.alive['modelV2'] and sm.valid['modelV2'] and sm['modelV2'].big and \
+      status.acceleratorState != AcceleratorState.none
+    # a fall while engaged is a soft disable, latched until disengage since the state machine
+    # cancels a soft disable the tick its event disappears. bigModelFailed drives the main
+    # state machine, bigModelLinkLost drives MADS and carries the guidance
+    if self.big_model_running and not running_big and enabled:
+      self.link_lost = True
+    self.big_model_running = running_big
+    if not enabled:
+      self.link_lost = False
+    if self.link_lost:
+      events.add(EventName.bigModelFailed)
+      events_sp.add(EventNameSP.bigModelLinkLost)

--- a/openpilot/sunnypilot/selfdrive/selfdrived/events.py
+++ b/openpilot/sunnypilot/selfdrive/selfdrived/events.py
@@ -8,8 +8,9 @@ import openpilot.cereal.messaging as messaging
 from openpilot.cereal import log, custom
 from opendbc.car.structs import car
 from openpilot.common.constants import CV
+from openpilot.common.realtime import DT_CTRL
 from openpilot.sunnypilot.selfdrive.selfdrived.events_base import EventsBase, Priority, ET, Alert, \
-  NoEntryAlert, ImmediateDisableAlert, EngagementAlert, NormalPermanentAlert, AlertCallbackType, wrong_car_mode_alert
+  NoEntryAlert, ImmediateDisableAlert, SoftDisableAlert, EngagementAlert, NormalPermanentAlert, AlertCallbackType, wrong_car_mode_alert
 from openpilot.sunnypilot.selfdrive.controls.lib.speed_limit import PCM_LONG_REQUIRED_MAX_SET_SPEED, CONFIRM_SPEED_THRESHOLD
 from openpilot.common.hardware import HARDWARE
 
@@ -25,6 +26,14 @@ EventNameSP = custom.OnroadEventSP.EventName
 EVENT_NAME_SP = {v: k for k, v in EventNameSP.schema.enumerants.items()}
 
 IS_MICI = HARDWARE.get_device_type() == 'mici'
+
+
+def soft_disable_alert(alert_text_2: str) -> AlertCallbackType:
+  def func(CP: car.CarParams, CS: car.CarState, sm: messaging.SubMaster, metric: bool, soft_disable_time: int, personality) -> Alert:
+    if soft_disable_time < int(0.5 / DT_CTRL):
+      return ImmediateDisableAlert(alert_text_2)
+    return SoftDisableAlert(alert_text_2)
+  return func
 
 
 def speed_limit_adjust_alert(CP: car.CarParams, CS: car.CarState, sm: messaging.SubMaster, metric: bool, soft_disable_time: int, personality) -> Alert:
@@ -253,11 +262,25 @@ EVENTS_SP: dict[int, dict[str, Alert | AlertCallbackType]] = {
       Priority.LOW, VisualAlert.none, AudibleAlert.prompt, 0.1),
   },
 
+  EventNameSP.bigModelAvailable: {
+    ET.PERMANENT: Alert(
+      "Model Available" if IS_MICI else "Big Model Available",
+      "Disengage to switch",
+      AlertStatus.normal, AlertSize.mid,
+      Priority.LOW, VisualAlert.none, AudibleAlert.prompt, 3.),
+  },
+
   EventNameSP.bigModelReady: {
     ET.PERMANENT: Alert(
       "Big Model Ready",
       "",
       AlertStatus.normal, AlertSize.small,
       Priority.LOW, VisualAlert.none, AudibleAlert.prompt, 2.),
+  },
+
+  # an accelerator on its own power reconnects mid-drive, so no "restart the car"
+  EventNameSP.bigModelLinkLost: {
+    ET.SOFT_DISABLE: soft_disable_alert("Big Model Lost"),
+    ET.PERMANENT: NormalPermanentAlert("Big Model Lost", "Small model is driving,\nreconnecting if it comes back", duration=20.),
   },
 }

--- a/openpilot/sunnypilot/selfdrive/selfdrived/tests/test_accelerator_events.py
+++ b/openpilot/sunnypilot/selfdrive/selfdrived/tests/test_accelerator_events.py
@@ -1,0 +1,153 @@
+import unittest
+from unittest.mock import Mock
+from types import SimpleNamespace
+
+from openpilot.cereal import custom, messaging
+from openpilot.common.prefix import OpenpilotPrefix
+from openpilot.common.realtime import DT_CTRL
+from openpilot.selfdrive.selfdrived.events import Events, EventName, ET
+from openpilot.selfdrive.selfdrived.selfdrived import SelfdriveD
+from openpilot.selfdrive.selfdrived.state import SOFT_DISABLE_TIME, State, StateMachine
+from openpilot.sunnypilot.selfdrive.selfdrived.accelerator_events import AcceleratorEvents
+from openpilot.sunnypilot.selfdrive.selfdrived.events import EVENTS_SP, EventsSP
+
+EventNameSP = custom.OnroadEventSP.EventName
+
+
+class TestAcceleratorEvents(unittest.TestCase):
+  def setUp(self):
+    prefix = OpenpilotPrefix()
+    prefix.__enter__()
+    self.addCleanup(prefix.__exit__, None, None, None)
+    self.sm = messaging.SubMaster(['modelV2', 'modelDataV2SP'])
+    self.events = Events()
+    self.events_sp = EventsSP()
+    self.accel = AcceleratorEvents()
+    for service in self.sm.services:
+      self.sm.data[service] = self.sm[service].as_builder()
+      self.sm.seen[service] = self.sm.alive[service] = self.sm.valid[service] = True
+
+  def step(self, state='none', big=False, alive=True, enabled=False):
+    self.sm['modelDataV2SP'].acceleratorState = state
+    self.sm['modelV2'].big = big
+    self.sm.alive['modelV2'] = alive
+    self.events.clear()
+    self.events_sp.clear()
+    self.accel.update(self.sm, enabled, self.events, self.events_sp)
+    return (EventName.bigModelLoading in self.events.names, EventName.bigModelFailed in self.events.names,
+            EventNameSP.bigModelLinkLost in self.events_sp.names)
+
+  def test_joining_blocks_only_while_modelv2_is_held_back(self):
+    self.assertEqual(self.step(state='joining', alive=False), (True, False, False))
+    self.assertEqual(self.step(state='joining', alive=False), (True, False, False))
+    # a late join onto a publishing modelV2 never keeps the driver out
+    self.assertEqual(self.step(state='joining', alive=True), (False, False, False))
+    self.assertEqual(self.step(state='none', alive=False), (False, False, False))
+    self.assertEqual(self.step(state='running', alive=False), (False, False, False))
+
+  def test_link_lost_while_engaged_latches_until_disengage(self):
+    self.assertEqual(self.step(state='running', big=True, enabled=True), (False, False, False))
+    # both events, every tick: the native one drives the main state machine's
+    # soft disable, the sunnypilot one drives MADS and carries the guidance
+    for _ in range(10):
+      self.assertEqual(self.step(state='retrying', big=False, enabled=True), (False, True, True))
+    # a rejoin while still engaged does not clear it; only a disengage does
+    self.assertEqual(self.step(state='running', big=True, enabled=True), (False, True, True))
+    self.assertEqual(self.step(state='running', big=True, enabled=False), (False, False, False))
+    # and the latch rearms for the next fall
+    self.assertEqual(self.step(state='running', big=True, enabled=True), (False, False, False))
+    self.assertEqual(self.step(state='unavailable', big=False, enabled=True), (False, True, True))
+
+  def test_link_lost_while_disengaged_is_silent(self):
+    self.assertEqual(self.step(state='running', big=True, enabled=False), (False, False, False))
+    self.assertEqual(self.step(state='retrying', big=False, enabled=False), (False, False, False))
+    # the fall was consumed: engaging afterwards does not replay it
+    self.assertEqual(self.step(state='retrying', big=False, enabled=True), (False, False, False))
+
+  def test_link_lost_ignores_a_chestnut_fall(self):
+    # comma's board has the native bigModelFailed for this; the adapter must not double it
+    self.assertEqual(self.step(state='none', big=True, enabled=True), (False, False, False))
+    self.assertEqual(self.step(state='none', big=False, enabled=True), (False, False, False))
+
+  def drive_state_machine(self, latched: bool) -> State:
+    """ENABLED, then the adapter's events fed to the real state machine for SOFT_DISABLE_TIME."""
+    machine = StateMachine()
+    machine.state = State.enabled
+    self.step(state='running', big=True, enabled=True)
+    for tick in range(int(SOFT_DISABLE_TIME / DT_CTRL) + 2):
+      self.step(state='retrying', big=False, enabled=True)
+      if not latched and tick > 0:
+        # what a one-tick event looks like to the machine on every tick after the first
+        self.events.clear()
+        self.events_sp.clear()
+      enabled, _ = machine.update(self.events)
+      if not enabled:
+        break
+    return machine.state
+
+  def test_a_latched_loss_takes_the_real_state_machine_to_disabled(self):
+    self.assertEqual(self.drive_state_machine(latched=True), State.disabled)
+
+  def test_a_one_tick_loss_would_not_have(self):
+    # SOFT_DISABLING returns to ENABLED the tick its SOFT_DISABLE event goes
+    # away, which is why the loss has to be latched rather than edge-raised.
+    self.assertEqual(self.drive_state_machine(latched=False), State.enabled)
+
+  def test_link_lost_is_a_soft_disable_that_does_not_ask_for_a_restart(self):
+    alerts = EVENTS_SP[EventNameSP.bigModelLinkLost]
+    self.assertEqual(set(alerts), {ET.SOFT_DISABLE, ET.PERMANENT})
+    self.assertEqual(alerts[ET.PERMANENT].alert_text_2, 'Small model is driving,\nreconnecting if it comes back')
+
+
+class TestNativeTracesWithAdapter(unittest.TestCase):
+  """The native block's traces are unchanged by the adapter with modelDataV2SP at defaults."""
+
+  def setUp(self):
+    prefix = OpenpilotPrefix()
+    prefix.__enter__()
+    self.addCleanup(prefix.__exit__, None, None, None)
+    sd = SelfdriveD.__new__(SelfdriveD)
+    sd.sm = messaging.SubMaster(['modelV2', 'modelDataV2SP', 'controlsState', 'deviceState', 'lateralManeuverPlan', 'alertDebug'])
+    sd.sm.data['modelV2'] = sd.sm['modelV2'].as_builder()
+    sd.sm.seen['modelV2'] = sd.sm.alive['modelV2'] = sd.sm.valid['modelV2'] = True
+    # engaged, the native block reports a board that is active but not present as failed
+    sd.sm.data['deviceState'] = sd.sm['deviceState'].as_builder()
+    sd.sm['deviceState'].chestnutPresent = True
+    sd.events = Events()
+    sd.events_sp = EventsSP()
+    sd.accelerator_events = AcceleratorEvents()
+    sd.params = Mock()
+    sd.big_model_loading = sd.big_model_active = sd.big_model_failed = sd.big_model_running = False
+    sd.big_model_ready_t = 0.
+    sd.enabled = True
+    sd.initialized = False
+    sd.startup_event = None
+    self.sd = sd
+
+  def step(self, loading, active=None, big=False, alive=True):
+    sd = self.sd
+    sd.params.get_bool.return_value = loading
+    sd.params.get.return_value = active
+    sd.sm.alive['modelV2'] = alive
+    sd.sm['modelV2'].big = big
+    sd.update_events(SimpleNamespace())
+    self.assertNotIn(EventNameSP.bigModelAvailable, sd.events_sp.names)
+    self.assertNotIn(EventNameSP.bigModelLinkLost, sd.events_sp.names)
+    return (EventNameSP.bigModelReady in sd.events_sp.names, EventName.bigModelFailed in sd.events.names,
+            EventName.bigModelLoading in sd.events.names)
+
+  def test_trace_a_good_load_chimes_once(self):
+    self.assertEqual(self.step(loading=True), (False, False, True))
+    self.assertEqual(self.step(loading=False), (False, False, False))
+    self.assertEqual(self.step(loading=False, active=True, big=True), (True, False, False))
+    for _ in range(10):
+      self.assertEqual(self.step(loading=False, active=True, big=True), (False, False, False))
+    # a chestnut falling back while engaged is the native failure alone
+    self.assertEqual(self.step(loading=False, active=False, big=False), (False, True, False))
+
+  def test_trace_b_failed_load_never_chimes(self):
+    self.assertEqual(self.step(loading=True), (False, False, True))
+    self.assertEqual(self.step(loading=True, active=False), (False, True, True))
+    self.assertEqual(self.step(loading=False, active=False), (False, False, False))
+    for _ in range(10):
+      self.assertEqual(self.step(loading=False, active=False), (False, False, False))

--- a/openpilot/sunnypilot/selfdrive/selfdrived/tests/test_big_model_availability.py
+++ b/openpilot/sunnypilot/selfdrive/selfdrived/tests/test_big_model_availability.py
@@ -1,0 +1,111 @@
+import unittest
+from unittest.mock import Mock
+from types import SimpleNamespace
+
+from openpilot.cereal import custom, messaging
+from openpilot.common.prefix import OpenpilotPrefix
+from openpilot.selfdrive.selfdrived.selfdrived import SelfdriveD
+from openpilot.selfdrive.selfdrived.events import Events, ET
+from openpilot.sunnypilot.selfdrive.selfdrived.accelerator_events import AcceleratorEvents
+from openpilot.sunnypilot.selfdrive.selfdrived.events import EVENTS_SP, EventsSP
+
+EventName = custom.OnroadEventSP.EventName
+
+
+class TestBigModelAvailability(unittest.TestCase):
+  def setUp(self):
+    prefix = OpenpilotPrefix()
+    prefix.__enter__()
+    self.addCleanup(prefix.__exit__, None, None, None)
+    self.sm = messaging.SubMaster(['modelV2', 'modelDataV2SP'])
+    self.events = Events()
+    self.events_sp = EventsSP()
+    self.accel = AcceleratorEvents()
+    for service in self.sm.services:
+      self.sm.data[service] = self.sm[service].as_builder()
+      self.sm.seen[service] = True
+      self.sm.alive[service] = True
+      self.sm.valid[service] = True
+
+  def update(self, available=False, big=False):
+    self.sm['modelDataV2SP'].bigModelAvailable = available
+    self.sm['modelV2'].big = big
+    self.events.clear()
+    self.events_sp.clear()
+    self.accel.update(self.sm, False, self.events, self.events_sp)
+    return EventName.bigModelAvailable in self.events_sp.names
+
+  def test_late_boot_chimes_once_then_can_rejoin(self):
+    self.assertFalse(self.update())
+    self.assertTrue(self.update(available=True))
+    for _ in range(100):
+      self.assertFalse(self.update(available=True))
+    self.assertFalse(self.update(big=True))
+    self.assertFalse(self.update())  # fallback, waiting to reconnect
+    self.assertTrue(self.update(available=True))
+
+  def test_chestnut_and_old_messages_do_not_announce_availability(self):
+    self.assertFalse(custom.ModelDataV2SP.new_message().bigModelAvailable)
+    self.assertFalse(self.update())
+    self.assertFalse(self.update(big=True))
+    self.assertFalse(self.update())
+
+  def test_running_big_suppresses_a_pending_status_from_previous_frame(self):
+    self.assertFalse(self.update(available=True, big=True))
+
+  def test_missing_invalid_or_stale_messages_never_announce(self):
+    for service in ('modelV2', 'modelDataV2SP'):
+      for check in ('seen', 'alive', 'valid'):
+        with self.subTest(service=service, check=check):
+          checks = getattr(self.sm, check)
+          checks[service] = False
+          self.assertFalse(self.update(available=True))
+          checks[service] = True
+    self.assertTrue(self.update(available=True))
+
+  def test_stale_gap_does_not_repeat_chime(self):
+    self.assertTrue(self.update(available=True))
+    self.sm.alive['modelDataV2SP'] = False
+    self.assertFalse(self.update())
+    self.sm.alive['modelDataV2SP'] = True
+    self.assertFalse(self.update(available=True))
+    self.assertFalse(self.update())  # an explicit loss rearms it
+    self.assertTrue(self.update(available=True))
+
+  def test_notification_has_no_control_effect(self):
+    alerts = EVENTS_SP[EventName.bigModelAvailable]
+    self.assertEqual(set(alerts), {ET.PERMANENT})
+    self.assertEqual(alerts[ET.PERMANENT].alert_text_2, 'Disengage to switch')
+
+  def test_main_event_loop_checks_availability_and_preserves_ready(self):
+    # Stop update_events at its normal initialization gate, after model events.
+    sd = SelfdriveD.__new__(SelfdriveD)
+    sd.sm = messaging.SubMaster(['modelV2', 'modelDataV2SP', 'controlsState', 'deviceState',
+                                'lateralManeuverPlan', 'alertDebug'])
+    for service in ('modelV2', 'modelDataV2SP'):
+      sd.sm.data[service] = sd.sm[service].as_builder()
+      sd.sm.seen[service] = sd.sm.alive[service] = sd.sm.valid[service] = True
+    sd.events = Events()
+    sd.events_sp = EventsSP()
+    sd.accelerator_events = AcceleratorEvents()
+    sd.params = Mock()
+    sd.params.get_bool.return_value = False
+    sd.params.get.return_value = None
+    sd.big_model_loading = sd.big_model_running = sd.big_model_active = sd.big_model_failed = False
+    sd.big_model_ready_t = 0.
+    sd.enabled = True
+    sd.initialized = False
+    sd.startup_event = None
+    sd.sm['modelDataV2SP'].acceleratorState = 'joining'
+    sd.sm['modelDataV2SP'].bigModelAvailable = True
+    sd.update_events(SimpleNamespace())
+    self.assertIn(EventName.bigModelAvailable, sd.events_sp.names)
+    self.assertNotIn(EventName.bigModelReady, sd.events_sp.names)
+    sd.sm['modelDataV2SP'].acceleratorState = 'running'
+    sd.sm['modelDataV2SP'].bigModelAvailable = False
+    sd.sm['modelV2'].big = True
+    sd.update_events(SimpleNamespace())
+    self.assertIn(EventName.bigModelReady, sd.events_sp.names)
+    self.assertNotIn(EventName.bigModelAvailable, sd.events_sp.names)
+    sd.update_events(SimpleNamespace())
+    self.assertNotIn(EventName.bigModelReady, sd.events_sp.names)

--- a/openpilot/system/hardware/hardwared.py
+++ b/openpilot/system/hardware/hardwared.py
@@ -24,6 +24,7 @@ from openpilot.common.hardware.usb import CHESTNUT_FW_VERSION, CHESTNUT_USB_PROD
 from openpilot.common.linux import LinuxSystemStats
 from openpilot.system.loggerd.config import get_available_percent
 from openpilot.common.swaglog import cloudlog
+from openpilot.sunnypilot import accelerators
 from openpilot.sunnypilot.system.statsd import statlog
 from openpilot.system.hardware.power_monitoring import PowerMonitoring
 from openpilot.system.hardware.fan_controller import FanController
@@ -312,6 +313,12 @@ def hardware_thread(end_event, hw_queue) -> None:
     chestnut_status.update(started_ts is None, branch, last_hw_state.usb_state, chestnut.failed,
                            params.get_bool("ChestnutLoading"), params.get("ChestnutActive"),
                            chestnut_state if chestnut_valid else None, set_offroad_alert_if_changed)
+
+    # an enabled accelerator that cannot come up is otherwise silently absent
+    accelerator_error = accelerators.unavailable_reason()
+    set_offroad_alert_if_changed("Offroad_AcceleratorUnavailable", accelerator_error is not None,
+                                 extra_text=accelerator_error)
+
     # this subset is only used for offroad
     temp_sources = [
       msg.deviceState.memoryTempC,
@@ -450,6 +457,8 @@ def hardware_thread(end_event, hw_queue) -> None:
     # Check if we need to shut down
     if power_monitor.should_shutdown(onroad_conditions["ignition"], in_car, off_ts, started_seen):
       cloudlog.warning(f"shutting device down, offroad since {off_ts}")
+      # an accelerator on its own supply outlives us; one param read when jetlink is off
+      accelerators.shutdown(f"comma shutting down, offroad since {off_ts}", timeout=25.0)
       params.put_bool("DoShutdown", True, block=True)
 
     msg.deviceState.started = started_ts is not None and not offroad_mode

--- a/openpilot/system/manager/process_config.py
+++ b/openpilot/system/manager/process_config.py
@@ -9,6 +9,7 @@ from openpilot.common.hardware import PC, COMMA_HARDWARE
 from openpilot.system.manager.process import PythonProcess, NativeProcess, DaemonProcess
 from openpilot.common.hardware.hw import Paths
 
+from openpilot.sunnypilot import accelerators
 from openpilot.sunnypilot.mapd.mapd_manager import MAPD_PATH
 
 from openpilot.sunnypilot.models.helpers import get_active_model_runner
@@ -169,6 +170,8 @@ procs = [
 procs += [
   # Models
   PythonProcess("models_manager", "openpilot.sunnypilot.models.manager", only_offroad),
+  # backends declare their offroad daemons; manager owns the onroad gating
+  *[PythonProcess(d.name, d.module, and_(only_offroad, d.should_run)) for d in accelerators.daemons()],
   NativeProcess("modeld_tinygrad", "openpilot/sunnypilot/modeld_v2", ["./modeld"], and_(only_onroad, is_tinygrad_model)),
 
   # Backup

--- a/tools/jetlink_bench.py
+++ b/tools/jetlink_bench.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Isolated, disengaged camera/modeld bench. Never starts controls or pandad."""
+import argparse
+import csv
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+from openpilot.cereal import messaging
+from openpilot.common.basedir import BASEDIR
+from openpilot.common.hardware import HARDWARE
+from openpilot.common.params import Params
+from openpilot.common.prefix import OpenpilotPrefix
+
+
+def main():
+  parser = argparse.ArgumentParser(description=__doc__)
+  parser.add_argument('--seconds', type=float, default=180)
+  parser.add_argument('--output', type=Path, required=True)
+  parser.add_argument('--small', action='store_true')
+  parser.add_argument('--engaged-until', type=float, default=0.0,
+                      help='fake an engaged selfdriveState for this many seconds, so the join has to wait for a window')
+  parser.add_argument('--write-chunk', type=int, choices=[16384, 32768, 65536, 131072, 262144, 524288],
+                      help='bench-only FunctionFS write quantum override, in bytes')
+  args = parser.parse_args()
+  if args.seconds <= 0:
+    parser.error('--seconds must be positive')
+  live = Params()
+  if not live.get_bool('IsOffroad'):
+    raise SystemExit('bench requires the real device to remain offroad')
+  # USB and cameras are physical resources, even with isolated messaging.
+  for proc in Path('/proc').glob('[0-9]*/cmdline'):
+    try:
+      argv = proc.read_bytes().split(b'\0')
+    except (OSError, ProcessLookupError):
+      continue
+    if argv and (Path(os.fsdecode(argv[0])).name == 'camerad' or
+                 b'openpilot.selfdrive.modeld.modeld' in argv or
+                 b'openpilot.sunnypilot.accelerators.jetlink.jetlinkd' in argv):
+      raise SystemExit(f'physical resource already owned by {proc.parent.name}: {argv[:3]}')
+  keys = ('CarParamsPersistent', 'CalibrationParams', 'JetlinkModel', 'JetlinkSpec', 'JetlinkEngineReady', 'JetlinkEndpoint')
+  saved = {key: live.get(key) for key in keys}
+  if saved['CarParamsPersistent'] is None:
+    raise SystemExit('no saved CarParams; bench cannot choose a vehicle configuration')
+  args.output.mkdir(parents=True, exist_ok=False)
+  stop = False
+
+  def stop_requested(*_):
+    nonlocal stop
+    stop = True
+
+  signal.signal(signal.SIGTERM, stop_requested)
+  signal.signal(signal.SIGINT, stop_requested)
+  children, files, rows = [], [], []
+  # Keep artifacts under the explicit output directory; no live Params writes.
+  with OpenpilotPrefix() as prefix:
+    params = Params()
+    for key, value in saved.items():
+      if value is not None:
+        params.put(key, value, block=True)
+    params.put('CarParams', saved['CarParamsPersistent'], block=True)
+    params.put_bool('JetlinkEnabled', not args.small, block=True)
+    pm = messaging.PubMaster(['selfdriveState', 'carState', 'carControl', 'deviceState', 'extrinsicsCalibration'])
+    sm = messaging.SubMaster(['modelV2', 'modelDataV2SP'])
+    calibration = None
+    if saved['CalibrationParams'] is not None:
+      calibration = messaging.log_from_bytes(saved['CalibrationParams'])
+    print(f'isolated prefix={prefix.prefix} output={args.output}', flush=True)
+    HARDWARE.set_power_save(False)
+    try:
+      model_command = [sys.executable, '-m', 'openpilot.selfdrive.modeld.modeld']
+      if args.write_chunk is not None:
+        model_command = [sys.executable, '-c',
+                         'from jetlink.transport.ffs import FfsTransport; '
+                         + f'FfsTransport.write_chunk={args.write_chunk}; '
+                         + 'import runpy; runpy.run_module("openpilot.selfdrive.modeld.modeld", run_name="__main__")']
+      for name, command in (
+        ('camerad', [str(Path(BASEDIR) / 'openpilot/system/camerad/camerad')]),
+        ('modeld', model_command)):
+        log = (args.output / f'{name}.log').open('w')
+        files.append(log)
+        children.append(subprocess.Popen(command, cwd=BASEDIR, stdout=log, stderr=subprocess.STDOUT))
+      start = last = time.monotonic()
+      tick = 0
+      with (args.output / 'frames.csv').open('w') as stream:
+        writer = csv.writer(stream)
+        writer.writerow(['elapsed_s', 'frame_id', 'big', 'valid', 'exec_ms', 'drop_pct', 'age_ms', 'accel_state', 'available'])
+        while not stop and time.monotonic() - start < args.seconds:
+          if any(child.poll() is not None for child in children):
+            raise RuntimeError('camera/modeld exited; inspect captured logs')
+          if tick % 100 == 0 and not live.get_bool('IsOffroad'):
+            raise RuntimeError('real ignition changed: stopping bench')
+          engaged = time.monotonic() - start < args.engaged_until
+          for service in ('selfdriveState', 'carState', 'carControl'):
+            message = messaging.new_message(service)
+            message.valid = True
+            if service == 'carState':
+              message.carState.standstill = True
+            elif service == 'selfdriveState':
+              # The promotion gate reads these three; faking them engaged holds the join back.
+              message.selfdriveState.enabled = engaged
+            elif service == 'carControl':
+              message.carControl.latActive = engaged
+              message.carControl.longActive = engaged
+            pm.send(service, message)
+          if tick % 10 == 0:
+            device = messaging.new_message('deviceState')
+            device.valid = True
+            device.deviceState.deviceType = HARDWARE.get_device_type()
+            pm.send('deviceState', device)
+            if calibration is not None:
+              message = calibration.as_builder()
+              message.logMonoTime = time.monotonic_ns()
+              pm.send('extrinsicsCalibration', message)
+          sm.update(0)
+          if sm.updated['modelV2']:
+            model = sm['modelV2']
+            status = sm['modelDataV2SP']
+            row = (time.monotonic() - start, model.frameId, int(model.big), int(sm.valid['modelV2']),
+                   model.modelExecutionTime * 1000, model.frameDropPerc,
+                   (sm.logMonoTime['modelV2'] - model.timestampEof) / 1e6,
+                   str(status.acceleratorState), int(status.bigModelAvailable))
+            rows.append(row)
+            writer.writerow(row)
+          if time.monotonic() - last >= 10:
+            last = time.monotonic()
+            stream.flush()
+            print(f't={last-start:.0f}s frames={len(rows)} big={sum(r[2] for r in rows)} engaged={engaged}',
+                  f'latest={rows[-1] if rows else None}', flush=True)
+          tick += 1
+          time.sleep(max(0, start + tick * 0.01 - time.monotonic()))
+    finally:
+      for child in reversed(children):
+        if child.poll() is None:
+          child.send_signal(signal.SIGINT)
+      for child in children:
+        try:
+          child.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+          child.kill()
+          child.wait(timeout=5)
+      for log in files:
+        log.close()
+      # Power saving belongs to hardwared if real ignition changed.
+      if live.get_bool('IsOffroad'):
+        HARDWARE.set_power_save(True)
+  summary = {}
+  for label, subset in [('all', rows), ('big', [r for r in rows if r[2]]), ('small', [r for r in rows if not r[2]])]:
+    if subset:
+      # the state column is text, so pick the numeric columns before numpy sees the rows
+      values = np.asarray([row[:7] for row in subset], dtype=float)
+      summary[label] = {'frames': len(subset), 'exec_p50_p99_p999_max_ms': np.percentile(values[:, 4], [50, 99, 99.9, 100]).tolist(),
+                        'over_50ms': int((values[:, 4] > 50).sum()), 'max_drop_pct': float(values[:, 5].max()),
+                        'lagging_frames': int((values[:, 5] > 1).sum()), 'invalid_frames': int((values[:, 3] == 0).sum()),
+                        'states': sorted({row[7] for row in subset})}
+  (args.output / 'summary.json').write_text(json.dumps(summary, indent=2) + '\n')
+  print(json.dumps(summary, indent=2), flush=True)
+  if not rows or (not args.small and not any(row[2] for row in rows)):
+    raise SystemExit('bench did not exercise the requested model')
+
+
+if __name__ == '__main__':
+  main()

--- a/tools/jetlink_live_bench.sh
+++ b/tools/jetlink_live_bench.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Run only cameras and modeld, with private Params and messaging.
+# Stop the offroad jetlinkd owner first; never run this in a moving vehicle.
+# OUTPUT may specify a new directory for logs, frame CSV and summary JSON.
+set -eu
+cd "$(dirname "$0")/.."
+export PYTHONPATH=$PWD
+exec /usr/local/venv/bin/python3 tools/jetlink_bench.py \
+  --seconds "${1:-180}" --output "${OUTPUT:-/data/tmp/jetlink-bench-$(date +%Y%m%d-%H%M%S)}"

--- a/tools/jetlink_replay.py
+++ b/tools/jetlink_replay.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""
+Copyright (c) 2026-, Zeph Leggett.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+
+Replay a recorded segment through the real modeld, on the accelerator, via process_replay
+so the code under test is the shipped modeld. Runs on the device against a segment
+already in /data/media, no network needed.
+
+    # jetlinkd owns the link offroad, so hand it over first
+    kill -TERM $(pgrep -f accelerators.jetlink.jetlinkd)
+    PYTHONPATH=/data/openpilot:/data/replaydeps tools/jetlink_replay.py \
+        --segment /data/media/0/realdata/00000151--cdb98c775d--9
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import replace
+from pathlib import Path
+
+import numpy as np
+
+# The camera state each stream is fed from, and the file it is recorded in.
+CAMERAS = {
+  'narrowRoadCameraState': 'fcamera.hevc',
+  'wideRoadCameraState': 'ecamera.hevc',
+}
+
+
+class HevcFrameReader:
+  """The slice of FrameReader process_replay uses. The real one shells out to ffmpeg,
+  which AGNOS does not ship; PyAV decodes on the device."""
+
+  pix_fmt = 'nv12'
+
+  def __init__(self, path: Path, limit: int):
+    import av
+    self.frames: list[np.ndarray] = []
+    self.base_id: int | None = None
+    with av.open(str(path)) as container:
+      stream = container.streams.video[0]
+      stream.thread_type = 'AUTO'
+      for i, frame in enumerate(container.decode(stream)):
+        if i >= limit:
+          break
+        # (h*3//2, w) for nv12: the Y plane then the interleaved UV rows, which
+        # is the flat layout process_replay slices back apart.
+        self.frames.append(frame.reformat(format='nv12').to_ndarray().reshape(-1))
+    if not self.frames:
+      raise SystemExit(f"no frames decoded from {path}")
+    self.h = stream.height
+    self.w = stream.width
+
+  def get(self, frame_id: int) -> np.ndarray:
+    # frameId counts from the start of the drive, not the segment, so the
+    # first one we are asked for defines the offset into this file.
+    if self.base_id is None:
+      self.base_id = frame_id
+    idx = frame_id - self.base_id
+    return self.frames[min(max(idx, 0), len(self.frames) - 1)]
+
+
+def disengaged(m):
+  """The joining state only swaps while disengaged, so an engaged segment would replay
+  entirely on the small model. The replay controls nothing."""
+  if m.which() == 'selfdriveState':
+    b = m.as_builder()
+    b.selfdriveState.enabled = False
+    return b.as_reader()
+  if m.which() == 'carControl':
+    b = m.as_builder()
+    b.carControl.latActive = False
+    b.carControl.longActive = False
+    return b.as_reader()
+  return m
+
+
+def trim_to_frames(msgs: list, n: int) -> list:
+  """Camera states run the whole minute; replaying them all against a 60-frame reader
+  would repeat the last frame and report 1200 results from 60 images."""
+  out, seen = [], 0
+  for m in msgs:
+    if m.which() == 'narrowRoadCameraState':
+      seen += 1
+      if seen > n:
+        break
+    out.append(m)
+  return out
+
+
+def model_name() -> str:
+  """Which large model this run will put on the accelerator."""
+  from openpilot.sunnypilot.accelerators.jetlink import helpers
+  chosen = helpers.selected_model()
+  if chosen is None:
+    return 'unknown'
+  return f"{chosen['name']} ({chosen['size'] / 1e6:.0f} MB, oid {chosen['oid'][:16]})"
+
+
+def jetlink_params() -> dict:
+  """process_replay gives modeld a private PARAMS_ROOT; without these it quietly runs
+  the small model, which passes everything except modelV2.big."""
+  from openpilot.common.params import Params
+  params = Params()
+  out: dict = {'JetlinkEnabled': True}
+  for key in ('JetlinkEngineReady', 'JetlinkSpec', 'JetlinkModel', 'JetlinkEndpoint'):
+    value = params.get(key)
+    if value is not None:
+      out[key] = value
+  return out
+
+
+ONLINE = Path('/sys/devices/system/cpu/online')
+
+
+def big_cores_up() -> bool:
+  """Cores 4-7 are offline offroad and config_realtime_process(7, 54) dies with EINVAL.
+  Same call hardwared makes at ignition, so timings match the scheduling modeld gets."""
+  from openpilot.common.hardware import HARDWARE
+  try:
+    HARDWARE.set_power_save(False)
+  except Exception as e:
+    print(f"  could not leave power save: {e}")
+  return ONLINE.read_text().strip() == '0-7'
+
+
+def unpin() -> None:
+  """Last resort: run modeld unpinned, with frame times that are the bench's, not the car's."""
+  from openpilot.common import realtime
+  realtime.set_core_affinity = lambda cores: None
+
+
+def dump(model, path: str) -> None:
+  """Per-frame outputs the planner and UI consume, for comparing two runs over the same frames."""
+  def col(f):
+    return np.array([f(m.modelV2) for m in model], dtype=np.float32)
+  np.savez(path,
+           frame_id=col(lambda v: v.frameId), big=col(lambda v: float(getattr(v, 'big', False))),
+           exec_ms=col(lambda v: v.modelExecutionTime * 1e3),
+           desired_curvature=col(lambda v: v.action.desiredCurvature),
+           desired_accel=col(lambda v: v.action.desiredAcceleration),
+           lane_y0=np.array([[ll.y[0] for ll in m.modelV2.laneLines] for m in model], dtype=np.float32),
+           lane_prob=np.array([list(m.modelV2.laneLineProbs) for m in model], dtype=np.float32),
+           edge_y0=np.array([[re.y[0] for re in m.modelV2.roadEdges] for m in model], dtype=np.float32),
+           pos_y=np.array([list(m.modelV2.position.y) for m in model], dtype=np.float32),
+           pos_x=np.array([list(m.modelV2.position.x) for m in model], dtype=np.float32))
+  print(f"  per-frame outputs written to {path}")
+
+
+def summarise(msgs, dump_path: str | None = None) -> int:
+  model = [m for m in msgs if m.which() == 'modelV2']
+  if not model:
+    print("FAIL: modeld produced no modelV2")
+    return 1
+  if dump_path:
+    dump(model, dump_path)
+
+  big = [bool(getattr(m.modelV2, 'big', False)) for m in model]
+  exec_ms = np.array([m.modelV2.modelExecutionTime for m in model]) * 1e3
+  drops = np.array([m.modelV2.frameDropPerc for m in model])
+  # Frame 0 is the warmup: the engine load and the first queue fill land there.
+  steady = exec_ms[1:] if len(exec_ms) > 1 else exec_ms
+
+  p50, p90 = np.percentile(steady, 50), np.percentile(steady, 90)
+  print(f"\nmodelV2 messages: {len(model)}")
+  print(f"  big (accelerator ran it): {sum(big)}/{len(big)}")
+  print(f"  execution time ms: mean {steady.mean():.2f}  p50 {p50:.2f}  p90 {p90:.2f}  max {steady.max():.2f}")
+  print(f"  first frame (engine load + queue fill): {exec_ms[0]:.1f} ms")
+  print(f"  frame drop: mean {drops.mean():.2f}%  max {drops.max():.2f}%")
+
+  last = model[-1].modelV2
+  lanes = np.array(last.laneLines[1].y) if len(last.laneLines) > 1 else np.array([])
+  plan_x = np.array(last.position.x) if len(last.position.x) else np.array([])
+  print("  last frame sanity:")
+  if lanes.size:
+    ok = bool(np.all(np.isfinite(lanes)))
+    print(f"    laneLines[1].y   n={lanes.size} finite={ok} range [{lanes.min():.2f}, {lanes.max():.2f}]")
+  else:
+    print("    laneLines empty")
+  if plan_x.size:
+    ok = bool(np.all(np.isfinite(plan_x)))
+    print(f"    position.x       n={plan_x.size} finite={ok} reaches {plan_x.max():.1f} m")
+  else:
+    print("    position empty")
+  print(f"    desiredCurvature {last.action.desiredCurvature:+.5f}")
+  if len(last.leadsV3):
+    print(f"    leadProb         {last.leadsV3[0].prob:.3f}")
+
+  bad = []
+  if not all(big):
+    bad.append(f"{len(big) - sum(big)} frames ran on the small model")
+  if steady.max() > 50:
+    bad.append(f"execution time peaked at {steady.max():.1f} ms, over the 50 ms budget")
+  if lanes.size and not np.all(np.isfinite(lanes)):
+    bad.append("lane lines contain non-finite values")
+  if bad:
+    print("\nFAIL: " + "; ".join(bad))
+    return 1
+  print("\nOK: every frame ran on the accelerator, inside the frame budget, with finite outputs")
+  return 0
+
+
+def main() -> int:
+  p = argparse.ArgumentParser()
+  p.add_argument('--segment', required=True, help='a directory under /data/media/0/realdata')
+  p.add_argument('--frames', type=int, default=60)
+  p.add_argument('--dump', help='write per-frame model outputs to this .npz')
+  args = p.parse_args()
+
+  seg = Path(args.segment)
+  rlog = next((seg / n for n in ('rlog.zst', 'rlog') if (seg / n).exists()), None)
+  if rlog is None:
+    raise SystemExit(f"no rlog in {seg}")
+
+  from openpilot.selfdrive.test.process_replay.process_replay import (
+    get_custom_params_from_lr,
+    get_process_config,
+    replay_process,
+  )
+  from openpilot.tools.lib.logreader import LogReader
+
+  full = list(LogReader(str(rlog)))
+  # process_replay's calibration and live-parameter snapshots are scattered through
+  # the whole segment, so read them off the full log before cutting it down
+  custom = get_custom_params_from_lr(full)
+  custom.update(jetlink_params())
+  lr = [disengaged(m) for m in trim_to_frames(full, args.frames)]
+  # cutting the log can drop the carParams process_replay fingerprints from
+  fingerprint = next((m.carParams.carFingerprint for m in full if m.which() == 'carParams'), None)
+  print(f"segment {seg.name}: {len(lr)} of {len(full)} messages, {args.frames} frames")
+  print(f"  car: {fingerprint}")
+  print(f"  model: {model_name()}")
+
+  frs = {}
+  for state, name in CAMERAS.items():
+    path = seg / name
+    if not path.exists():
+      raise SystemExit(f"missing {path}")
+    frs[state] = HevcFrameReader(path, args.frames)
+    print(f"  {state}: {len(frs[state].frames)} frames at {frs[state].w}x{frs[state].h}")
+
+  pinned = big_cores_up()
+  how = 'pinned as onroad' if pinned else 'UNPINNED, timings are not representative'
+  print(f"  cores online: {ONLINE.read_text().strip()} ({how})")
+  if not pinned:
+    unpin()
+
+  cfg = get_process_config('modeld')
+  # the joining state swaps only on a disengaged frame and assumes engaged until told;
+  # modeld never subscribes to selfdriveState, so process_replay would not deliver it
+  cfg = replace(cfg, pubs=list(dict.fromkeys([*cfg.pubs, 'selfdriveState', 'carState', 'carControl'])))
+  out = replay_process(cfg, lr, frs, fingerprint=fingerprint, custom_params=custom)
+  return summarise(out, args.dump)
+
+
+if __name__ == '__main__':
+  sys.exit(main())


### PR DESCRIPTION
Add Jetlink support to run large driving models on an NVIDIA Jetson connected to the comma over USB. Users can select a model in sunnypilot, prepare it while parked, and use the local small model while the Jetson starts or reconnects.

Depends on #2000 for startup-alert fixes and the “Big Model Ready” chime on the first valid big-model frame.

### Features

- **Model settings:** Adds an **Accelerator Link** toggle and **Accelerator Model** picker in both UI layouts. Link and model changes are available only offroad. Jetlink is disabled by default.
- **Model preparation:** Downloads the selected ONNX model, transfers it to the Jetson, and builds a TensorRT engine with progress and estimated build time. Cached engines are reused and checked when the Jetson reconnects.
- **Model choice:** Uses a separate ONNX catalog for the Jetson, with Cinque Terre as the default. Existing QCOM model bundles cannot run under TensorRT.
- **Startup and recovery:** Starts on the default small model and connects in the background. A prepared Jetson can join later in the drive once controls are disengaged.
- **Power management:** Releases the USB connection when parked and idle so a configured Jetson server can suspend. Presents the connection again when needed and requests Jetson shutdown when the comma powers off, with a bounded wait.

### These are what I have tested for reliability 

| Situation | Behavior |
| --- | --- |
| Preparing a model while parked | Model settings show download/build progress and readiness. |
| Jetson is still booting | The default small model runs while Jetlink connects. |
| Large model becomes available while engaged | “Big Model Available” prompts the driver to disengage to switch. |
| Large model starts running | “Big Model Ready” chimes after the first valid big-model frame. |
| Link fails while engaged | Falls back to the small model and triggers a soft disable. “Big Model Lost” explains that the small model is running and the connection will be retried. |
| Link fails while disengaged | Falls back silently and retries. Switching back to the large model again requires disengagement. |
| Jetlink cannot initialize | An offroad accelerator-unavailable alert reports the setup error. |

While Jetlink is enabled, sunnypilot uses stock modeld and the default small model for startup and fallback. The UI reports that model rather than the stored custom small-model selection. Turning the link off restores normal model selection.

### Setup

Requires a Jetson running the matching [Jetlink server](https://github.com/zoompilot/jetlink), a separate Jetson power supply, and a USB 3 data cable from **Jetson USB-A to comma USB-C**. The reference setup is an Orin Nano Super 8 GB with JetPack 6.1 and TensorRT 10.3.

The client ships as the pinned `jetlink_repo` submodule. With the server configured and connected, enable **Accelerator Link**, select an **Accelerator Model**, and complete preparation while parked. Installing the package alone does not enable the link. Wired TCP is also available through `JetlinkEndpoint` for bench use.

### Implementation

The comma retains camera processing, image warping, output parsing, and vehicle control. The Jetson runs inference and maintains model history buffers; it has no CAN access. The comma is the USB FunctionFS gadget and the Jetson is the host.

- Adds a small accelerator module under `openpilot/sunnypilot/accelerators`. The native chestnut path retains priority and its existing implementation.
- Switches models only with fresh, valid state confirming that controls are disengaged. Inference failures reset the small-model history and rerun the frame locally; reconnect delays increase from 5 to 60 seconds. The inference timeout is 0.5 seconds.
- Keeps connection work off the model frame thread. `jetlinkd` owns USB offroad; `modeld` owns it onroad. VM tuning is applied only when enabled and restored when disabled.
- Adds accelerator state to `ModelDataV2SP` without changing the meaning of `deviceState.chestnutPresent` or `chestnutState`. Jetson telemetry is recorded in swaglog.

### Verification

- Local regression suites: **501 passed, 3 skipped** across accelerators, models, modeld_v2, selfdrived, sunnypilot selfdrived, and UI.
- Tests cover model switching, reconnects, soft-disable persistence, opt-in behavior, model selection, and native chestnut equivalence.
- Ruff passed on changed files; affected runtime modules import on a PC.
- `validate_sp_cereal_upstream.py`: **cereal compat OK**.
- On-device opt-out check: with `JetlinkEnabled` absent, setup leaves the USB gadget inactive and accelerator shutdown returns in under 1 ms.

Live camera/modeld inference against a Jetson and shutdown with an unresponsive Jetson are not exercised in CI. Sustained latency, thermal behavior, USB faults, and suspend/wake require hardware validation; the software test results do not establish driving readiness.
