### PR TITLE
modeld: compile every driver camera into the prebuilt

### DIFF
--- a/openpilot/selfdrive/modeld/SConscript
+++ b/openpilot/selfdrive/modeld/SConscript
@@ -18,15 +18,19 @@ tinygrad_root = env.Dir("#").abspath
 tinygrad_files = ["#"+x for x in glob.glob(env.Dir("#tinygrad_repo").relpath + "/**", recursive=True, root_dir=tinygrad_root)
                   if 'pycache' not in x and os.path.isfile(os.path.join(tinygrad_root, x))]
 
-def estimate_pickle_max_size(onnx_size):
+def estimate_pickle_max_size(onnx_size, num_cameras=1):
   # QCOM programs for models with spatial recurrent features can approach 2x
-  # the ONNX size. Overestimating only adds an empty trailing chunk.
-  return 2.0 * onnx_size + 10 * 1024 * 1024
+  # the ONNX size, once per camera. Overestimating only adds an empty trailing chunk.
+  return 2.0 * onnx_size * num_cameras + 10 * 1024 * 1024
 
 if arch == 'comma_arm64':
   from openpilot.common.hardware import HARDWARE
-  camera = _os_fisheye if HARDWARE.get_device_type() == "mici" else _ar_ox_fisheye
-  camera_configs = [(camera.width, camera.height)]
+  # tizi and mici share the GPU, so a prebuilt can carry the jits for both driver cameras
+  if os.getenv('PREBUILT_ALL_CAMERAS'):
+    camera_configs = [(c.width, c.height) for c in (_ar_ox_fisheye, _os_fisheye)]
+  else:
+    camera = _os_fisheye if HARDWARE.get_device_type() == "mici" else _ar_ox_fisheye
+    camera_configs = [(camera.width, camera.height)]
   tg_backend = 'QCOM'
   tg_flags = f'DEV={tg_backend} IMAGE=1 FLOAT16=1 NOLOCALS=1 JIT_BATCH_SIZE=0 OPENPILOT_HACKS=1'
 else:
@@ -84,7 +88,7 @@ if not os.getenv('SKIP_TINYGRAD_COMPILE'):
           f'--onnx {File(f"models/{file_prefix}driving_supercombo.onnx").abspath} '
           f'--output {target_pkl_path} --frame-skip {frame_skip}')
     onnx_sizes_sum = sum(os.path.getsize(f) for f in driving_onnx_deps)
-    chunk_targets = get_chunk_targets(target_pkl_path, estimate_pickle_max_size(onnx_sizes_sum))
+    chunk_targets = get_chunk_targets(target_pkl_path, estimate_pickle_max_size(onnx_sizes_sum, len(camera_configs)))
     def do_compile(target, source, env, command=cmd, pkl=target_pkl_path, chunks=chunk_targets):
       from openpilot.system.hardware.chestnut.flash import link_up
       # chestnut can enumerate before its PCIe link is up due to varying 12V power behavior across cars

--- a/openpilot/selfdrive/modeld/dmonitoringmodeld.py
+++ b/openpilot/selfdrive/modeld/dmonitoringmodeld.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import os
-from openpilot.selfdrive.modeld.helpers import MODELS_DIR, get_tg_input_devices
+from openpilot.selfdrive.modeld.helpers import MODELS_DIR, dm_warp_path, get_tg_input_devices
 from tinygrad.tensor import Tensor
 import time
 import pickle
@@ -45,7 +45,7 @@ class ModelState:
     self.tensor_inputs = {k: Tensor(v, device='NPY').realize() for k,v in self.numpy_inputs.items()}
     self._blob_cache : dict[int, Tensor] = {}
     self.model_run = pickle.load(open_file_chunked(str(MODEL_PKL_PATH)))
-    with open(MODELS_DIR / f'dm_warp_{cam_w}x{cam_h}_tinygrad.pkl', "rb") as f:
+    with open(dm_warp_path(cam_w, cam_h), "rb") as f:
       self.image_warp = pickle.load(f)
 
   def run(self, buf: VisionBuf, calib: np.ndarray, transform: np.ndarray) -> tuple[np.ndarray, float]:

--- a/openpilot/selfdrive/modeld/helpers.py
+++ b/openpilot/selfdrive/modeld/helpers.py
@@ -47,6 +47,22 @@ def load_oob(f):
       yield pb
   return pickle.load(io.BytesIO(opcodes), buffers=buffers())
 
+# the jits are keyed by driver camera resolution, so a build from another device may have none for this one
+def _camera_mismatch(cam_w: int, cam_h: int, compiled: str, path) -> RuntimeError:
+  return RuntimeError(f"no jit for this device's {cam_w}x{cam_h} driver camera: {path} has only [{compiled or 'none'}], rebuild it")
+
+def dm_warp_path(cam_w: int, cam_h: int):
+  path = MODELS_DIR / f'dm_warp_{cam_w}x{cam_h}_tinygrad.pkl'
+  if not path.is_file():
+    compiled = ', '.join(sorted(p.name.split('_')[2] for p in MODELS_DIR.glob('dm_warp_*_tinygrad.pkl')))
+    raise _camera_mismatch(cam_w, cam_h, compiled, MODELS_DIR)
+  return path
+
+def check_camera_jit(jits: dict, cam_w: int, cam_h: int, path) -> None:
+  if (cam_w, cam_h) not in jits:
+    compiled = ', '.join(f'{w}x{h}' for w, h in sorted(k for k in jits if isinstance(k, tuple)))
+    raise _camera_mismatch(cam_w, cam_h, compiled, path)
+
 def chestnut_present() -> bool:
   for d in USB_DEVICES_PATH.glob("*"):
     try:

--- a/openpilot/selfdrive/modeld/modeld.py
+++ b/openpilot/selfdrive/modeld/modeld.py
@@ -33,7 +33,7 @@ from openpilot.selfdrive.modeld.fill_model_msg import fill_model_msg, fill_drivi
 from openpilot.common.file_chunker import open_file_chunked
 from openpilot.common.hardware.usb import CHESTNUT_USB_IDS
 from openpilot.selfdrive.modeld.constants import ModelConstants, Plan
-from openpilot.selfdrive.modeld.helpers import chestnut_present, chestnut_compiled, chestnut_ready, modeld_pkl_path, load_oob
+from openpilot.selfdrive.modeld.helpers import chestnut_present, chestnut_compiled, chestnut_ready, modeld_pkl_path, load_oob, check_camera_jit
 
 from openpilot.sunnypilot.livedelay.helpers import get_lat_delay
 from openpilot.sunnypilot.modeld_v2.modeld_base import ModelStateBase
@@ -180,7 +180,8 @@ class ModelState(ModelStateBase):
 
   def __init__(self, cam_w: int, cam_h: int, chestnut: bool):
     ModelStateBase.__init__(self)
-    jits = load_oob(open_file_chunked(modeld_pkl_path(chestnut)))
+    pkl_path = modeld_pkl_path(chestnut)
+    jits = load_oob(open_file_chunked(pkl_path))
     input_devices = jits['input_devices']
     self.model_device = input_devices['model']
     metadata = jits['metadata']
@@ -196,6 +197,7 @@ class ModelState(ModelStateBase):
     self.input_queues, self.npy, self.frame_views = make_input_queues(
       self.input_shapes, self.frame_skip, device=self.model_device, frame_copy_size=self.frame_copy_size)
     self.parser = Parser()
+    check_camera_jit(jits['run_model'], cam_w, cam_h, pkl_path)
     self.run_model = jits['run_model'][(cam_w,cam_h)]
 
   def slice_outputs(self, model_outputs: np.ndarray, output_slices: dict[str, slice]) -> dict[str, np.ndarray]:

--- a/openpilot/selfdrive/modeld/tests/test_helpers.py
+++ b/openpilot/selfdrive/modeld/tests/test_helpers.py
@@ -1,0 +1,14 @@
+from openpilot.common.test import OpenpilotTestCase
+from openpilot.selfdrive.modeld.helpers import check_camera_jit
+
+
+class TestCheckCameraJit(OpenpilotTestCase):
+  def test_missing_camera_is_named(self):
+    mici_only = {'metadata': {}, 'run_policy': None, (1344, 760): None}
+    with self.assertRaisesRegex(RuntimeError, r"1928x1208 driver camera.*has only \[1344x760\]"):
+      check_camera_jit(mici_only, 1928, 1208, "driving_tinygrad.pkl")
+
+  def test_compiled_camera_passes(self):
+    both = {'metadata': {}, (1344, 760): None, (1928, 1208): None}
+    for cam_w, cam_h in ((1344, 760), (1928, 1208)):
+      check_camera_jit(both, cam_w, cam_h, "driving_tinygrad.pkl")

--- a/openpilot/sunnypilot/modeld_v2/modeld.py
+++ b/openpilot/sunnypilot/modeld_v2/modeld.py
@@ -17,7 +17,7 @@ from tinygrad.tensor import Tensor
 
 import openpilot.cereal.messaging as messaging
 from openpilot.common.hardware import COMMA_HARDWARE
-from openpilot.selfdrive.modeld.helpers import chestnut_present, load_oob
+from openpilot.selfdrive.modeld.helpers import check_camera_jit, chestnut_present, load_oob
 from openpilot.cereal import log
 from opendbc.car.structs import car
 from openpilot.cereal.services import SERVICE_LIST
@@ -143,11 +143,14 @@ class ModelState(ModelStateBase):
         self.input_queues, self.numpy_inputs, self.frame_buffers = make_stock_input_queues(
           self.input_shapes, self.frame_skip, device=self.DEV, frame_copy_size=self.frame_copy_size)
         self.frame_views, self.npy = self.frame_buffers, self.numpy_inputs
+        check_camera_jit(jits['run_model'], cam_w, cam_h, pkl_path)
         self.run_model, self.run_policy, self.warp = jits['run_model'][(cam_w, cam_h)], None, None
       else:
         self.input_queues, self.numpy_inputs = make_supercombo_input_queues(self.input_shapes, self.frame_skip, device=self.QUEUE_DEV)
+        check_camera_jit(jits, cam_w, cam_h, pkl_path)
         self.run_model, self.run_policy, self.warp = None, jits['run_policy'], jits[(cam_w, cam_h)]
     else:
+      check_camera_jit(jits, cam_w, cam_h, pkl_path)
       self.run_model, self.run_policy, self.warp = None, jits['run_policy'], jits[(cam_w, cam_h)]
       vision_metadata = metadata['vision']
       policy_keys = [k for k in metadata if k not in ('vision', 'warp_dev')]

--- a/tools/release/build_release.sh
+++ b/tools/release/build_release.sh
@@ -48,7 +48,7 @@ for policy in /sys/devices/system/cpu/cpufreq/policy*; do
   echo "$hardware_max" | sudo tee "$policy/scaling_max_freq" >/dev/null
 done
 
-scons
+PREBUILT_ALL_CAMERAS=1 scons
 if [ -n "$INCLUDE_BIG_MODEL" ]; then
   test -f openpilot/selfdrive/modeld/models/big_driving_tinygrad.pkl.chunkmanifest
 fi


### PR DESCRIPTION
### The Issue

_maybe this https://github.com/commaai/openpilot/issues/38762_
A prebuilt release only works on the kind of device it was built on. The release build compiles the driving model and driver monitoring warp jits for the driver camera of the machine running `scons`, and nothing else. The same tree is then pushed to both the tizi and mici release branches, so one of them is missing the jits for its own camera.

The result on the wrong device is `process not running: dmonitoringmodeld` from the first boot. dmonitoringmodeld crashes before its first frame because the warp file for its camera resolution does not exist, and modeld would fail the same way on the stock model.

We hit this on our fork: our releases are cut on a comma four and every comma 3X that installed them lost driver monitoring. Cutting on a tizi, as sunnypilot does, breaks it for the comma four instead.

### The Fix
* The release build now compiles the jits for both driver cameras. tizi and mici share the same GPU, so the compiled kernels run on either and only the camera resolution differs. A source build on a device is unchanged and still compiles just its own camera.
* The chunk size estimate for the driving pkl accounts for the extra camera, so a build that comes up short fails in CI rather than on the device.
* When a device does have a build without its camera, modeld and dmonitoringmodeld now fail with a message naming the camera and what the build contains, instead of a bare `FileNotFoundError` or `KeyError`.

### Notes
* Verified on our fork: a 3X on a comma four cut release now runs driver monitoring.
* Compiling both cameras adds a few minutes to the release build.
* Downloaded model bundles are unaffected; this only concerns the pkls built by `scons`.
