### PR TITLE
models: one-off migration of the chunked catalog to whole files

### DIFF
--- a/.github/workflows/migrate-whole-file-models.yaml
+++ b/.github/workflows/migrate-whole-file-models.yaml
@@ -1,0 +1,99 @@
+# One-off: turn a chunked driving_models manifest into a whole-file one (selector version 20) without recompiling.
+# Reads the chunks named by the source manifest, uploads each joined pkl beside them, writes the target manifest.
+# Delete together with release/ci/migrate_whole_file_models.py once the catalog is on whole files.
+name: migrate-whole-file-models
+run-name: Migrate ${{ inputs.target_hardware }} driving_models v${{ inputs.src_json_version }} -> v${{ inputs.dst_json_version }}${{ inputs.dry_run && ' (dry run)' || '' }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_hardware:
+        description: 'Manifest family to migrate'
+        required: true
+        default: 'qcom'
+        type: choice
+        options:
+          - qcom
+          - chestnut
+      src_json_version:
+        description: 'Chunked driving_models version to read (22 for qcom, 25 for chestnut)'
+        required: true
+        default: '22'
+        type: string
+      dst_json_version:
+        description: 'Whole-file driving_models version to write (23 for qcom, 26 for chestnut)'
+        required: true
+        default: '23'
+        type: string
+      selector_version:
+        description: 'minimum_selector_version stamped on every migrated bundle (REQUIRED_JSON_VERSION in helpers.py)'
+        required: true
+        default: '20'
+        type: string
+      hf_repo:
+        description: 'Dataset that receives the whole files (the chunks are read from the URLs in the source manifest)'
+        required: true
+        default: 'sunnypilot/sunnypilot_models_v1'
+        type: string
+      docs_repo:
+        description: 'GitHub repo holding the driving_models JSON on its gh-pages branch'
+        required: true
+        default: 'sunnypilot/sunnypilot-models'
+        type: string
+      only:
+        description: 'Comma-separated short names to migrate (empty = whole catalog)'
+        required: false
+        default: ''
+        type: string
+      dry_run:
+        description: 'Download and verify only: no uploads, no manifest'
+        required: true
+        default: true
+        type: boolean
+
+env:
+  PREFIX: driving_models_${{ inputs.target_hardware == 'chestnut' && 'chestnut_' || '' }}v
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout sunnypilot (the dispatching repo and branch)
+        uses: actions/checkout@v4
+
+      - name: Checkout docs repo (gh-pages)
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.docs_repo }}
+          ref: gh-pages
+          path: docs
+          ssh-key: ${{ secrets.CI_SUNNYPILOT_DOCS_PRIVATE_KEY }}
+
+      - name: Install dependencies
+        run: pip install --upgrade "huggingface_hub>=0.22.0" requests
+
+      - name: Migrate
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          python3 release/ci/migrate_whole_file_models.py \
+            --src-json "docs/docs/${PREFIX}${{ inputs.src_json_version }}.json" \
+            --dst-json "docs/docs/${PREFIX}${{ inputs.dst_json_version }}.json" \
+            --hf-repo "${{ inputs.hf_repo }}" \
+            --selector-version "${{ inputs.selector_version }}" \
+            --only "${{ inputs.only }}" \
+            --work-dir "${{ runner.temp }}" \
+            ${{ inputs.dry_run && '--dry-run' || '' }}
+
+      - name: Push the whole-file manifest to the docs repo
+        if: ${{ !inputs.dry_run }}
+        run: |
+          cd docs
+          git config --global user.name "GitHub Action"
+          git config --global user.email "action@github.com"
+          git pull origin gh-pages
+          git add "docs/${PREFIX}${{ inputs.dst_json_version }}.json"
+          git commit -m "Add ${PREFIX}${{ inputs.dst_json_version }}.json: whole files migrated from ${PREFIX}${{ inputs.src_json_version }}.json" || echo "No changes to commit"
+          git push origin gh-pages

--- a/openpilot/sunnypilot/models/tests/test_migrate_whole_file_models.py
+++ b/openpilot/sunnypilot/models/tests/test_migrate_whole_file_models.py
@@ -1,0 +1,219 @@
+"""
+Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+"""
+import hashlib
+import http.server
+import json
+import os
+import socketserver
+import tempfile
+import threading
+import unittest
+import urllib.parse
+from pathlib import Path
+from typing import cast
+from types import SimpleNamespace
+from unittest import mock
+
+import requests
+from huggingface_hub import HfApi
+
+from openpilot.common.test import OpenpilotTestCase
+from release.ci import migrate_whole_file_models as migrate
+
+SRC_REPO = "sunnypilot/sunnypilot_models_v1"
+DST_REPO = "fork/sunnypilot_models_v1"
+
+
+def sha256(data: bytes) -> str:
+  return hashlib.sha256(data).hexdigest()
+
+
+class RepoHandler(http.server.BaseHTTPRequestHandler):
+  """Serves /datasets/<repo>/resolve/main/<path> from a dict per repo; honors single byte ranges like HuggingFace."""
+  repos: dict[str, dict[str, bytes]] = {}
+
+  def do_GET(self):
+    _, _, repo_and_path = self.path.partition("/datasets/")
+    repo, _, path = urllib.parse.unquote(repo_and_path).partition(migrate.RESOLVE)
+    body = self.repos.get(repo, {}).get(path)
+    if body is None:
+      self.send_response(404)
+      self.end_headers()
+      return
+    range_header = self.headers.get("Range", "")
+    if range_header.startswith("bytes="):
+      start, _, end = range_header[6:].partition("-")
+      start, end = int(start), int(end)
+      self.send_response(206)
+      self.send_header("Content-Range", f"bytes {start}-{end}/{len(body)}")
+      body = body[start:end + 1]
+    else:
+      self.send_response(200)
+    self.send_header("Content-Length", str(len(body)))
+    self.end_headers()
+    self.wfile.write(body)
+
+  def log_message(self, *args, **kwargs):
+    pass
+
+
+class FakeHfApi:
+  """Enough of HfApi for the script: LFS metadata lookup and file upload, backed by the served dict."""
+
+  def __init__(self, files: dict[str, bytes]):
+    self.files = files
+    self.uploads: list[str] = []
+
+  def get_paths_info(self, repo_id, paths, repo_type):
+    assert repo_id == DST_REPO and repo_type == "dataset"
+    return [SimpleNamespace(path=p, size=len(self.files[p]), lfs=SimpleNamespace(sha256=sha256(self.files[p]))) for p in paths if p in self.files]
+
+  def upload_file(self, *, path_or_fileobj, path_in_repo, repo_id, repo_type, commit_message):
+    assert repo_id == DST_REPO and repo_type == "dataset" and commit_message
+    self.files[path_in_repo] = Path(path_or_fileobj).read_bytes()
+    self.uploads.append(path_in_repo)
+
+
+class TestMigrateWholeFileModels(OpenpilotTestCase):
+  FOLDER = "models/recompiled9/model-Lav2 Model (January 24, 2024)-117"
+  FILE = "driving_lav2_model_january_24_2024_tinygrad.pkl"
+
+  @classmethod
+  def setUpClass(cls):
+    super().setUpClass()
+    cls.server = socketserver.ThreadingTCPServer(("127.0.0.1", 0), RepoHandler)
+    cls.server.daemon_threads = True
+    threading.Thread(target=cls.server.serve_forever, daemon=True).start()
+    cls.endpoint = f"http://127.0.0.1:{cls.server.server_address[1]}"
+
+  @classmethod
+  def tearDownClass(cls):
+    cls.server.shutdown()
+    cls.server.server_close()
+    super().tearDownClass()
+
+  def setUp(self):
+    super().setUp()
+    self.whole = os.urandom(3 * 1024 + 517)
+    self.chunks = [self.whole[:2048], self.whole[2048:]]
+    self.src_files = {f"{self.FOLDER}/{self.FILE}.chunk{i + 1:02d}of02": chunk for i, chunk in enumerate(self.chunks)}
+    self.dst_files: dict[str, bytes] = {}
+    RepoHandler.repos = {SRC_REPO: self.src_files, DST_REPO: self.dst_files}
+    self.api = FakeHfApi(self.dst_files)
+    self.session = requests.Session()
+    patcher = mock.patch.object(migrate.hf_constants, "ENDPOINT", self.endpoint)
+    patcher.start()
+    self.addCleanup(patcher.stop)
+    patcher = mock.patch.object(migrate.time, "sleep")
+    patcher.start()
+    self.addCleanup(patcher.stop)
+
+  def bundle(self, short_name="LAV2", index=3):
+    quoted_folder = urllib.parse.quote(self.FOLDER)
+    return {
+      "short_name": short_name, "display_name": f"{short_name} (January 24, 2024)", "is_20hz": False, "is_big": False, "ref": "abc",
+      "environment": "release", "runner": "tinygrad", "index": index, "minimum_selector_version": "19", "generation": "12",
+      "overrides": {"folder": "Release Models", "lat": ".1", "long": ".3"},
+      "models": [{"type": "chunked", "artifact": {
+        "file_name": self.FILE,
+        "download_uri": {"url": f"{self.endpoint}/datasets/{SRC_REPO}{migrate.RESOLVE}{quoted_folder}/{self.FILE}", "sha256": sha256(self.whole)},
+        "chunks": [{"file_name": f"{self.FILE}.chunk{i + 1:02d}of02", "sha256": sha256(chunk)} for i, chunk in enumerate(self.chunks)],
+      }}],
+    }
+
+  def manifest(self, *bundles):
+    return {"tinygrad_ref": "e837e367", "bundles": list(bundles)}
+
+  def run_migration(self, src, **kwargs):
+    return migrate.migrate_manifest(src, hf_repo=DST_REPO, api=cast(HfApi, self.api), session=self.session, selector_version=20, model_type="driving",
+                                    log=lambda _: None, **kwargs)
+
+  def test_joins_uploads_and_rewrites_entry(self):
+    dst = self.run_migration(self.manifest(self.bundle()))
+    path = f"{self.FOLDER}/{self.FILE}"
+    assert self.api.uploads == [path]
+    assert self.dst_files[path] == self.whole
+    assert dst["tinygrad_ref"] == "e837e367"
+    bundle = dst["bundles"][0]
+    assert bundle["minimum_selector_version"] == "20"
+    assert bundle["index"] == 3 and bundle["overrides"] == {"folder": "Release Models", "lat": ".1", "long": ".3"}
+    model = bundle["models"][0]
+    assert model["type"] == "driving"
+    assert "chunks" not in model["artifact"]
+    assert model["artifact"]["download_uri"] == {"url": f"{self.endpoint}/datasets/{DST_REPO}{migrate.RESOLVE}{urllib.parse.quote(self.FOLDER)}/{self.FILE}",
+                                                 "sha256": sha256(self.whole)}
+    # the URL the manifest carries must be fetchable by ranges, as the client does it
+    assert requests.get(model["artifact"]["download_uri"]["url"], headers={"Range": "bytes=0-0"}).status_code == 206
+
+  def test_rerun_keeps_stored_file_without_transfer(self):
+    self.dst_files[f"{self.FOLDER}/{self.FILE}"] = self.whole
+    with mock.patch.object(migrate, "download", side_effect=AssertionError("must not download")):
+      dst = self.run_migration(self.manifest(self.bundle()))
+    assert self.api.uploads == []
+    assert "chunks" not in dst["bundles"][0]["models"][0]["artifact"]
+
+  def test_stale_stored_file_is_replaced(self):
+    self.dst_files[f"{self.FOLDER}/{self.FILE}"] = b"an older build under the same name"
+    self.run_migration(self.manifest(self.bundle()))
+    assert self.dst_files[f"{self.FOLDER}/{self.FILE}"] == self.whole
+
+  def test_whole_hash_mismatch_stops_before_upload(self):
+    bad = self.bundle()
+    bad["models"][0]["artifact"]["download_uri"]["sha256"] = sha256(b"not the joined file")
+    with self.assertRaisesRegex(RuntimeError, "joined chunks hash"):
+      self.run_migration(self.manifest(self.bundle("OK", 1), bad))
+    assert self.api.uploads == [f"{self.FOLDER}/{self.FILE}"]  # the good bundle before it; the bad one never uploaded
+
+  def test_corrupt_chunk_is_retried_then_fails(self):
+    self.src_files[f"{self.FOLDER}/{self.FILE}.chunk02of02"] = b"corrupt"
+    with self.assertRaisesRegex(RuntimeError, "giving up"):
+      self.run_migration(self.manifest(self.bundle()))
+    assert self.api.uploads == []
+
+  def test_dry_run_verifies_without_uploading(self):
+    dst = self.run_migration(self.manifest(self.bundle()), dry_run=True)
+    assert self.api.uploads == [] and self.dst_files == {}
+    assert "chunks" not in dst["bundles"][0]["models"][0]["artifact"]
+
+  def test_only_and_limit_select_bundles(self):
+    src = self.manifest(self.bundle("A", 1), self.bundle("B", 2), self.bundle("C", 3))
+    assert [b["short_name"] for b in self.run_migration(src, only={"C", "A"})["bundles"]] == ["A", "C"]
+    assert [b["short_name"] for b in self.run_migration(src, limit=2)["bundles"]] == ["A", "B"]
+    with self.assertRaisesRegex(ValueError, "not in the source manifest: Z"):
+      self.run_migration(src, only={"Z"})
+
+  def test_unchunked_entry_needs_a_stored_file(self):
+    plain = self.bundle()
+    del plain["models"][0]["artifact"]["chunks"]
+    with self.assertRaisesRegex(RuntimeError, "no chunks to join"):
+      self.run_migration(self.manifest(plain))
+    self.dst_files[f"{self.FOLDER}/{self.FILE}"] = self.whole
+    assert self.run_migration(self.manifest(plain))["bundles"][0]["models"][0]["type"] == "driving"
+
+  def test_missing_tinygrad_ref_is_refused(self):
+    with self.assertRaisesRegex(ValueError, "tinygrad_ref"):
+      self.run_migration({"bundles": [self.bundle()]})
+
+  def test_repo_path_and_dest_url_round_trip(self):
+    url = "https://huggingface.co/datasets/sunnypilot/sunnypilot_models_v1/resolve/main/models/recompiled23/model-Terrible%20Model%20%28August%2015%2C%202026%29-117/driving_terrible_model_tinygrad.pkl"
+    path = migrate.repo_path(url)
+    assert path == "models/recompiled23/model-Terrible Model (August 15, 2026)-117/driving_terrible_model_tinygrad.pkl"
+    with mock.patch.object(migrate.hf_constants, "ENDPOINT", "https://huggingface.co"):
+      assert migrate.dest_url("sunnypilot/sunnypilot_models_v1", path) == url
+
+  def test_written_manifest_matches_parser_style(self):
+    dst = self.run_migration(self.manifest(self.bundle()))
+    with tempfile.TemporaryDirectory() as d:
+      out = Path(d) / "driving_models_v23.json"
+      migrate.write_manifest(out, dst)
+      text = out.read_text()
+    assert '"overrides": { "folder": "Release Models", "lat": ".1", "long": ".3" }' in text
+    assert json.loads(text) == dst
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/release/ci/migrate_whole_file_models.py
+++ b/release/ci/migrate_whole_file_models.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""One-off migration of a chunked driving_models manifest to whole files (selector version 20).
+
+For every model in the source manifest the .chunkNNofMM files are downloaded, joined and checked
+against download_uri.sha256, which has always been the hash of the whole file. The whole pkl is
+uploaded beside its chunks and HuggingFace's stored LFS hash is compared with the manifest before
+the entry is accepted. The target manifest is the source with the chunk lists dropped, the model
+type set and the selector version bumped; nothing else moves. Old clients keep reading the source
+manifest and its chunks.
+
+Rerunnable: a model whose whole file is already stored with the right hash is not transferred
+again. The target manifest is only written when every selected model migrated, so it never lists
+a model that cannot be downloaded.
+
+Delete this script and its workflow once the catalog is on whole files.
+"""
+import argparse
+import hashlib
+import json
+import posixpath
+import re
+import shutil
+import sys
+import tempfile
+import time
+import urllib.parse
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import requests
+from huggingface_hub import HfApi
+from huggingface_hub import constants as hf_constants
+from huggingface_hub.utils import disable_progress_bars
+
+RESOLVE = "/resolve/main/"
+DOWNLOAD_ATTEMPTS = 3
+BLOCK = 1 << 20
+
+
+def repo_path(url: str) -> str:
+  """'https://huggingface.co/datasets/o/n/resolve/main/models/x/y.pkl' -> 'models/x/y.pkl' (unquoted)."""
+  path = urllib.parse.urlparse(url).path
+  if RESOLVE not in path:
+    raise ValueError(f"not a HuggingFace resolve URL: {url}")
+  return urllib.parse.unquote(path.split(RESOLVE, 1)[1])
+
+
+def dest_url(hf_repo: str, path: str) -> str:
+  # the same quoting as make_model_url in the docs repo's json_parser.py: each path segment on its own
+  quoted = "/".join(urllib.parse.quote(segment) for segment in path.split("/"))
+  return f"{hf_constants.ENDPOINT}/datasets/{hf_repo}{RESOLVE}{quoted}"
+
+
+def chunk_urls(artifact: dict) -> list[str]:
+  folder = posixpath.dirname(artifact["download_uri"]["url"])
+  return [f"{folder}/{urllib.parse.quote(chunk['file_name'])}" for chunk in artifact["chunks"]]
+
+
+def download(session: requests.Session, url: str, dest: Path, expected_sha256: str) -> None:
+  """Stream url to dest, retried on transport errors and on a hash mismatch."""
+  last: Exception | None = None
+  for attempt in range(DOWNLOAD_ATTEMPTS):
+    try:
+      digest = hashlib.sha256()
+      with session.get(url, stream=True, timeout=60) as response, open(dest, "wb") as f:
+        response.raise_for_status()
+        for block in response.iter_content(BLOCK):
+          f.write(block)
+          digest.update(block)
+      if digest.hexdigest() != expected_sha256:
+        raise ValueError(f"sha256 mismatch for {url}")
+      return
+    except (requests.RequestException, ValueError) as e:
+      last = e
+      time.sleep(2 * (attempt + 1))
+  raise RuntimeError(f"giving up on {url}: {last}")
+
+
+def join_chunks(chunks: list[Path], whole: Path) -> str:
+  digest = hashlib.sha256()
+  with open(whole, "wb") as out:
+    for chunk in chunks:
+      with open(chunk, "rb") as f:
+        for block in iter(lambda: f.read(BLOCK), b""):
+          out.write(block)
+          digest.update(block)
+  return digest.hexdigest()
+
+
+def stored_file(api: HfApi, hf_repo: str, path: str) -> tuple[str, int] | None:
+  """(sha256, size) of the LFS object HuggingFace holds at path, None when absent."""
+  for entry in api.get_paths_info(hf_repo, [path], repo_type="dataset"):
+    lfs = getattr(entry, "lfs", None)
+    sha256 = getattr(lfs, "sha256", None) if lfs is not None else None
+    if sha256:
+      return sha256, int(entry.size)
+  return None
+
+
+def range_probe(session: requests.Session, url: str, size: int) -> None:
+  """The client fetches whole files as byte ranges, so the stored file must answer one."""
+  with session.get(url, headers={"Range": "bytes=0-0"}, stream=True, timeout=30) as response:
+    total = response.headers.get("Content-Range", "").rpartition("/")[2]
+    if response.status_code != 206 or total != str(size):
+      raise RuntimeError(f"{url}: HTTP {response.status_code}, Content-Range total {total!r}; expected 206 and {size}")
+
+
+def migrate_artifact(api: HfApi, session: requests.Session, hf_repo: str, name: str, artifact: dict,
+                     work_dir: Path, workers: int, dry_run: bool) -> tuple[str, int, str]:
+  """Make sure the whole file for artifact is stored under hf_repo with the manifest's hash.
+  Returns (url, size, outcome) with outcome one of 'kept', 'uploaded', 'verified (dry run)'."""
+  expected = artifact["download_uri"]["sha256"]
+  path = repo_path(artifact["download_uri"]["url"])
+  url = dest_url(hf_repo, path)
+
+  stored = stored_file(api, hf_repo, path)
+  if stored is not None and stored[0] == expected:
+    range_probe(session, url, stored[1])
+    return url, stored[1], "kept"
+  if not artifact.get("chunks"):
+    raise RuntimeError(f"{name}: no chunks to join and no whole file with hash {expected} stored at {path}")
+
+  model_dir = Path(tempfile.mkdtemp(prefix="model-", dir=work_dir))
+  try:
+    chunk_paths = [model_dir / chunk["file_name"] for chunk in artifact["chunks"]]
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+      list(pool.map(lambda job: download(session, *job),
+                    zip(chunk_urls(artifact), chunk_paths, [chunk["sha256"] for chunk in artifact["chunks"]], strict=True)))
+    whole = model_dir / posixpath.basename(path)
+    joined = join_chunks(chunk_paths, whole)
+    for chunk_path in chunk_paths:
+      chunk_path.unlink()
+    if joined != expected:
+      raise RuntimeError(f"{name}: joined chunks hash to {joined}, manifest says {expected}")
+    size = whole.stat().st_size
+    if dry_run:
+      return url, size, "verified (dry run)"
+
+    api.upload_file(path_or_fileobj=str(whole), path_in_repo=path, repo_id=hf_repo, repo_type="dataset",
+                    commit_message=f"Whole file for {name}: {posixpath.basename(path)}")
+  finally:
+    shutil.rmtree(model_dir, ignore_errors=True)
+
+  stored = stored_file(api, hf_repo, path)
+  if stored is None or stored[0] != expected:
+    raise RuntimeError(f"{name}: HuggingFace holds {stored} at {path} after upload, expected hash {expected}")
+  range_probe(session, url, size)
+  return url, size, "uploaded"
+
+
+def migrate_manifest(src: dict, *, hf_repo: str, api: HfApi, session: requests.Session, selector_version: int, model_type: str,
+                     only: set[str] | None = None, limit: int | None = None, workers: int = 8, work_dir: Path | None = None,
+                     dry_run: bool = False, log: Callable[[str], None] = lambda line: print(line, flush=True)) -> dict:
+  """The whole-file manifest for src. Raises before anything is written if a model cannot be migrated."""
+  if "tinygrad_ref" not in src:
+    raise ValueError("source manifest has no tinygrad_ref; the client's manifest test requires one")
+  bundles = [bundle for bundle in src["bundles"] if only is None or bundle["short_name"] in only]
+  if only is not None and (missing := only - {bundle["short_name"] for bundle in bundles}):
+    raise ValueError(f"not in the source manifest: {', '.join(sorted(missing))}")
+  if limit is not None:
+    bundles = bundles[:limit]
+  if not bundles:
+    raise ValueError("no bundles selected")
+
+  work_dir = Path(tempfile.mkdtemp(prefix="migrate-", dir=work_dir))
+  migrated = []
+  try:
+    for i, bundle in enumerate(bundles, 1):
+      out = json.loads(json.dumps(bundle))
+      out["minimum_selector_version"] = str(selector_version)
+      for model in out["models"]:
+        model["type"] = model_type
+        artifact = model["artifact"]
+        started = time.monotonic()
+        url, size, outcome = migrate_artifact(api, session, hf_repo, bundle["short_name"], artifact, work_dir, workers, dry_run)
+        artifact.pop("chunks", None)
+        artifact["download_uri"]["url"] = url
+        log(f"[{i}/{len(bundles)}] {bundle['short_name']}: {outcome}, {size / 1e6:.1f} MB, {time.monotonic() - started:.0f} s")
+      migrated.append(out)
+  finally:
+    shutil.rmtree(work_dir, ignore_errors=True)
+
+  dst = {key: value for key, value in src.items() if key != "bundles"}
+  dst["bundles"] = migrated
+  return dst
+
+
+def collapse_overrides(json_text: str) -> str:
+  # one line per overrides dict, as json_parser.py writes it
+  def replacer(match):
+    items = [line.strip().rstrip(",") for line in match.group(2).splitlines() if line.strip()]
+    return f'{match.group(1)}{{ {", ".join(items)} }}'
+  return re.sub(r'("overrides": ){\s*([^}]*)\s*}', replacer, json_text)
+
+
+def write_manifest(path: Path, manifest: dict) -> None:
+  path.write_text(collapse_overrides(json.dumps(manifest, indent=2)) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+  parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+  parser.add_argument("--src-json", required=True, type=Path, help="chunked manifest to read, e.g. docs/docs/driving_models_v22.json")
+  parser.add_argument("--dst-json", required=True, type=Path, help="whole-file manifest to write, e.g. docs/docs/driving_models_v23.json")
+  parser.add_argument("--hf-repo", required=True, help="dataset that receives the whole files; chunks are read from the source manifest's URLs")
+  parser.add_argument("--selector-version", type=int, default=20)
+  parser.add_argument("--model-type", default="driving")
+  parser.add_argument("--only", default="", help="comma-separated short names; empty means every bundle")
+  parser.add_argument("--limit", type=int, default=None, help="stop after this many bundles (rehearsals)")
+  parser.add_argument("--workers", type=int, default=8, help="parallel chunk downloads per model")
+  parser.add_argument("--work-dir", type=Path, default=None, help="scratch space for one model at a time")
+  parser.add_argument("--dry-run", action="store_true", help="download and verify only: no uploads, no manifest")
+  args = parser.parse_args()
+  disable_progress_bars()  # the upload bars are per-file tqdm output, unreadable in a CI log
+
+  src = json.loads(args.src_json.read_text(encoding="utf-8"))
+  only = {name.strip() for name in args.only.split(",") if name.strip()} or None
+  try:
+    dst = migrate_manifest(src, hf_repo=args.hf_repo, api=HfApi(), session=requests.Session(), selector_version=args.selector_version,
+                           model_type=args.model_type, only=only, limit=args.limit, workers=args.workers, work_dir=args.work_dir,
+                           dry_run=args.dry_run)
+  except Exception as e:
+    print(f"migration stopped, nothing written: {e}", file=sys.stderr)
+    return 1
+
+  if args.dry_run:
+    print(f"dry run: {len(dst['bundles'])} bundle(s) verified, {args.dst_json} not written", flush=True)
+    return 0
+  write_manifest(args.dst_json, dst)
+  print(f"{args.dst_json} written with {len(dst['bundles'])} bundle(s) at selector version {args.selector_version}", flush=True)
+  return 0
+
+
+if __name__ == "__main__":
+  sys.exit(main())


### PR DESCRIPTION
Add a script that takes an existing model manifest file, downloads all of the individual chunks, merges them into one file which is checked against the existing whole file sha256 in the manifest to ensure it's correct and then uploads them to the existing hugging face folder the chunks were in, dropping the chunks and setting the type from chunked->driving.

Example diff of a model from old to new:
```diff
  "short_name": "LAV2",
  ...
- "minimum_selector_version": "19",
+ "minimum_selector_version": "20",          # bundle-level: the exact-match gate
  ...
  "models": [
    {
-     "type": "chunked",
+     "type": "driving",                       # model-level
      "artifact": {
        "file_name": "driving_lav2_january_24_2024_tinygrad.pkl",
        "download_uri": {
          "url": ".../models/recompiled23/model-LAv2.../driving_lav2..._tinygrad.pkl",
          "sha256": "e58e6c5b...953a"          # ← UNCHANGED
        },
-       "chunks": [
-         { "file_name": "...pkl.chunk01of02", "sha256": "337088..." },
-         { "file_name": "...pkl.chunk02of02", "sha256": "1877690..." }
-       ]                                       # whole chunks array dropped
      }
    }
  ]
```

This PR does not do anything on it's own, but is more of a preparation step for migration once the other PRs are ready to merge. The process will be something like:
1. Merge this PR
2. Merge #2011, #2012, #2013, #2014 sometime, no rush as it's all inert code until the chunks are no longer in the active manifest
3. Run the workflow from this action twice, one for small models and one for big models
4. Merge #2015 to flip over master to use the new whole file manifest and clean up old chunked downloader

Test runs:
- qcom v22 -> v23: [github action run](https://github.com/AmyJeanes/sunnypilot/actions/runs/34143725868) + [output manifest](https://github.com/AmyJeanes/sunnypilot-models/blob/gh-pages/docs/driving_models_v23.json)
- chestnut v25 -> v26: [github action run](https://github.com/AmyJeanes/sunnypilot/actions/runs/34142347346) + [output manifest](https://github.com/AmyJeanes/sunnypilot-models/blob/gh-pages/docs/driving_models_chestnut_v26.json)

[output hugging face repository](https://huggingface.co/datasets/AmyJeanes/sunnypilot_models_v1/tree/main/models)

One decision to be made: Do we upload the files to a new recompiledN folder in hugging face, or keep them in the same folder as the script currently does. I currently chose to keep them where they were as 1. it's not a recompile it's just joining the chunks together and 2. because the full file URL actually is already present in the existing manifest files, and this script makes them resolve, otherwise we'd have to edit them too.