### PR TITLE
models: switch to whole-file manifests (selector version 20)

### DIFF
--- a/.github/workflows/sunnypilot-build-model.yaml
+++ b/.github/workflows/sunnypilot-build-model.yaml
@@ -261,11 +261,10 @@ jobs:
           sudo rm -rf ${{ env.OUTPUT_DIR }}
           mkdir -p ${{ env.OUTPUT_DIR }}
 
-          # Copy the model files
+          # Copy the model files (the compiled pkl is published whole; clients range-request it)
           rsync -avm \
             --include='*.dlc' \
-            --include='*.chunk*' \
-            --include='*.chunkmanifest' \
+            --include='*_tinygrad.pkl' \
             --exclude='*' \
             --delete-excluded \
             --chown=comma:comma \

--- a/openpilot/cereal/custom.capnp
+++ b/openpilot/cereal/custom.capnp
@@ -150,7 +150,7 @@ struct ModelManagerSP @0xaedffd8f31e7b55d {
     fileName @0 :Text;
     downloadUri @1 :DownloadUri;
     downloadProgress @2 :DownloadProgress;
-    chunks @3 :List(Chunk);
+    chunks @3 :List(Chunk);  # unused since selector version 20: models are whole files
   }
 
   struct Model {
@@ -165,7 +165,8 @@ struct ModelManagerSP @0xaedffd8f31e7b55d {
       policy @3;
       offPolicy @4;
       onPolicy @5;
-      chunked @6;
+      chunked @6;  # legacy: the combined driving pkl split into .chunkNNofMM files (manifests v18-v22)
+      driving @7;  # the combined driving pkl, published whole (selector version 20+)
     }
   }
 

--- a/openpilot/cereal/custom.capnp
+++ b/openpilot/cereal/custom.capnp
@@ -138,6 +138,7 @@ struct ModelManagerSP @0xaedffd8f31e7b55d {
     status @0 :DownloadStatus;
     progress @1 :Float32;
     eta @2 :UInt32;
+    speed @3 :Float32;  # bytes per second, smoothed
   }
 
   struct Chunk {

--- a/openpilot/selfdrive/ui/sunnypilot/layouts/settings/models.py
+++ b/openpilot/selfdrive/ui/sunnypilot/layouts/settings/models.py
@@ -241,7 +241,10 @@ class ModelsLayout(Widget):
     if ds.verifying in statuses:
       return {"name": name, "downloading": True, "progress": progress, "status_text": tr("verifying")}
     if ds.downloading in statuses:
-      return {"name": name, "downloading": True, "progress": progress}
+      # max, not sum: artifacts sharing a file mirror the same transfer, and only one file is in flight
+      speed = max((p.speed for p in progresses), default=0.0)
+      status_text = f"{speed / 1048576:.1f} MB/s" if speed > 0 else ""
+      return {"name": name, "downloading": True, "progress": progress, "status_text": status_text}
     if statuses <= {ds.downloaded, ds.cached}:
       return {"name": name, "text_color": ON_COLOR, "icon": "icons/checkmark.png"}
     # circled_slash is authored grey; tinting it again only darkens it

--- a/openpilot/selfdrive/ui/sunnypilot/mici/layouts/models.py
+++ b/openpilot/selfdrive/ui/sunnypilot/mici/layouts/models.py
@@ -212,8 +212,9 @@ class ModelsLayoutMici(NavScroller):
     self.current_model_info.info_text.set_text(info_text)
 
     if manager.selectedBundle and manager.selectedBundle.status == custom.ModelManagerSP.DownloadStatus.failed:
-      self.current_model_info.info_header.set_text(tr("error") + self._download_progress)
-      self.current_model_info.info_text.set_text(tr("download failed"))
+      # a failed bundle stays on the row until the next request, so it names the model and does not animate
+      self.current_model_info.info_header.set_text(tr("error"))
+      self.current_model_info.info_text.set_text(f"{manager.selectedBundle.internalName.lower()}  |  {tr('download failed')}")
 
     elif manager.selectedBundle and manager.selectedBundle.status == custom.ModelManagerSP.DownloadStatus.downloading:
       self.cancel_download_btn.set_visible(True)

--- a/openpilot/selfdrive/ui/sunnypilot/mici/layouts/models.py
+++ b/openpilot/selfdrive/ui/sunnypilot/mici/layouts/models.py
@@ -221,6 +221,7 @@ class ModelsLayoutMici(NavScroller):
       progress = 0.0
       count = 0
       verifying = False
+      speed = 0.0  # max, not sum: artifacts sharing a file mirror the same transfer, and only one file is in flight
       for model in manager.selectedBundle.models:
         count += 1
         p = model.artifact.downloadProgress
@@ -228,6 +229,7 @@ class ModelsLayoutMici(NavScroller):
                         custom.ModelManagerSP.DownloadStatus.verifying):
           progress += p.progress
           verifying = verifying or p.status == custom.ModelManagerSP.DownloadStatus.verifying
+          speed = max(speed, p.speed)
         elif p.status in (custom.ModelManagerSP.DownloadStatus.downloaded,
                           custom.ModelManagerSP.DownloadStatus.cached):
           progress += 100.0
@@ -241,7 +243,10 @@ class ModelsLayoutMici(NavScroller):
       self.current_model_info.current_model_text.set_text(name_text)
       self.current_model_info.info_header.set_text(tr("progress") + self._download_progress)
       self.current_model_info.info_header._shimmer = True
-      self.current_model_info.info_text.set_text(f"{progress/count:.2f}%")
+      progress_text = f"{progress/count:.2f}%"
+      if speed > 0:
+        progress_text += f"  |  {speed / 1048576:.1f} MB/s"
+      self.current_model_info.info_text.set_text(progress_text)
 
     elif manager.selectedBundle and manager.selectedBundle.status == custom.ModelManagerSP.DownloadStatus.downloaded:
       self.current_model_info.info_header.set_text(tr("downloaded"))

--- a/openpilot/sunnypilot/modeld_v2/compile_modeld.py
+++ b/openpilot/sunnypilot/modeld_v2/compile_modeld.py
@@ -293,7 +293,6 @@ if __name__ == "__main__":
     else:
       raise RuntimeError("Chestnut not ready, skipping big model build")
 
-  from openpilot.common.file_chunker import chunk_file, get_chunk_targets
   from openpilot.selfdrive.modeld.get_model_metadata import make_metadata_dict
   from openpilot.system.camerad.cameras.nv12_info import get_nv12_info
   from tinygrad.nn.onnx import OnnxRunner
@@ -384,8 +383,6 @@ if __name__ == "__main__":
   with open(args.output, "wb") as file:
     dump_oob(output_data, file)
 
+  # published whole: the model manager fetches it with parallel byte ranges
   pkl_size = os.path.getsize(args.output)
   print(f"Saved combined JIT to {args.output} ({pkl_size / 1e6:.2f} MB)")
-  chunk_targets = get_chunk_targets(args.output, pkl_size)
-  chunk_file(args.output, chunk_targets)
-  print(f"Chunked into {len(chunk_targets) - 1} file(s)")

--- a/openpilot/sunnypilot/modeld_v2/tests/test_fallback.py
+++ b/openpilot/sunnypilot/modeld_v2/tests/test_fallback.py
@@ -6,18 +6,37 @@ See the LICENSE.md file in the root directory for more details.
 """
 
 import io
-import requests
 
-from openpilot.common.file_chunker import get_chunk_name
 from openpilot.common.hardware import hw
 from openpilot.common.test import OpenpilotTestCase
 from openpilot.selfdrive.modeld.helpers import dump_oob
 import openpilot.sunnypilot.modeld_v2.modeld as modeld_module
 from openpilot.sunnypilot.modeld_v2.tests import helpers as tests_helpers
 from openpilot.sunnypilot.modeld_v2.tests.helpers import DummyModel, DummyBundle, CAM_W, CAM_H
-from openpilot.sunnypilot.models.fetcher import ModelParser, ModelFetcher
+from openpilot.sunnypilot.models.fetcher import ModelParser
+from openpilot.sunnypilot.models.helpers import REQUIRED_JSON_VERSION
 
 tmp_path = tests_helpers.tmp_path
+
+
+def manifest_bundle(short_name: str, file_name: str, is_big: bool) -> dict:
+  """A whole-file manifest bundle as the fetcher parses it from driving_models_*.json."""
+  return {
+    "index": 0,
+    "short_name": short_name,
+    "display_name": short_name,
+    "generation": 1,
+    "environment": "release",
+    "runner": "tinygrad",
+    "is_big": is_big,
+    "minimum_selector_version": str(REQUIRED_JSON_VERSION),
+    "ref": short_name,
+    "overrides": {"lat": ".1", "long": ".3"},
+    "models": [{
+      "type": "supercombo",
+      "artifact": {"file_name": file_name, "download_uri": {"url": f"https://example.com/{file_name}", "sha256": "s"}},
+    }],
+  }
 
 
 class TestFallback(OpenpilotTestCase):
@@ -38,19 +57,15 @@ class TestFallback(OpenpilotTestCase):
 
   def test_download_models_and_init_modelstate_fallback(self, tmp_path, monkeypatch):
     monkeypatch.setattr(hw.Paths, 'model_root', staticmethod(lambda: str(tmp_path)))
-    big_json = requests.get(ModelFetcher.MODEL_URL_CHESTNUT).json()
-    big_bundle = ModelParser.parse_models(big_json)[-1]
-    small_json = requests.get(ModelFetcher.MODEL_URL).json()
-    small_bundle = ModelParser.parse_models(small_json)[-1]
+    big_bundle = ModelParser.parse_models({"bundles": [manifest_bundle("big", "big_driving_test_tinygrad.pkl", True)]})[0]
+    small_bundle = ModelParser.parse_models({"bundles": [manifest_bundle("small", "driving_test_tinygrad.pkl", False)]})[0]
 
     buf = io.BytesIO()
     dump_oob(tests_helpers.make_pkl_data(tests_helpers.ARCHETYPES['supercombo_non20hz']), buf)
     oob_bytes = buf.getvalue()
 
     for bundle in (big_bundle, small_bundle):
-      artifact = bundle.models[0].artifact
-      for i in range(len(artifact.chunks)):
-        (tmp_path / get_chunk_name(artifact.fileName, i, len(artifact.chunks))).write_bytes(oob_bytes if i == 0 else b"")
+      (tmp_path / bundle.models[0].artifact.fileName).write_bytes(oob_bytes)
 
     monkeypatch.setattr(modeld_module, 'get_active_bundle', lambda params=None, *, chestnut=None: small_bundle)
     assert modeld_module.ModelState(CAM_W, CAM_H, chestnut=False).chestnut is False

--- a/openpilot/sunnypilot/models/fetcher.py
+++ b/openpilot/sunnypilot/models/fetcher.py
@@ -6,12 +6,10 @@ See the LICENSE.md file in the root directory for more details.
 """
 
 import time
-import os
 import requests
 from requests.exceptions import (SSLError, RequestException, HTTPError)
 from openpilot.common.params import Params
 from openpilot.common.swaglog import cloudlog
-from openpilot.common.hardware.hw import Paths
 from openpilot.sunnypilot.models.helpers import is_bundle_version_compatible
 from openpilot.cereal import custom
 
@@ -27,34 +25,11 @@ class ModelParser:
     return download_uri
 
   @staticmethod
-  def _parse_chunk(chunk_data) -> custom.ModelManagerSP.Chunk:
-    chunk = custom.ModelManagerSP.Chunk()
-    chunk.fileName = chunk_data.get("file_name")
-    chunk.sha256 = chunk_data.get("sha256")
-    return chunk
-
-  @staticmethod
   def _parse_artifact(artifact_data) -> custom.ModelManagerSP.Artifact:
+    # whole-file artifacts only: download_uri points at the complete model and sha256 covers all of it
     artifact = custom.ModelManagerSP.Artifact()
     artifact.fileName = artifact_data.get("file_name")
     artifact.downloadUri = ModelParser._parse_download_uri(artifact_data.get("download_uri", {}))
-
-    if "chunks" in artifact_data:
-      artifact.chunks = [ModelParser._parse_chunk(chunk_data) for chunk_data in artifact_data["chunks"]]
-
-      try:
-        model_dir = Paths.model_root()
-        os.makedirs(model_dir, exist_ok=True)
-        manifest_path = os.path.join(model_dir, f"{artifact.fileName}.chunkmanifest")
-        num_chunks = str(len(artifact.chunks))
-
-        if not os.path.exists(manifest_path) or open(manifest_path).read().strip() != num_chunks:
-          with open(manifest_path, "w") as f:
-            f.write(num_chunks)
-          cloudlog.info(f"Wrote chunk manifest for {artifact.fileName}: {num_chunks} chunks")
-      except Exception as e:
-        cloudlog.warning(f"Failed to write chunk manifest for {artifact.fileName}: {e}")
-
     return artifact
 
   @staticmethod
@@ -138,8 +113,10 @@ class ModelCache:
 
 class ModelFetcher:
   """Handles fetching and caching of model data from remote source"""
-  MODEL_URL = "https://raw.githubusercontent.com/sunnypilot/sunnypilot-models/refs/heads/gh-pages/docs/driving_models_v22.json"
-  MODEL_URL_CHESTNUT = "https://raw.githubusercontent.com/sunnypilot/sunnypilot-models/refs/heads/gh-pages/docs/driving_models_chestnut_v25.json"
+  # v23 / chestnut_v26 are the first whole-file manifests (no chunks, selector version 20).
+  # Older clients keep reading the chunked v22 / chestnut_v25 manifests.
+  MODEL_URL = "https://raw.githubusercontent.com/sunnypilot/sunnypilot-models/refs/heads/gh-pages/docs/driving_models_v23.json"
+  MODEL_URL_CHESTNUT = "https://raw.githubusercontent.com/sunnypilot/sunnypilot-models/refs/heads/gh-pages/docs/driving_models_chestnut_v26.json"
 
   MODEL_SOURCES = {
     "qcom": (MODEL_URL, ""),
@@ -270,5 +247,3 @@ if __name__ == "__main__":
       model_overrides = {override.key: override.value for override in bundle.overrides}
       print(f"Bundle: {bundle.internalName}, Type: {model.type}, Status: {bundle.status}, Overrides: {model_overrides}")
       print(f"Artifact: {model.artifact.fileName}, Download URI: {model.artifact.downloadUri.uri}")
-      if model.artifact.chunks:
-        print(f"Contains {len(model.artifact.chunks)} chunks.")

--- a/openpilot/sunnypilot/models/helpers.py
+++ b/openpilot/sunnypilot/models/helpers.py
@@ -16,7 +16,8 @@ from openpilot.common.hardware.hw import Paths
 from openpilot.selfdrive.modeld.helpers import chestnut_present
 
 # SET ME TO THE EXACT JSON VERSION WE SET IN SUNNYPILOT_MODELS REPO
-REQUIRED_JSON_VERSION = 19
+# 20: whole-file models downloaded by parallel byte ranges; chunked bundles (<= 19) are not loaded
+REQUIRED_JSON_VERSION = 20
 
 CUSTOM_MODEL_PATH = Paths.model_root()
 ModelManager = custom.ModelManagerSP
@@ -58,20 +59,12 @@ def is_bundle_version_compatible(bundle: dict) -> bool:
 
 def _bundle_artifacts(bundle: custom.ModelManagerSP.ModelBundle) -> list[tuple[str, str]]:
   artifacts = []
-  from openpilot.common.file_chunker import get_chunk_name
   for model in getattr(bundle, 'models', []) or []:
-    for artifact in (getattr(model, 'artifact', None),):
-      if artifact and getattr(artifact, 'fileName', None):
-        if len(artifact.chunks) > 0:
-          for i, chunk in enumerate(artifact.chunks):
-            chunk_name = get_chunk_name(artifact.fileName, i, len(artifact.chunks))
-            if getattr(chunk, 'sha256', None):
-              artifacts.append((chunk_name, chunk.sha256))
-        else:
-          if getattr(artifact, 'downloadUri', None):
-            sha256 = getattr(artifact.downloadUri, 'sha256', None)
-            if sha256:
-              artifacts.append((artifact.fileName, sha256))
+    artifact = getattr(model, 'artifact', None)
+    if artifact and getattr(artifact, 'fileName', None) and getattr(artifact, 'downloadUri', None):
+      sha256 = getattr(artifact.downloadUri, 'sha256', None)
+      if sha256:
+        artifacts.append((artifact.fileName, sha256))
   return artifacts
 
 

--- a/openpilot/sunnypilot/models/manager.py
+++ b/openpilot/sunnypilot/models/manager.py
@@ -6,6 +6,7 @@ See the LICENSE.md file in the root directory for more details.
 """
 
 import asyncio
+import json
 import os
 import re
 import threading
@@ -48,19 +49,25 @@ def _is_transient(e: BaseException) -> bool:
 
 
 class _Progress:
-  """Bytes landed on disk, shared between worker threads and the reporter on the event loop."""
+  """Shared between worker threads and the reporter on the event loop: bytes landed on disk and the
+  indices of the pieces that are complete."""
 
-  def __init__(self):
-    self._bytes = 0
+  def __init__(self, done: set[int], done_bytes: int):
+    self._bytes = done_bytes
+    self._done = set(done)
     self._lock = threading.Lock()
 
   def add_bytes(self, n: int) -> None:
     with self._lock:
       self._bytes += n
 
-  def snapshot(self) -> int:
+  def mark_done(self, index: int) -> None:
     with self._lock:
-      return self._bytes
+      self._done.add(index)
+
+  def snapshot(self) -> tuple[int, set[int]]:
+    with self._lock:
+      return self._bytes, set(self._done)
 
 
 def _piece_ranges(total: int, piece_size: int) -> list[tuple[int, int]]:
@@ -68,10 +75,52 @@ def _piece_ranges(total: int, piece_size: int) -> list[tuple[int, int]]:
   return [(start, min(start + piece_size, total)) for start in range(0, total, piece_size)]
 
 
-def _prepare_target(path: str, total: int) -> None:
-  """A sparse file of the full size; every piece lands at its own offset."""
+def _sidecar_path(path: str) -> str:
+  """Resume state of an in-progress download; its presence marks `path` as incomplete."""
+  return f"{path}.download"
+
+
+def _download_in_progress(path: str) -> bool:
+  return os.path.isfile(_sidecar_path(path))
+
+
+def _save_resume_state(path: str, layout: dict, done: set[int]) -> None:
+  # durable against power loss: the sidecar only ever names pieces whose bytes are already
+  # synced (see _fetch_piece), and is itself synced before it replaces the previous one
+  tmp = _sidecar_path(path) + ".tmp"
+  with open(tmp, "w") as f:
+    json.dump({**layout, "done": sorted(done)}, f)
+    f.flush()
+    os.fsync(f.fileno())
+  os.replace(tmp, _sidecar_path(path))
+  dir_fd = os.open(os.path.dirname(path) or ".", os.O_RDONLY)
+  try:
+    os.fsync(dir_fd)
+  finally:
+    os.close(dir_fd)
+
+
+def _remove_download_state(path: str) -> None:
+  for stale in (_sidecar_path(path), _sidecar_path(path) + ".tmp"):
+    if os.path.isfile(stale):
+      os.remove(stale)
+
+
+def _prepare_target(path: str, layout: dict) -> set[int]:
+  """Returns the pieces already on disk when `path` is an interrupted download of the same file
+  (matching sidecar layout and size); otherwise starts fresh with a sparse file of the full size."""
+  total = layout["total"]
+  try:
+    with open(_sidecar_path(path)) as f:
+      state = json.load(f)
+    if isinstance(state, dict) and all(state.get(k) == v for k, v in layout.items()) and os.path.getsize(path) == total:
+      return {i for i in state.get("done", []) if isinstance(i, int)}
+  except (OSError, ValueError, TypeError):  # missing, unreadable or malformed sidecar: start over
+    pass
   with open(path, "wb") as f:
     f.truncate(total)
+  _save_resume_state(path, layout, set())
+  return set()
 
 
 def _content_range_total(response: requests.Response) -> int | None:
@@ -116,6 +165,12 @@ def _fetch_piece(url: str, path: str, index: int, start: int, end: int | None, p
             f.truncate()  # unknown length: the body defines the file size
           if end is not None and written != end - start:
             raise requests.exceptions.ConnectionError(f"short read: {written} of {end - start} bytes")
+          # a piece counts as done only once its bytes are on flash: a sudden power loss
+          # (engine crank, battery disconnect) must not leave the sidecar claiming pieces
+          # that were still in the page cache, or the resumed file can never verify
+          f.flush()
+          os.fdatasync(f.fileno())
+      progress.mark_done(index)
       return
     except requests.RequestException as e:
       progress.add_bytes(-written)  # the piece restarts from scratch
@@ -124,6 +179,11 @@ def _fetch_piece(url: str, path: str, index: int, start: int, end: int | None, p
       cloudlog.warning(f"retrying {label} after {type(e).__name__}: {e}")
       if cancel.wait(PIECE_BACKOFF * (1 + attempt)):
         raise DownloadCancelled("Download cancelled") from None
+
+
+def _remove_file(path: str) -> None:
+  if os.path.isfile(path):
+    os.remove(path)
 
 
 class ModelManagerSP:
@@ -197,10 +257,11 @@ class ModelManagerSP:
       eta = self._calculate_eta(artifact.fileName, progress)
     self._set_progress(artifact, custom.ModelManagerSP.DownloadStatus.downloading, progress, eta, speed)
 
-  async def _report_until_done(self, tasks: list[asyncio.Future], artifact, progress: _Progress, total: int) -> None:
-    """Publishes progress, speed and eta every REPORT_INTERVAL until the pieces land. Runs on the event loop: workers never touch messaging."""
+  async def _report_until_done(self, tasks: list[asyncio.Future], artifact, progress: _Progress, path: str, layout: dict) -> None:
+    """Publishes progress, speed and eta every REPORT_INTERVAL until the pieces land, recording finished
+    pieces in the sidecar for resume. Runs on the event loop: workers never touch messaging."""
     pending = set(tasks)
-    last_bytes = progress.snapshot()
+    last_bytes, saved = progress.snapshot()
     last_time, speed = time.monotonic(), 0.0
     while pending:
       done, pending = await asyncio.wait(pending, timeout=REPORT_INTERVAL)
@@ -209,37 +270,48 @@ class ModelManagerSP:
       if self._download_interrupted():
         raise DownloadCancelled("Download cancelled")
       now = time.monotonic()
-      done_bytes = progress.snapshot()
+      done_bytes, done_pieces = progress.snapshot()
+      if done_pieces != saved:
+        _save_resume_state(path, layout, done_pieces)
+        saved = done_pieces
       if (dt := now - last_time) > 0:
         instant = max(0.0, (done_bytes - last_bytes) / dt)
         speed = instant if speed == 0 else SPEED_SMOOTHING * speed + (1 - SPEED_SMOOTHING) * instant
       last_time, last_bytes = now, done_bytes
-      self._publish_progress(artifact, done_bytes, total, speed)
+      self._publish_progress(artifact, done_bytes, layout["total"], speed)
 
   async def _download_file(self, url: str, path: str, artifact) -> None:
-    """Downloads `url` to `path` as parallel byte-range pieces, each written in place at its offset."""
+    """Downloads `url` to `path` as parallel byte-range pieces, each written in place at its offset. A
+    `.download` sidecar lists the finished pieces so an interrupted transfer resumes, and is removed
+    once every piece has landed."""
     self._download_start_times[artifact.fileName] = time.monotonic()
     loop = asyncio.get_running_loop()
 
     total, ranged = await loop.run_in_executor(None, _probe_size, url)
-    pieces: list[tuple[int, int | None]] = list(_piece_ranges(total, PIECE_SIZE)) if ranged else [(0, None)]
-    await loop.run_in_executor(None, _prepare_target, path, total)
-    progress = _Progress()
+    piece_size = PIECE_SIZE
+    pieces: list[tuple[int, int | None]] = list(_piece_ranges(total, piece_size)) if ranged else [(0, None)]
+    # sha256 keys the resume state to this exact content: a republished model of the same name
+    # and size never resumes from the old bytes
+    layout = {"total": total, "piece_size": piece_size, "ranged": ranged, "sha256": artifact.downloadUri.sha256}
+    done = await loop.run_in_executor(None, _prepare_target, path, layout)
+    progress = _Progress(done, sum(end - start for i, (start, end) in enumerate(pieces) if i in done and end is not None))
     cancel = threading.Event()
 
     with ThreadPoolExecutor(max_workers=MAX_CONCURRENT_CHUNKS) as pool:
       # every worker owns its request: a shared requests.Session is not thread-safe
       tasks = [loop.run_in_executor(pool, _fetch_piece, url, path, i, start, end, progress, cancel, self._block_size)
-               for i, (start, end) in enumerate(pieces)]
+               for i, (start, end) in enumerate(pieces) if i not in done]
       try:
-        await self._report_until_done(tasks, artifact, progress, total)
+        await self._report_until_done(tasks, artifact, progress, path, layout)
       except BaseException:
         cancel.set()
         for task in tasks:
           task.cancel()  # drops queued pieces; running ones see the event at their next block
         await asyncio.gather(*tasks, return_exceptions=True)
+        _save_resume_state(path, layout, progress.snapshot()[1])
         raise
 
+    _remove_download_state(path)
     del self._download_start_times[artifact.fileName]
 
   async def _download_chunked(self, base_url: str, base_path: str, artifact, skip: frozenset[int] | set[int] = frozenset()) -> None:
@@ -316,6 +388,8 @@ class ModelManagerSP:
           self._sync_artifact_progress(artifact)
           self._report_status()
         is_cached = len(valid_chunks) == num_chunks
+      elif _download_in_progress(full_path):
+        cloudlog.info(f"Resuming interrupted download of {filename}")
       else:
         self._set_progress(artifact, status.verifying, 0)
         if await verify_file(full_path, expected_hash):
@@ -336,6 +410,9 @@ class ModelManagerSP:
         await self._download_file(url, full_path, artifact)
         self._set_progress(artifact, status.verifying, 99)
         if not await verify_file(full_path, expected_hash):
+          # nothing in a bad file is worth resuming from
+          _remove_file(full_path)
+          _remove_download_state(full_path)
           raise ValueError(f"Hash validation failed for {filename}")
 
       self._set_progress(artifact, status.downloaded, 100)
@@ -354,9 +431,8 @@ class ModelManagerSP:
 
     except Exception as e:
       cloudlog.error(f"Error downloading {filename}: {str(e)}")
-      for f in [full_path] + [p for p in (os.path.join(destination_path, f) for f in os.listdir(destination_path)) if filename in p]:
-        if os.path.isfile(f):  # noqa: ASYNC240
-          os.remove(f)
+      # nothing is deleted here: a bad file was already discarded by the hash check, an interrupted
+      # one is resume state (file + sidecar) for the next attempt, and chunks are re-verified anyway
       artifact.downloadProgress.status = status.failed
       artifact.downloadProgress.eta = 0
       artifact.downloadProgress.speed = 0

--- a/openpilot/sunnypilot/models/manager.py
+++ b/openpilot/sunnypilot/models/manager.py
@@ -6,6 +6,7 @@ See the LICENSE.md file in the root directory for more details.
 """
 
 import asyncio
+import glob
 import json
 import os
 import re
@@ -186,6 +187,14 @@ def _fetch_piece(url: str, path: str, index: int, start: int, end: int | None, p
         raise DownloadCancelled("Download cancelled") from None
 
 
+def _remove_legacy_chunks(path: str) -> None:
+  """Manifests before selector version 20 shipped models as .chunkNNofMM files plus a .chunkmanifest,
+  which open_file_chunked prefers over a whole file of the same name. Drop them so they can never
+  shadow a whole-file download."""
+  for stale in glob.glob(f"{glob.escape(path)}.chunk*"):
+    os.remove(stale)
+
+
 def _remove_file(path: str) -> None:
   if os.path.isfile(path):
     os.remove(path)
@@ -339,50 +348,6 @@ class ModelManagerSP:
             raise DownloadCancelled("Download cancelled") from e
           await asyncio.sleep(min(RETRY_POLL, remaining))
 
-  async def _download_chunked(self, base_url: str, base_path: str, artifact, skip: frozenset[int] | set[int] = frozenset()) -> None:
-    from openpilot.common.file_chunker import get_chunk_name, get_manifest_path
-
-    num_chunks = len(artifact.chunks)
-    if num_chunks == 0:
-      raise ValueError("No chunks defined in artifact")
-
-    manifest_path = get_manifest_path(base_path)
-    self._download_start_times[artifact.fileName] = time.monotonic()
-
-    # Shared connection saves a TCP+TLS handshake per chunk.
-    # Keep sequential: the link saturates on one stream and Session is not thread-safe.
-    completed = len(skip)
-    with requests.Session() as session:
-      for i, _ in enumerate(artifact.chunks):
-        if i in skip:
-          continue
-        chunk_url = get_chunk_name(base_url, i, num_chunks)
-        chunk_path = get_chunk_name(base_path, i, num_chunks)
-        chunk_downloaded = 0
-        with session.get(chunk_url, stream=True, timeout=DOWNLOAD_TIMEOUT) as response:
-          response.raise_for_status()
-          chunk_size = int(response.headers.get("content-length", 0))
-          with open(chunk_path, 'wb') as f:  # noqa: ASYNC230
-            for data in response.iter_content(chunk_size=self._block_size):
-              f.write(data)
-              chunk_downloaded += len(data)
-              if self._download_interrupted():
-                raise DownloadCancelled("Download cancelled")
-              intra = chunk_downloaded / max(chunk_size, 1)
-              progress = min(99.0, ((completed + intra) / num_chunks) * 100)
-              artifact.downloadProgress.status = custom.ModelManagerSP.DownloadStatus.downloading
-              artifact.downloadProgress.progress = progress
-              artifact.downloadProgress.eta = self._calculate_eta(artifact.fileName, progress)
-              self._sync_artifact_progress(artifact)
-              self._report_status()
-        completed += 1
-
-    with open(manifest_path, 'w') as f:  # noqa: ASYNC230
-      f.write(str(num_chunks))
-    if os.path.isfile(base_path):  # noqa: ASYNC240
-      os.remove(base_path)
-    del self._download_start_times[artifact.fileName]
-
   async def _process_artifact(self, artifact, destination_path: str) -> None:
     if not artifact.downloadUri.uri:
       return None
@@ -396,54 +361,28 @@ class ModelManagerSP:
     status = custom.ModelManagerSP.DownloadStatus
 
     try:
-      # progress counts only valid chunks so a resumed download continues the
-      # bar from where verification left it, instead of falling back to zero
-      is_cached = False
-      valid_chunks: set[int] = set()
-      if len(artifact.chunks) > 0:
-        from openpilot.common.file_chunker import get_chunk_name
-        num_chunks = len(artifact.chunks)
-        for i, chunk in enumerate(artifact.chunks):
-          if self._download_interrupted():
-            raise DownloadCancelled("Download cancelled")
-          if await verify_file(get_chunk_name(full_path, i, num_chunks), chunk.sha256):
-            valid_chunks.add(i)
-          artifact.downloadProgress.status = custom.ModelManagerSP.DownloadStatus.verifying
-          artifact.downloadProgress.progress = (len(valid_chunks) / num_chunks) * 100
-          self._sync_artifact_progress(artifact)
-          self._report_status()
-        is_cached = len(valid_chunks) == num_chunks
-      elif _download_in_progress(full_path):
+      _remove_legacy_chunks(full_path)
+      if _download_in_progress(full_path):
         cloudlog.info(f"Resuming interrupted download of {filename}")
       else:
         self._set_progress(artifact, status.verifying, 0)
         if await verify_file(full_path, expected_hash):
-          is_cached = True
+          self._set_progress(artifact, status.cached, 100)
+          return
 
-      if is_cached:
-        self._set_progress(artifact, status.cached, 100)
-        return
+      await self._download_with_retries(url, full_path, artifact)
 
-      if len(artifact.chunks) > 0:
-        await self._download_chunked(url, full_path, artifact, skip=valid_chunks)
-        from openpilot.common.file_chunker import get_chunk_name
-        for i, chunk in enumerate(artifact.chunks):
-          chunk_path = get_chunk_name(full_path, i, len(artifact.chunks))
-          if not await verify_file(chunk_path, chunk.sha256):
-            raise ValueError(f"Hash validation failed for chunk {i+1} of {filename}")
-      else:
-        await self._download_with_retries(url, full_path, artifact)
-        self._set_progress(artifact, status.verifying, 99)
-        if not await verify_file(full_path, expected_hash):
-          # nothing in a bad file is worth resuming from
-          _remove_file(full_path)
-          _remove_download_state(full_path)
-          raise ValueError(f"Hash validation failed for {filename}")
+      self._set_progress(artifact, status.verifying, 99)
+      if not await verify_file(full_path, expected_hash):
+        # nothing in a bad file is worth resuming from
+        _remove_file(full_path)
+        _remove_download_state(full_path)
+        raise ValueError(f"Hash validation failed for {filename}")
 
       self._set_progress(artifact, status.downloaded, 100)
 
     except DownloadCancelled:
-      # a cancel keeps whatever is on disk: complete chunks resume the next attempt
+      # a cancel keeps the file and its sidecar: the next attempt resumes
       self._download_start_times.pop(artifact.fileName, None)
       artifact.downloadProgress.status = status.failed
       artifact.downloadProgress.eta = 0
@@ -456,8 +395,8 @@ class ModelManagerSP:
 
     except Exception as e:
       cloudlog.error(f"Error downloading {filename}: {str(e)}")
-      # nothing is deleted here: a bad file was already discarded by the hash check, an interrupted
-      # one is resume state (file + sidecar) for the next attempt, and chunks are re-verified anyway
+      # nothing is deleted here: a bad file was already discarded by the hash check, and an
+      # interrupted one is resume state (file + sidecar) for the next attempt
       artifact.downloadProgress.status = status.failed
       artifact.downloadProgress.eta = 0
       artifact.downloadProgress.speed = 0
@@ -596,12 +535,11 @@ class ModelManagerSP:
           if model.artifact.fileName:
             active_files.append(model.artifact.fileName)
 
-    # Remove all files except active ones (including their chunk files)
+    # Everything else goes: other models, interrupted downloads and their .download sidecars, legacy chunk files
     model_dir = Paths.model_root()
     try:
       for filename in os.listdir(model_dir):
-        base = filename.split('.chunk')[0] if '.chunk' in filename else filename
-        if base not in active_files and filename not in active_files:
+        if filename not in active_files:
           file_path = os.path.join(model_dir, filename)
           if os.path.isfile(file_path):
             os.remove(file_path)

--- a/openpilot/sunnypilot/models/manager.py
+++ b/openpilot/sunnypilot/models/manager.py
@@ -34,6 +34,7 @@ PIECE_BACKOFF = 1.0  # seconds before the first retry, growing linearly
 # HTTP statuses a server sends while overloaded or throttling; any other 4xx/5xx is permanent
 TRANSIENT_HTTP_STATUS = frozenset({408, 429, 500, 502, 503, 504})
 REPORT_INTERVAL = 0.5  # seconds between progress publications
+SPEED_SMOOTHING = 0.7  # weight of the previous speed sample in the published speed
 
 
 class DownloadCancelled(Exception):
@@ -162,6 +163,7 @@ class ModelManagerSP:
         artifact.downloadProgress.status = source_artifact.downloadProgress.status
         artifact.downloadProgress.progress = source_artifact.downloadProgress.progress
         artifact.downloadProgress.eta = source_artifact.downloadProgress.eta
+        artifact.downloadProgress.speed = source_artifact.downloadProgress.speed
 
   def _calculate_eta(self, filename: str, progress: float) -> int:
     """Calculate ETA based on elapsed time and current progress"""
@@ -178,29 +180,41 @@ class ModelManagerSP:
 
     return max(1, int(eta))  # Return at least 1 second if download is ongoing
 
-  def _set_progress(self, artifact, status, progress: float, eta: int = 0) -> None:
+  def _set_progress(self, artifact, status, progress: float, eta: int = 0, speed: float = 0.0) -> None:
     artifact.downloadProgress.status = status
     artifact.downloadProgress.progress = progress
     artifact.downloadProgress.eta = eta
+    artifact.downloadProgress.speed = speed
     self._sync_artifact_progress(artifact)
     self._report_status()
 
-  def _publish_progress(self, artifact, done_bytes: int, total: int) -> None:
+  def _publish_progress(self, artifact, done_bytes: int, total: int, speed: float) -> None:
     # 99 until the assembled file passes its hash check
     progress = min(99.0, done_bytes / total * 100) if total > 0 else 0.0
-    eta = self._calculate_eta(artifact.fileName, progress)
-    self._set_progress(artifact, custom.ModelManagerSP.DownloadStatus.downloading, progress, eta)
+    if speed > 0 and total > 0:
+      eta = max(1, int((total - done_bytes) / speed))
+    else:
+      eta = self._calculate_eta(artifact.fileName, progress)
+    self._set_progress(artifact, custom.ModelManagerSP.DownloadStatus.downloading, progress, eta, speed)
 
   async def _report_until_done(self, tasks: list[asyncio.Future], artifact, progress: _Progress, total: int) -> None:
-    """Publishes progress every REPORT_INTERVAL until the pieces land. Runs on the event loop: workers never touch messaging."""
+    """Publishes progress, speed and eta every REPORT_INTERVAL until the pieces land. Runs on the event loop: workers never touch messaging."""
     pending = set(tasks)
+    last_bytes = progress.snapshot()
+    last_time, speed = time.monotonic(), 0.0
     while pending:
       done, pending = await asyncio.wait(pending, timeout=REPORT_INTERVAL)
       for task in done:
         task.result()  # re-raises a worker failure
       if self._download_interrupted():
         raise DownloadCancelled("Download cancelled")
-      self._publish_progress(artifact, progress.snapshot(), total)
+      now = time.monotonic()
+      done_bytes = progress.snapshot()
+      if (dt := now - last_time) > 0:
+        instant = max(0.0, (done_bytes - last_bytes) / dt)
+        speed = instant if speed == 0 else SPEED_SMOOTHING * speed + (1 - SPEED_SMOOTHING) * instant
+      last_time, last_bytes = now, done_bytes
+      self._publish_progress(artifact, done_bytes, total, speed)
 
   async def _download_file(self, url: str, path: str, artifact) -> None:
     """Downloads `url` to `path` as parallel byte-range pieces, each written in place at its offset."""
@@ -331,6 +345,7 @@ class ModelManagerSP:
       self._download_start_times.pop(artifact.fileName, None)
       artifact.downloadProgress.status = status.failed
       artifact.downloadProgress.eta = 0
+      artifact.downloadProgress.speed = 0
       self._sync_artifact_progress(artifact)
       if self.selected_bundle:
         self.selected_bundle.status = status.failed
@@ -344,6 +359,7 @@ class ModelManagerSP:
           os.remove(f)
       artifact.downloadProgress.status = status.failed
       artifact.downloadProgress.eta = 0
+      artifact.downloadProgress.speed = 0
       self._sync_artifact_progress(artifact)
       if self.selected_bundle:
         self.selected_bundle.status = status.failed
@@ -386,6 +402,7 @@ class ModelManagerSP:
           artifact.downloadProgress.status = custom.ModelManagerSP.DownloadStatus.cached
           artifact.downloadProgress.progress = 100
           artifact.downloadProgress.eta = 0
+          artifact.downloadProgress.speed = 0
         else:
           seen_artifacts.add(artifact.fileName)
           await self._process_artifact(artifact, destination_path)

--- a/openpilot/sunnypilot/models/manager.py
+++ b/openpilot/sunnypilot/models/manager.py
@@ -7,7 +7,10 @@ See the LICENSE.md file in the root directory for more details.
 
 import asyncio
 import os
+import re
+import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 
 import requests
 from openpilot.common.params import Params
@@ -22,10 +25,104 @@ from openpilot.sunnypilot.models.helpers import (ACTIVE_BUNDLE_KEYS, get_active_
 
 # (connect, read) seconds. read is per-request inactivity, not a total cap
 DOWNLOAD_TIMEOUT = (30, 30)
+# HuggingFace throttles each connection to ~1-2 MB/s but not the connection count; 12 saturates the device link
+MAX_CONCURRENT_CHUNKS = 12
+# small enough that even a ~50 MB model splits into many pieces, keeping all workers busy
+PIECE_SIZE = 8 * 1024 * 1024
+PIECE_RETRIES = 3
+PIECE_BACKOFF = 1.0  # seconds before the first retry, growing linearly
+# HTTP statuses a server sends while overloaded or throttling; any other 4xx/5xx is permanent
+TRANSIENT_HTTP_STATUS = frozenset({408, 429, 500, 502, 503, 504})
+REPORT_INTERVAL = 0.5  # seconds between progress publications
 
 
 class DownloadCancelled(Exception):
   pass
+
+
+def _is_transient(e: BaseException) -> bool:
+  if isinstance(e, requests.HTTPError):
+    return e.response is not None and e.response.status_code in TRANSIENT_HTTP_STATUS
+  return isinstance(e, (requests.ConnectionError, requests.Timeout, requests.exceptions.ChunkedEncodingError))
+
+
+class _Progress:
+  """Bytes landed on disk, shared between worker threads and the reporter on the event loop."""
+
+  def __init__(self):
+    self._bytes = 0
+    self._lock = threading.Lock()
+
+  def add_bytes(self, n: int) -> None:
+    with self._lock:
+      self._bytes += n
+
+  def snapshot(self) -> int:
+    with self._lock:
+      return self._bytes
+
+
+def _piece_ranges(total: int, piece_size: int) -> list[tuple[int, int]]:
+  """[start, end) byte ranges tiling a file of `total` bytes."""
+  return [(start, min(start + piece_size, total)) for start in range(0, total, piece_size)]
+
+
+def _prepare_target(path: str, total: int) -> None:
+  """A sparse file of the full size; every piece lands at its own offset."""
+  with open(path, "wb") as f:
+    f.truncate(total)
+
+
+def _content_range_total(response: requests.Response) -> int | None:
+  if response.status_code != 206:
+    return None
+  match = re.fullmatch(r"bytes \d+-\d+/(\d+)", response.headers.get("Content-Range", ""))
+  return int(match.group(1)) if match else None
+
+
+def _probe_size(url: str) -> tuple[int, bool]:
+  """(total bytes, server honors byte ranges). A one-byte Range probe doubles as the size lookup:
+  a 206 carries the total in Content-Range, a 200 means the server only serves whole bodies."""
+  with requests.get(url, headers={"Range": "bytes=0-0"}, stream=True, timeout=DOWNLOAD_TIMEOUT) as response:
+    response.raise_for_status()
+    total = _content_range_total(response)
+    if total is not None:
+      return total, True
+    return int(response.headers.get("Content-Length", 0)), False
+
+
+def _fetch_piece(url: str, path: str, index: int, start: int, end: int | None, progress: _Progress,
+                 cancel: threading.Event, block_size: int) -> None:
+  """Worker thread: streams one byte range into `path` at its offset (`end is None` = whole body, no range support)."""
+  headers = {"Range": f"bytes={start}-{end - 1}"} if end is not None else {}
+  label = f"{os.path.basename(path)} piece {index}"
+  for attempt in range(PIECE_RETRIES):
+    written = 0
+    try:
+      with requests.get(url, headers=headers, stream=True, timeout=DOWNLOAD_TIMEOUT) as response:
+        response.raise_for_status()
+        if end is not None and response.status_code != 206:
+          raise ValueError(f"server ignored byte range for {label}")
+        with open(path, "r+b") as f:
+          f.seek(start)
+          for block in response.iter_content(chunk_size=block_size):
+            if cancel.is_set():
+              raise DownloadCancelled("Download cancelled")
+            f.write(block)
+            written += len(block)
+            progress.add_bytes(len(block))
+          if end is None:
+            f.truncate()  # unknown length: the body defines the file size
+          if end is not None and written != end - start:
+            raise requests.exceptions.ConnectionError(f"short read: {written} of {end - start} bytes")
+      return
+    except requests.RequestException as e:
+      progress.add_bytes(-written)  # the piece restarts from scratch
+      if not _is_transient(e) or attempt == PIECE_RETRIES - 1:
+        raise
+      cloudlog.warning(f"retrying {label} after {type(e).__name__}: {e}")
+      if cancel.wait(PIECE_BACKOFF * (1 + attempt)):
+        raise DownloadCancelled("Download cancelled") from None
 
 
 class ModelManagerSP:
@@ -41,7 +138,7 @@ class ModelManagerSP:
     self.source_models: dict[str, list[custom.ModelManagerSP.ModelBundle]] = {}
     self.selected_bundle: custom.ModelManagerSP.ModelBundle = None
     self.active_bundle: custom.ModelManagerSP.ModelBundle = get_active_bundle(self.params, chestnut=self.chestnut_present)
-    self._chunk_size = 128 * 1000  # 128 KB chunks
+    self._block_size = 128 * 1000  # 128 KB network read blocks
     self._download_start_times: dict[str, float] = {}  # Track start time per model
     self._download_ref: bytes | str | None = None
 
@@ -81,33 +178,55 @@ class ModelManagerSP:
 
     return max(1, int(eta))  # Return at least 1 second if download is ongoing
 
-  async def _download_file(self, url: str, path: str, model) -> None:
-    """Downloads a file with progress tracking"""
-    self._download_start_times[model.fileName] = time.monotonic()
+  def _set_progress(self, artifact, status, progress: float, eta: int = 0) -> None:
+    artifact.downloadProgress.status = status
+    artifact.downloadProgress.progress = progress
+    artifact.downloadProgress.eta = eta
+    self._sync_artifact_progress(artifact)
+    self._report_status()
 
-    with requests.get(url, stream=True, timeout=DOWNLOAD_TIMEOUT) as response:  # noqa: ASYNC210
-      response.raise_for_status()
-      total_size = int(response.headers.get("content-length", 0))
-      bytes_downloaded = 0
+  def _publish_progress(self, artifact, done_bytes: int, total: int) -> None:
+    # 99 until the assembled file passes its hash check
+    progress = min(99.0, done_bytes / total * 100) if total > 0 else 0.0
+    eta = self._calculate_eta(artifact.fileName, progress)
+    self._set_progress(artifact, custom.ModelManagerSP.DownloadStatus.downloading, progress, eta)
 
-      with open(path, 'wb') as f:  # noqa: ASYNC230
-        for chunk in response.iter_content(chunk_size=self._chunk_size):  # type: bytes
-          f.write(chunk)
-          bytes_downloaded += len(chunk)
+  async def _report_until_done(self, tasks: list[asyncio.Future], artifact, progress: _Progress, total: int) -> None:
+    """Publishes progress every REPORT_INTERVAL until the pieces land. Runs on the event loop: workers never touch messaging."""
+    pending = set(tasks)
+    while pending:
+      done, pending = await asyncio.wait(pending, timeout=REPORT_INTERVAL)
+      for task in done:
+        task.result()  # re-raises a worker failure
+      if self._download_interrupted():
+        raise DownloadCancelled("Download cancelled")
+      self._publish_progress(artifact, progress.snapshot(), total)
 
-          if self._download_interrupted():
-            raise DownloadCancelled("Download cancelled")
+  async def _download_file(self, url: str, path: str, artifact) -> None:
+    """Downloads `url` to `path` as parallel byte-range pieces, each written in place at its offset."""
+    self._download_start_times[artifact.fileName] = time.monotonic()
+    loop = asyncio.get_running_loop()
 
-          if total_size > 0:
-            progress = (bytes_downloaded / total_size) * 100
-            model.downloadProgress.status = custom.ModelManagerSP.DownloadStatus.downloading
-            model.downloadProgress.progress = progress
-            model.downloadProgress.eta = self._calculate_eta(model.fileName, progress)
-            self._sync_artifact_progress(model)
-            self._report_status()
+    total, ranged = await loop.run_in_executor(None, _probe_size, url)
+    pieces: list[tuple[int, int | None]] = list(_piece_ranges(total, PIECE_SIZE)) if ranged else [(0, None)]
+    await loop.run_in_executor(None, _prepare_target, path, total)
+    progress = _Progress()
+    cancel = threading.Event()
 
-    # Clean up start time after download completes
-    del self._download_start_times[model.fileName]
+    with ThreadPoolExecutor(max_workers=MAX_CONCURRENT_CHUNKS) as pool:
+      # every worker owns its request: a shared requests.Session is not thread-safe
+      tasks = [loop.run_in_executor(pool, _fetch_piece, url, path, i, start, end, progress, cancel, self._block_size)
+               for i, (start, end) in enumerate(pieces)]
+      try:
+        await self._report_until_done(tasks, artifact, progress, total)
+      except BaseException:
+        cancel.set()
+        for task in tasks:
+          task.cancel()  # drops queued pieces; running ones see the event at their next block
+        await asyncio.gather(*tasks, return_exceptions=True)
+        raise
+
+    del self._download_start_times[artifact.fileName]
 
   async def _download_chunked(self, base_url: str, base_path: str, artifact, skip: frozenset[int] | set[int] = frozenset()) -> None:
     from openpilot.common.file_chunker import get_chunk_name, get_manifest_path
@@ -133,7 +252,7 @@ class ModelManagerSP:
           response.raise_for_status()
           chunk_size = int(response.headers.get("content-length", 0))
           with open(chunk_path, 'wb') as f:  # noqa: ASYNC230
-            for data in response.iter_content(chunk_size=self._chunk_size):
+            for data in response.iter_content(chunk_size=self._block_size):
               f.write(data)
               chunk_downloaded += len(data)
               if self._download_interrupted():
@@ -163,6 +282,7 @@ class ModelManagerSP:
     expected_hash = artifact.downloadUri.sha256
     filename = artifact.fileName
     full_path = os.path.join(destination_path, filename)
+    status = custom.ModelManagerSP.DownloadStatus
 
     try:
       # progress counts only valid chunks so a resumed download continues the
@@ -183,15 +303,12 @@ class ModelManagerSP:
           self._report_status()
         is_cached = len(valid_chunks) == num_chunks
       else:
+        self._set_progress(artifact, status.verifying, 0)
         if await verify_file(full_path, expected_hash):
           is_cached = True
 
       if is_cached:
-        artifact.downloadProgress.status = custom.ModelManagerSP.DownloadStatus.cached
-        artifact.downloadProgress.progress = 100
-        artifact.downloadProgress.eta = 0
-        self._sync_artifact_progress(artifact)
-        self._report_status()
+        self._set_progress(artifact, status.cached, 100)
         return
 
       if len(artifact.chunks) > 0:
@@ -203,23 +320,20 @@ class ModelManagerSP:
             raise ValueError(f"Hash validation failed for chunk {i+1} of {filename}")
       else:
         await self._download_file(url, full_path, artifact)
+        self._set_progress(artifact, status.verifying, 99)
         if not await verify_file(full_path, expected_hash):
           raise ValueError(f"Hash validation failed for {filename}")
 
-      artifact.downloadProgress.status = custom.ModelManagerSP.DownloadStatus.downloaded
-      artifact.downloadProgress.progress = 100
-      artifact.downloadProgress.eta = 0
-      self._sync_artifact_progress(artifact)
-      self._report_status()
+      self._set_progress(artifact, status.downloaded, 100)
 
     except DownloadCancelled:
       # a cancel keeps whatever is on disk: complete chunks resume the next attempt
       self._download_start_times.pop(artifact.fileName, None)
-      artifact.downloadProgress.status = custom.ModelManagerSP.DownloadStatus.failed
+      artifact.downloadProgress.status = status.failed
       artifact.downloadProgress.eta = 0
       self._sync_artifact_progress(artifact)
       if self.selected_bundle:
-        self.selected_bundle.status = custom.ModelManagerSP.DownloadStatus.failed
+        self.selected_bundle.status = status.failed
       self._report_status()
       raise
 
@@ -228,11 +342,11 @@ class ModelManagerSP:
       for f in [full_path] + [p for p in (os.path.join(destination_path, f) for f in os.listdir(destination_path)) if filename in p]:
         if os.path.isfile(f):  # noqa: ASYNC240
           os.remove(f)
-      artifact.downloadProgress.status = custom.ModelManagerSP.DownloadStatus.failed
+      artifact.downloadProgress.status = status.failed
       artifact.downloadProgress.eta = 0
       self._sync_artifact_progress(artifact)
       if self.selected_bundle:
-        self.selected_bundle.status = custom.ModelManagerSP.DownloadStatus.failed
+        self.selected_bundle.status = status.failed
       self._report_status()
       self._download_start_times.pop(artifact.fileName, None)
       raise

--- a/openpilot/sunnypilot/models/manager.py
+++ b/openpilot/sunnypilot/models/manager.py
@@ -30,8 +30,13 @@ DOWNLOAD_TIMEOUT = (30, 30)
 MAX_CONCURRENT_CHUNKS = 12
 # small enough that even a ~50 MB model splits into many pieces, keeping all workers busy
 PIECE_SIZE = 8 * 1024 * 1024
-PIECE_RETRIES = 3
+PIECE_RETRIES = 3  # attempts per piece before the transfer as a whole is retried
 PIECE_BACKOFF = 1.0  # seconds before the first retry, growing linearly
+# A transfer whose pieces exhaust their retries (dropped link, DNS blip, overloaded server) is
+# retried from its resume state after a cancellable backoff of RETRY_BACKOFF * 2**attempt seconds.
+DOWNLOAD_ATTEMPTS = 4
+RETRY_BACKOFF = 2.0
+RETRY_POLL = 0.25  # how often a backoff checks for a cancel
 # HTTP statuses a server sends while overloaded or throttling; any other 4xx/5xx is permanent
 TRANSIENT_HTTP_STATUS = frozenset({408, 429, 500, 502, 503, 504})
 REPORT_INTERVAL = 0.5  # seconds between progress publications
@@ -314,6 +319,26 @@ class ModelManagerSP:
     _remove_download_state(path)
     del self._download_start_times[artifact.fileName]
 
+  async def _download_with_retries(self, url: str, path: str, artifact) -> None:
+    """A transfer that fails transiently is retried after a cancellable backoff. Every retry resumes
+    from the sidecar, so nothing already on disk is fetched again. Permanent errors raise at once."""
+    for attempt in range(DOWNLOAD_ATTEMPTS):
+      try:
+        await self._download_file(url, path, artifact)
+        return
+      except Exception as e:
+        if not _is_transient(e) or attempt == DOWNLOAD_ATTEMPTS - 1:
+          raise
+        delay = RETRY_BACKOFF * 2 ** attempt
+        cloudlog.warning(f"Retrying {artifact.fileName} in {delay:g}s after {type(e).__name__}: {e}")
+        progress = artifact.downloadProgress
+        self._set_progress(artifact, progress.status, progress.progress, progress.eta, 0.0)  # stalled: no speed
+        deadline = time.monotonic() + delay
+        while (remaining := deadline - time.monotonic()) > 0:
+          if self._download_interrupted():
+            raise DownloadCancelled("Download cancelled") from e
+          await asyncio.sleep(min(RETRY_POLL, remaining))
+
   async def _download_chunked(self, base_url: str, base_path: str, artifact, skip: frozenset[int] | set[int] = frozenset()) -> None:
     from openpilot.common.file_chunker import get_chunk_name, get_manifest_path
 
@@ -407,7 +432,7 @@ class ModelManagerSP:
           if not await verify_file(chunk_path, chunk.sha256):
             raise ValueError(f"Hash validation failed for chunk {i+1} of {filename}")
       else:
-        await self._download_file(url, full_path, artifact)
+        await self._download_with_retries(url, full_path, artifact)
         self._set_progress(artifact, status.verifying, 99)
         if not await verify_file(full_path, expected_hash):
           # nothing in a bad file is worth resuming from
@@ -516,11 +541,14 @@ class ModelManagerSP:
       self._download_ref = ref_to_download
       try:
         self.download(model_to_download, Paths.model_root(), source)
+      except DownloadCancelled:
+        self.selected_bundle = None  # a cancel clears the row
       except Exception as e:
-        cloudlog.exception(e)
+        cloudlog.exception(e)  # a failure stays on the row until the next request or a cancel
+      else:
+        self.selected_bundle = None
       finally:
         self._release_download_ref()
-        self.selected_bundle = None
 
   def main_thread(self) -> None:
     """Main thread for model management"""

--- a/openpilot/sunnypilot/models/tests/test_manager_download.py
+++ b/openpilot/sunnypilot/models/tests/test_manager_download.py
@@ -9,6 +9,7 @@ import asyncio
 import contextlib
 import hashlib
 import http.server
+import json
 import math
 import os
 import re
@@ -217,6 +218,25 @@ class ManagerDownloadTestBase(OpenpilotTestCase):
   def path(self) -> str:
     return os.path.join(self.dest, FILE_NAME)
 
+  @property
+  def sidecar(self) -> str:
+    return manager_module._sidecar_path(self.path)
+
+  def resume_state(self) -> dict:
+    with open(self.sidecar) as f:
+      return json.load(f)
+
+  def write_resume_state(self, done: list[int], total: int = len(WHOLE_BODY), file_size: int | None = None,
+                         file_sha256: str = sha256(WHOLE_BODY)) -> None:
+    """An interrupted download: a full-size file holding the `done` pieces plus its sidecar."""
+    with open(self.path, 'wb') as f:
+      f.truncate(len(WHOLE_BODY) if file_size is None else file_size)
+      for i in done:
+        f.seek(i * PIECE)
+        f.write(WHOLE_BODY[i * PIECE:(i + 1) * PIECE])
+    with open(self.sidecar, 'w') as f:
+      json.dump({"total": total, "piece_size": PIECE, "ranged": True, "sha256": file_sha256, "done": done}, f)
+
   @staticmethod
   def piece_requests() -> list[tuple[int, int]]:
     """Honored ranges minus the one-byte size probe."""
@@ -258,6 +278,7 @@ class TestManagerDownload(ManagerDownloadTestBase):
     def body():
       artifact = self.download_file()
       assert self.read_path() == WHOLE_BODY
+      assert not os.path.exists(self.sidecar), "resume sidecar must go once every piece has landed"
       assert artifact.fileName not in self.manager._download_start_times
     self.run_with_server(body)
 
@@ -312,6 +333,7 @@ class TestManagerDownload(ManagerDownloadTestBase):
       self.download_file()
       assert self.read_path() == WHOLE_BODY
       assert DownloadHandler.request_ranges == [None, None], "expected the probe plus one whole-body request"
+      assert not os.path.exists(self.sidecar)
     self.run_with_server(body)
 
   def test_http_error_propagates(self):
@@ -319,6 +341,8 @@ class TestManagerDownload(ManagerDownloadTestBase):
       DownloadHandler.fail_ranges = {piece_range(1): 404}
       with self.assertRaises(requests.exceptions.HTTPError):
         self.download_file()
+      assert os.path.isfile(self.sidecar), "a failed download stays marked incomplete"
+      assert 1 not in self.resume_state()["done"]
     self.run_with_server(body)
 
   def test_transient_error_is_retried(self):
@@ -330,8 +354,8 @@ class TestManagerDownload(ManagerDownloadTestBase):
     self.run_with_server(body)
 
   def test_cancellation_via_download_ref(self):
-    """Removing DownloadRef mid-transfer cancels the download. One piece is held back so the transfer
-    spans several reporter ticks; the ref vanishes on the second."""
+    """Removing DownloadRef mid-transfer cancels the download and keeps the finished pieces. One piece
+    is held back so the transfer spans several reporter ticks; the ref vanishes on the second."""
     def body():
       DownloadHandler.stall_ranges = {piece_range(5)}
       DownloadHandler.stall_event = threading.Event()
@@ -349,6 +373,8 @@ class TestManagerDownload(ManagerDownloadTestBase):
       with self.assertRaises(DownloadCancelled):
         self.download_file()
       assert checks["n"] >= 2, "cancel must have been polled while the transfer was running"
+      state = self.resume_state()
+      assert state["done"] and 5 not in state["done"], "a cancel must record the finished pieces for resume"
       assert os.path.getsize(self.path) == len(WHOLE_BODY)
     self.run_with_server(body)
 
@@ -361,7 +387,7 @@ class TestManagerDownload(ManagerDownloadTestBase):
       threading.Timer(0.3, DownloadHandler.stall_event.set).start()
       with self.assertRaises(DownloadCancelled):
         self.download_file()
-      assert DownloadHandler.stall_released_by_event is True, "the cancel must have caught the piece mid-transfer"
+      assert 3 not in self.resume_state()["done"], "cancelled piece must not be recorded as complete"
     self.run_with_server(body)
 
   def test_replaced_download_ref_queues_instead_of_cancelling(self):
@@ -370,6 +396,73 @@ class TestManagerDownload(ManagerDownloadTestBase):
       self.manager.params.get.side_effect = lambda key: b"other-ref" if key == "ModelManager_DownloadRef" else None
       self.manager._download_ref = b"ref"
       self.download_file()
+      assert self.read_path() == WHOLE_BODY
+    self.run_with_server(body)
+
+  def test_resume_skips_complete_pieces(self):
+    """Pieces recorded in the sidecar are kept and not re-requested; progress starts above their share."""
+    def body():
+      self.write_resume_state(done=[0, 4])
+      self.download_file()
+      requested = self.piece_requests()
+      assert piece_range(0) not in requested and piece_range(4) not in requested, "complete piece was re-downloaded"
+      assert self.read_path() == WHOLE_BODY
+      assert min(self.reported) >= 2 * PIECE / len(WHOLE_BODY) * 100 - 1, "progress must not restart below the resumed share"
+      assert not os.path.exists(self.sidecar)
+    self.run_with_server(body)
+
+  def test_resume_state_for_another_layout_is_ignored(self):
+    """A sidecar written for a different file size (the model was republished) starts over."""
+    def body():
+      self.write_resume_state(done=[0], total=len(WHOLE_BODY) + 1)
+      self.download_file()
+      assert piece_range(0) in self.piece_requests()
+      assert self.read_path() == WHOLE_BODY
+    self.run_with_server(body)
+
+  def test_resume_state_for_other_content_is_ignored(self):
+    """A sidecar for different bytes of the same name and size (the model was republished) starts over."""
+    def body():
+      self.write_resume_state(done=[0], file_sha256="0" * 64)
+      self.download_file()
+      assert piece_range(0) in self.piece_requests()
+      assert self.read_path() == WHOLE_BODY
+    self.run_with_server(body)
+
+  def test_malformed_resume_state_starts_over(self):
+    """A sidecar that is not the expected JSON object is ignored, never fatal."""
+    def body():
+      layout = {"total": len(WHOLE_BODY), "piece_size": PIECE, "ranged": True, "sha256": sha256(WHOLE_BODY)}
+      for junk in (b'[]', b'{"total": ', json.dumps({**layout, "done": 3}).encode(), json.dumps({**layout, "done": ["0", None]}).encode()):
+        with open(self.path, 'wb') as f:
+          f.truncate(len(WHOLE_BODY))
+        with open(self.sidecar, 'wb') as f:
+          f.write(junk)
+        DownloadHandler.request_ranges = []
+        self.download_file()
+        assert sorted(self.piece_requests()) == [piece_range(i) for i in range(NUM_PIECES)], f"sidecar {junk!r} must be ignored"
+        assert self.read_path() == WHOLE_BODY
+        assert not os.path.exists(self.sidecar)
+    self.run_with_server(body)
+
+  def test_resume_needs_a_full_size_file(self):
+    """A sidecar whose file was truncated underneath it is not trusted."""
+    def body():
+      self.write_resume_state(done=[0], file_size=PIECE)
+      self.download_file()
+      assert piece_range(0) in self.piece_requests()
+      assert self.read_path() == WHOLE_BODY
+    self.run_with_server(body)
+
+  def test_pieces_and_resume_state_are_synced_to_disk(self):
+    """Every piece is fdatasync'd before it is recorded, and the sidecar is fsync'd: a power loss
+    mid-download must never leave resume state naming bytes that never reached flash."""
+    def body():
+      with mock.patch.object(manager_module.os, 'fdatasync', wraps=os.fdatasync) as piece_sync, \
+           mock.patch.object(manager_module.os, 'fsync', wraps=os.fsync) as state_sync:
+        self.download_file()
+      assert piece_sync.call_count == NUM_PIECES, f"expected one fdatasync per piece, got {piece_sync.call_count}"
+      assert state_sync.call_count >= 2, "sidecar file and directory must be fsync'd"
       assert self.read_path() == WHOLE_BODY
     self.run_with_server(body)
 
@@ -556,7 +649,7 @@ class TestChunkedDownload(ManagerDownloadTestBase):
 
 
 class TestProcessArtifact(ManagerDownloadTestBase):
-  """Verification and cleanup around the download."""
+  """Verification, cleanup and resume policy around the download."""
 
   def test_downloaded_file_verifies_and_ends_idle(self):
     def body():
@@ -576,7 +669,31 @@ class TestProcessArtifact(ManagerDownloadTestBase):
       with self.assertRaises(ValueError):
         asyncio.run(self.manager._process_artifact(artifact, self.dest))
       assert not os.path.isfile(self.path)
+      assert not os.path.exists(self.sidecar), "a corrupt file must not be resumed from"
       assert artifact.downloadProgress.status == custom.ModelManagerSP.DownloadStatus.failed
+    self.run_with_server(body)
+
+  def test_transport_error_keeps_resume_state(self):
+    def body():
+      DownloadHandler.fail_ranges = {piece_range(1): 500}
+      artifact = self.make_artifact()
+      with self.assertRaises(requests.exceptions.HTTPError):
+        asyncio.run(self.manager._process_artifact(artifact, self.dest))
+      assert os.path.isfile(self.path) and os.path.isfile(self.sidecar), "finished pieces must survive a transport error"
+      assert self.resume_state()["done"]
+    self.run_with_server(body)
+
+  def test_interrupted_download_resumes_without_reverifying(self):
+    """A file with a sidecar is known incomplete: skip hashing it and pick up where it stopped."""
+    def body():
+      self.write_resume_state(done=[0, 1, 2])
+      artifact = self.make_artifact()
+      asyncio.run(self.manager._process_artifact(artifact, self.dest))
+      ds = custom.ModelManagerSP.DownloadStatus
+      assert self.reported_statuses[0] == ds.downloading, "an in-progress download is not verified first"
+      assert piece_range(0) not in self.piece_requests()
+      assert self.read_path() == WHOLE_BODY
+      assert artifact.downloadProgress.status == ds.downloaded
     self.run_with_server(body)
 
   def test_cached_file_skips_network(self):

--- a/openpilot/sunnypilot/models/tests/test_manager_download.py
+++ b/openpilot/sunnypilot/models/tests/test_manager_download.py
@@ -6,9 +6,12 @@ See the LICENSE.md file in the root directory for more details.
 """
 
 import asyncio
+import contextlib
 import hashlib
 import http.server
+import math
 import os
+import re
 import tempfile
 import threading
 import time
@@ -22,83 +25,155 @@ from urllib3.connectionpool import HTTPConnectionPool
 from openpilot.cereal import custom
 from openpilot.common.test import OpenpilotTestCase
 from openpilot.common.file_chunker import get_chunk_name, get_manifest_path
-from openpilot.selfdrive.test.helpers import http_server_context
 from openpilot.sunnypilot.models import manager as manager_module
 from openpilot.sunnypilot.models.fetcher import ModelFetcher, get_cached_bundles
 from openpilot.sunnypilot.models import helpers
 from openpilot.sunnypilot.models.helpers import (get_active_bundle, get_active_source, get_selected_bundle,
                                                   resolve_bundle_by_ref, validate_active_bundles)
-from openpilot.sunnypilot.models.manager import ModelManagerSP
+from openpilot.sunnypilot.models.manager import DownloadCancelled, ModelManagerSP
 
+FILE_NAME = 'driving_test_tinygrad.pkl'
+# non-repeating bytes so a misordered or duplicated piece changes the assembled file
+WHOLE_BODY = bytes(range(256)) * 40
+PIECE = 1000  # test piece size -> 11 pieces, the last one short
+NUM_PIECES = math.ceil(len(WHOLE_BODY) / PIECE)
+# a legacy chunked entry, served by path; goes with the chunked download path
 CHUNK_BODIES = [b'A' * 5000, b'B' * 5000, b'C' * 3000]
-WHOLE_BODY = b'Z' * 9000
 
 
 def sha256(data: bytes) -> str:
   return hashlib.sha256(data).hexdigest()
 
 
+def piece_range(index: int) -> tuple[int, int]:
+  """Inclusive byte range the client is expected to request for piece `index`."""
+  start = index * PIECE
+  return start, min(start + PIECE, len(WHOLE_BODY)) - 1
+
+
 class DownloadHandler(http.server.BaseHTTPRequestHandler):
-  """Serves the fixture bodies. Class attributes are reset per test."""
-  request_paths: list[str] = []
-  fail_paths: dict[str, int] = {}
-  stall_paths: set[str] = set()
+  """Serves WHOLE_BODY with byte-range support. Class attributes are reset per test."""
+  request_ranges: list[tuple[int, int] | None] = []  # None: no (honored) Range header
+  fail_ranges: dict[tuple[int, int], int] = {}  # range -> HTTP status, every time
+  fail_once: set[tuple[int, int]] = set()  # ranges that 503 on their first request only
+  fail_times: dict[tuple[int, int], int] = {}  # range -> how many more requests 503 before it succeeds
+  stall_ranges: set[tuple[int, int]] = set()
   stall_event: threading.Event | None = None
+  stall_released_by_event: bool | None = None
+  support_ranges = True
+  corrupt = False
+  request_paths: list[str] = []  # every path requested, chunk or whole
+  fail_paths: dict[str, int] = {}  # chunk path -> HTTP status
 
   def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
     pass
 
-  def _body_for(self, path):
-    if path.endswith('.whole'):
-      return WHOLE_BODY
-    for i in range(len(CHUNK_BODIES)):
-      if path.endswith(get_chunk_name('', i, len(CHUNK_BODIES))):
-        return CHUNK_BODIES[i]
-    return None
-
   def do_GET(self):
-    type(self).request_paths.append(self.path)
-
-    status = type(self).fail_paths.get(self.path)
-    if status:
-      self.send_response(status)
+    cls = type(self)
+    cls.request_paths.append(self.path)
+    if self.path in cls.fail_paths:
+      self.send_response(cls.fail_paths[self.path])
       self.end_headers()
       return
-
-    body = self._body_for(self.path)
-    if body is None:
+    for i, chunk in enumerate(CHUNK_BODIES):
+      if self.path.endswith(get_chunk_name('', i, len(CHUNK_BODIES))):
+        self.send_response(200)
+        self.send_header('Content-Length', str(len(chunk)))
+        self.end_headers()
+        self.wfile.write(chunk)
+        return
+    if not self.path.endswith('/' + FILE_NAME):
       self.send_response(404)
       self.end_headers()
       return
 
-    self.send_response(200)
-    self.send_header('Content-Length', str(len(body)))
+    body = WHOLE_BODY
+    if cls.corrupt:
+      body = body[:5000] + bytes([body[5000] ^ 0xFF]) + body[5001:]
+
+    rng = None
+    match = re.fullmatch(r'bytes=(\d+)-(\d+)', self.headers.get('Range', ''))
+    if match and cls.support_ranges:
+      rng = (int(match.group(1)), int(match.group(2)))
+    cls.request_ranges.append(rng)
+
+    if rng in cls.fail_ranges:
+      self.send_response(cls.fail_ranges[rng])
+      self.end_headers()
+      return
+    if rng in cls.fail_once:
+      cls.fail_once.discard(rng)
+      self.send_response(503)
+      self.end_headers()
+      return
+    if rng is not None and cls.fail_times.get(rng, 0) > 0:
+      cls.fail_times[rng] -= 1
+      self.send_response(503)
+      self.end_headers()
+      return
+
+    if rng is None:
+      payload = body
+      self.send_response(200)
+    else:
+      start, end = rng
+      payload = body[start:end + 1]
+      self.send_response(206)
+      self.send_header('Content-Range', f'bytes {start}-{end}/{len(body)}')
+    self.send_header('Content-Length', str(len(payload)))
     self.end_headers()
 
-    if self.path in type(self).stall_paths:
-      # write a little, then wait so the test can cancel mid-transfer
-      self.wfile.write(body[:100])
+    if rng in cls.stall_ranges:
+      # write a little, then hold the connection until the test releases it
+      self.wfile.write(payload[:100])
       self.wfile.flush()
-      if type(self).stall_event is not None:
-        type(self).stall_event.wait(timeout=5)
-      self.wfile.write(body[100:])
+      if cls.stall_event is not None:
+        cls.stall_released_by_event = cls.stall_event.wait(timeout=5)
+      self.wfile.write(payload[100:])
     else:
-      self.wfile.write(body)
+      self.wfile.write(payload)
+
+
+@contextlib.contextmanager
+def threaded_server(handler):
+  """One thread per request, so parallel range requests are served concurrently."""
+  server = http.server.ThreadingHTTPServer(('127.0.0.1', 0), handler)
+  thread = threading.Thread(target=server.serve_forever)
+  thread.start()
+  try:
+    yield f'http://127.0.0.1:{server.server_port}'
+  finally:
+    server.shutdown()
+    server.server_close()
+    thread.join()
 
 
 class ManagerDownloadTestBase(OpenpilotTestCase):
   def setUp(self):
     super().setUp()
+    DownloadHandler.request_ranges = []
+    DownloadHandler.fail_ranges = {}
+    DownloadHandler.fail_once = set()
+    DownloadHandler.fail_times = {}
+    DownloadHandler.stall_ranges = set()
+    DownloadHandler.stall_event = None
+    DownloadHandler.stall_released_by_event = None
+    DownloadHandler.support_ranges = True
+    DownloadHandler.corrupt = False
     DownloadHandler.request_paths = []
     DownloadHandler.fail_paths = {}
-    DownloadHandler.stall_paths = set()
-    DownloadHandler.stall_event = None
 
     self._tmp = tempfile.TemporaryDirectory()
     self.addCleanup(self._tmp.cleanup)
     self.dest = self._tmp.name
 
+    for name, value in (('PIECE_SIZE', PIECE), ('REPORT_INTERVAL', 0.05), ('PIECE_BACKOFF', 0.01)):
+      patcher = mock.patch.object(manager_module, name, value)
+      patcher.start()
+      self.addCleanup(patcher.stop)
+
     self.reported: list[float] = []
+    self.reported_statuses: list[int] = []
 
     self.manager = ModelManagerSP.__new__(ModelManagerSP)
     self.manager.params = mock.MagicMock()
@@ -110,7 +185,7 @@ class ManagerDownloadTestBase(OpenpilotTestCase):
     self.manager.active_bundle = None
     self.manager.available_models = []
     self.manager.chestnut_present = False
-    self.manager._chunk_size = 1024
+    self.manager._block_size = 256
     self.manager._download_start_times = {}
 
   def _record_progress(self, *args) -> None:
@@ -118,53 +193,190 @@ class ManagerDownloadTestBase(OpenpilotTestCase):
     artifact = getattr(self, 'artifact', None)
     if artifact is not None:
       self.reported.append(float(artifact.downloadProgress.progress))
+      status = artifact.downloadProgress.status
+      self.reported_statuses.append(getattr(status, 'raw', status))  # .raw: _DynamicEnum is not int()-able
 
-  def make_artifact(self, chunked: bool):
+  def make_artifact(self, chunked: bool = False):
     bundle = custom.ModelManagerSP.ModelBundle.new_message()
     bundle.init('models', 1)
     artifact = bundle.models[0].artifact
-    artifact.fileName = 'driving_test_tinygrad.pkl'
-    if chunked:
-      artifact.downloadUri.uri = self.base_url + '/driving_test_tinygrad.pkl'
+    artifact.fileName = FILE_NAME
+    artifact.downloadUri.uri = self.base_url + '/' + FILE_NAME
+    if chunked:  # a legacy manifest entry: the whole file's hash plus one per chunk
       artifact.downloadUri.sha256 = sha256(b''.join(CHUNK_BODIES))
       artifact.init('chunks', len(CHUNK_BODIES))
       for i, body in enumerate(CHUNK_BODIES):
         artifact.chunks[i].sha256 = sha256(body)
     else:
-      artifact.downloadUri.uri = self.base_url + '/driving_test_tinygrad.pkl.whole'
       artifact.downloadUri.sha256 = sha256(WHOLE_BODY)
     self._bundle = bundle
     self.artifact = artifact
     return artifact
 
-  def chunk_paths(self, base_path):
-    return [get_chunk_name(base_path, i, len(CHUNK_BODIES)) for i in range(len(CHUNK_BODIES))]
+  @property
+  def path(self) -> str:
+    return os.path.join(self.dest, FILE_NAME)
 
-  def assert_no_partials(self, base_path):
-    leftovers = [p for p in [base_path, get_manifest_path(base_path)] + self.chunk_paths(base_path)
-                 if os.path.isfile(p)]
-    assert leftovers == [], f"partial files left behind: {leftovers}"
+  @staticmethod
+  def piece_requests() -> list[tuple[int, int]]:
+    """Honored ranges minus the one-byte size probe."""
+    return [r for r in DownloadHandler.request_ranges if r is not None and r != (0, 0)]
+
+  def run_with_server(self, fn):
+    with threaded_server(DownloadHandler) as base_url:
+      self.base_url = base_url
+      return fn()
+
+  def download_file(self):
+    artifact = self.make_artifact()
+    asyncio.run(self.manager._download_file(artifact.downloadUri.uri, self.path, artifact))
+    return artifact
+
+  def read_path(self) -> bytes:
+    with open(self.path, 'rb') as f:
+      return f.read()
+
+  def _make_params_with_store(self):
+    params = mock.MagicMock()
+    store = {}
+
+    def get(key, *args, **kwargs):
+      return store.get(key, b"0")  # b"0" -> download not cancelled
+
+    def put(key, value, *args, **kwargs):
+      store[key] = value
+
+    params.get.side_effect = get
+    params.put.side_effect = put
+    return params, store
 
 
 class TestManagerDownload(ManagerDownloadTestBase):
-  """Exercises the real _download_file / _download_chunked against a local server."""
-
-  def run_with_server(self, fn):
-    with http_server_context(handler=DownloadHandler) as (host, port):
-      self.base_url = f'http://{host}:{port}'
-      return fn()
+  """Exercises the real parallel byte-range _download_file against a local server."""
 
   def test_download_file_writes_exact_bytes(self):
     def body():
-      artifact = self.make_artifact(chunked=False)
-      path = os.path.join(self.dest, artifact.fileName)
-      asyncio.run(self.manager._download_file(artifact.downloadUri.uri, path, artifact))
-      with open(path, 'rb') as f:
-        written = f.read()
-      assert written == WHOLE_BODY
-      assert sha256(written) == artifact.downloadUri.sha256
+      artifact = self.download_file()
+      assert self.read_path() == WHOLE_BODY
       assert artifact.fileName not in self.manager._download_start_times
     self.run_with_server(body)
+
+  def test_pieces_tile_the_file(self):
+    def body():
+      self.download_file()
+      expected = [piece_range(i) for i in range(NUM_PIECES)]
+      assert sorted(self.piece_requests()) == expected
+    self.run_with_server(body)
+
+  def test_pieces_download_in_parallel(self):
+    """The stalled piece is only released once every other piece has been requested. A serial
+    downloader would sit on it until the server's stall timeout instead."""
+    def body():
+      DownloadHandler.stall_ranges = {piece_range(0)}
+      DownloadHandler.stall_event = threading.Event()
+      others = {piece_range(i) for i in range(1, NUM_PIECES)}
+
+      def release_when_others_requested():
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline and not others <= set(self.piece_requests()):
+          time.sleep(0.01)
+        DownloadHandler.stall_event.set()
+
+      threading.Thread(target=release_when_others_requested).start()
+      self.download_file()
+      assert DownloadHandler.stall_released_by_event is True, "other pieces did not download while one was stalled"
+      assert self.read_path() == WHOLE_BODY
+    self.run_with_server(body)
+
+  def test_progress_is_monotonic_and_bounded(self):
+    def body():
+      self.download_file()
+      assert self.reported, "expected progress reports"
+      for a, b in zip(self.reported, self.reported[1:], strict=False):
+        assert b >= a, f"progress went backwards: {a} -> {b}"
+      assert max(self.reported) <= 99.0, f"progress must stay <=99 until verify, got {max(self.reported)}"
+    self.run_with_server(body)
+
+  def test_fallback_when_server_ignores_ranges(self):
+    """A 200 to the range probe means whole bodies only: one plain stream, same result."""
+    def body():
+      DownloadHandler.support_ranges = False
+      self.download_file()
+      assert self.read_path() == WHOLE_BODY
+      assert DownloadHandler.request_ranges == [None, None], "expected the probe plus one whole-body request"
+    self.run_with_server(body)
+
+  def test_http_error_propagates(self):
+    def body():
+      DownloadHandler.fail_ranges = {piece_range(1): 404}
+      with self.assertRaises(requests.exceptions.HTTPError):
+        self.download_file()
+    self.run_with_server(body)
+
+  def test_transient_error_is_retried(self):
+    def body():
+      DownloadHandler.fail_once = {piece_range(2)}
+      self.download_file()
+      assert self.read_path() == WHOLE_BODY
+      assert self.piece_requests().count(piece_range(2)) == 2
+    self.run_with_server(body)
+
+  def test_cancellation_via_download_ref(self):
+    """Removing DownloadRef mid-transfer cancels the download. One piece is held back so the transfer
+    spans several reporter ticks; the ref vanishes on the second."""
+    def body():
+      DownloadHandler.stall_ranges = {piece_range(5)}
+      DownloadHandler.stall_event = threading.Event()
+      threading.Timer(0.3, DownloadHandler.stall_event.set).start()
+      checks = {"n": 0}
+
+      def get(key):
+        if key == "ModelManager_DownloadRef":
+          checks["n"] += 1
+          return b"ref" if checks["n"] <= 1 else None
+        return b"0"
+
+      self.manager.params.get.side_effect = get
+      self.manager._download_ref = b"ref"
+      with self.assertRaises(DownloadCancelled):
+        self.download_file()
+      assert checks["n"] >= 2, "cancel must have been polled while the transfer was running"
+      assert os.path.getsize(self.path) == len(WHOLE_BODY)
+    self.run_with_server(body)
+
+  def test_cancel_stops_a_running_piece(self):
+    """A worker blocked on a slow piece exits at its next block once cancelled."""
+    def body():
+      DownloadHandler.stall_ranges = {piece_range(3)}
+      DownloadHandler.stall_event = threading.Event()
+      self.manager.params.get.return_value = None  # cancelled
+      threading.Timer(0.3, DownloadHandler.stall_event.set).start()
+      with self.assertRaises(DownloadCancelled):
+        self.download_file()
+      assert DownloadHandler.stall_released_by_event is True, "the cancel must have caught the piece mid-transfer"
+    self.run_with_server(body)
+
+  def test_replaced_download_ref_queues_instead_of_cancelling(self):
+    """Selecting another model mid-transfer lets the running download finish."""
+    def body():
+      self.manager.params.get.side_effect = lambda key: b"other-ref" if key == "ModelManager_DownloadRef" else None
+      self.manager._download_ref = b"ref"
+      self.download_file()
+      assert self.read_path() == WHOLE_BODY
+    self.run_with_server(body)
+
+  def test_repeat_downloads_are_stable(self):
+    """Back-to-back runs must produce identical bytes and leak no start-time state."""
+    def body():
+      for _ in range(2):
+        self.download_file()
+        assert self.read_path() == WHOLE_BODY
+        assert self.manager._download_start_times == {}
+    self.run_with_server(body)
+
+
+class TestChunkedDownload(ManagerDownloadTestBase):
+  """The chunked download path, still used by the manifests before selector version 20."""
 
   def test_download_chunked_writes_all_chunks_and_manifest(self):
     def body():
@@ -299,39 +511,6 @@ class TestManagerDownload(ManagerDownloadTestBase):
       assert os.path.isfile(get_manifest_path(base_path))
     self.run_with_server(body)
 
-  def test_replaced_download_ref_is_kept(self):
-    """A selection made during a download must survive that download's cleanup."""
-    self.manager.params.get.return_value = b"new-ref"
-    self.manager._download_ref = b"old-ref"
-    self.manager._release_download_ref()
-    self.manager.params.remove.assert_not_called()
-
-  def test_own_download_ref_is_released(self):
-    self.manager.params.get.return_value = b"ref"
-    self.manager._download_ref = b"ref"
-    self.manager._release_download_ref()
-    self.manager.params.remove.assert_called_once_with("ModelManager_DownloadRef")
-
-  def test_cached_bundle_cancel_skips_slot_write(self):
-    """A cancel must stop an already-on-disk bundle before it is applied to the slot."""
-    def body():
-      artifact = self.make_artifact(chunked=True)
-      base_path = os.path.join(self.dest, artifact.fileName)
-      for i, data in enumerate(CHUNK_BODIES):
-        with open(get_chunk_name(base_path, i, len(CHUNK_BODIES)), 'wb') as f:
-          f.write(data)
-      self._bundle.ref = "test-ref"
-      params, store = self._make_params_with_store()
-      store["ModelManager_DownloadRef"] = None  # removed -> cancelled
-      self.manager.params = params
-      self.manager._download_ref = b"ref"
-      with self.assertRaises(Exception) as ctx:
-        asyncio.run(self.manager._download_bundle(self._bundle, self.dest, "qcom"))
-      assert 'cancelled' in str(ctx.exception).lower()
-      assert "ModelManager_ActiveBundle" not in store
-      assert all(os.path.isfile(p) for p in self.chunk_paths(base_path)), "cancel must not delete cached chunks"
-    self.run_with_server(body)
-
   def test_resume_skips_valid_chunks(self):
     """A chunk already on disk is kept and not re-downloaded; progress starts above its share."""
     def body():
@@ -367,24 +546,63 @@ class TestManagerDownload(ManagerDownloadTestBase):
       assert artifact.downloadProgress.status == custom.ModelManagerSP.DownloadStatus.cached
     self.run_with_server(body)
 
-  def _make_params_with_store(self):
-    params = mock.MagicMock()
-    store = {}
 
-    def get(key, *args, **kwargs):
-      return store.get(key, b"0")  # b"0" -> download not cancelled
+class TestProcessArtifact(ManagerDownloadTestBase):
+  """Verification and cleanup around the download."""
 
-    def put(key, value, *args, **kwargs):
-      store[key] = value
+  def test_downloaded_file_verifies_and_ends_idle(self):
+    def body():
+      artifact = self.make_artifact()
+      asyncio.run(self.manager._process_artifact(artifact, self.dest))
+      assert self.read_path() == WHOLE_BODY
+      assert artifact.downloadProgress.status == custom.ModelManagerSP.DownloadStatus.downloaded
+      assert artifact.downloadProgress.progress == 100
+      assert artifact.downloadProgress.eta == 0
+    self.run_with_server(body)
 
-    params.get.side_effect = get
-    params.put.side_effect = put
-    return params, store
+  def test_hash_mismatch_discards_file_and_parts(self):
+    def body():
+      DownloadHandler.corrupt = True
+      artifact = self.make_artifact()
+      with self.assertRaises(ValueError):
+        asyncio.run(self.manager._process_artifact(artifact, self.dest))
+      assert not os.path.isfile(self.path)
+      assert artifact.downloadProgress.status == custom.ModelManagerSP.DownloadStatus.failed
+    self.run_with_server(body)
+
+  def test_cached_file_skips_network(self):
+    def body():
+      with open(self.path, 'wb') as f:
+        f.write(WHOLE_BODY)
+      artifact = self.make_artifact()
+      asyncio.run(self.manager._process_artifact(artifact, self.dest))
+      assert DownloadHandler.request_ranges == [], "cached file must not hit the network"
+      ds = custom.ModelManagerSP.DownloadStatus
+      assert self.reported_statuses == [ds.verifying, ds.cached]
+      assert artifact.downloadProgress.progress == 100
+    self.run_with_server(body)
+
+  def test_cached_bundle_cancel_skips_slot_write(self):
+    """A cancel must stop an already-on-disk bundle before it is applied to the slot."""
+    def body():
+      with open(self.path, 'wb') as f:
+        f.write(WHOLE_BODY)
+      self.make_artifact()
+      self._bundle.ref = "test-ref"
+      params, store = self._make_params_with_store()
+      store["ModelManager_DownloadRef"] = None  # removed -> cancelled
+      self.manager.params = params
+      self.manager._download_ref = b"ref"
+      with self.assertRaises(DownloadCancelled):
+        asyncio.run(self.manager._download_bundle(self._bundle, self.dest, "qcom"))
+      assert "ModelManager_ActiveBundle" not in store
+      assert os.path.isfile(self.path), "cancel must not delete a cached model"
+    self.run_with_server(body)
 
   def test_download_writes_qcom_slot(self):
     """A download resolved to the qcom source writes the qcom active bundle slot only."""
     def body():
-      artifact = self.make_artifact(chunked=True)
+      self.make_artifact()
       self._bundle.ref = "test-ref"
       self._bundle.minimumSelectorVersion = helpers.REQUIRED_JSON_VERSION
       params, store = self._make_params_with_store()
@@ -396,15 +614,13 @@ class TestManagerDownload(ManagerDownloadTestBase):
       assert self.manager.selected_bundle.status == custom.ModelManagerSP.DownloadStatus.downloaded
       assert self.manager.active_bundle is not None and self.manager.active_bundle.ref == "test-ref"
       assert self.manager.active_bundle.status == custom.ModelManagerSP.DownloadStatus.downloaded
-      chunk_names = [get_chunk_name(artifact.fileName, i, len(artifact.chunks)) for i in range(len(artifact.chunks))]
-      missing = [c for c in chunk_names if not os.path.isfile(os.path.join(self.dest, c))]
-      assert missing == [], f"chunks missing from the cache: {missing}"
+      assert self.read_path() == WHOLE_BODY
     self.run_with_server(body)
 
   def test_download_writes_chestnut_slot(self):
     """A download resolved to the chestnut source writes the chestnut active bundle slot only."""
     def body():
-      self.make_artifact(chunked=True)
+      self.make_artifact()
       self._bundle.ref = "big-ref"
       self._bundle.minimumSelectorVersion = helpers.REQUIRED_JSON_VERSION
       params, store = self._make_params_with_store()
@@ -416,6 +632,18 @@ class TestManagerDownload(ManagerDownloadTestBase):
       assert self.manager.selected_bundle.status == custom.ModelManagerSP.DownloadStatus.downloaded
     self.run_with_server(body)
 
+  def test_replaced_download_ref_is_kept(self):
+    """A selection made during a download must survive that download's cleanup."""
+    self.manager.params.get.return_value = b"new-ref"
+    self.manager._download_ref = b"old-ref"
+    self.manager._release_download_ref()
+    self.manager.params.remove.assert_not_called()
+
+  def test_own_download_ref_is_released(self):
+    self.manager.params.get.return_value = b"ref"
+    self.manager._download_ref = b"ref"
+    self.manager._release_download_ref()
+    self.manager.params.remove.assert_called_once_with("ModelManager_DownloadRef")
 
 class TestManagerImports(OpenpilotTestCase):
   """Catches undeclared dependencies. aiohttp lived only in the AGNOS venv; 19.6 dropped
@@ -432,6 +660,9 @@ class TestManagerImports(OpenpilotTestCase):
   def test_download_timeout_is_explicit(self):
     connect, read = manager_module.DOWNLOAD_TIMEOUT
     assert connect > 0 and read > 0, "requests defaults to no timeout; downloads would hang forever"
+
+  def test_parallelism_is_bounded(self):
+    assert 1 < manager_module.MAX_CONCURRENT_CHUNKS <= 32, "HuggingFace was only verified rate-limit free up to 32 connections"
 
 
 class TestResolveBundleByRef(OpenpilotTestCase):

--- a/openpilot/sunnypilot/models/tests/test_manager_download.py
+++ b/openpilot/sunnypilot/models/tests/test_manager_download.py
@@ -168,7 +168,7 @@ class ManagerDownloadTestBase(OpenpilotTestCase):
     self.addCleanup(self._tmp.cleanup)
     self.dest = self._tmp.name
 
-    for name, value in (('PIECE_SIZE', PIECE), ('REPORT_INTERVAL', 0.05), ('PIECE_BACKOFF', 0.01)):
+    for name, value in (('PIECE_SIZE', PIECE), ('REPORT_INTERVAL', 0.05), ('PIECE_BACKOFF', 0.01), ('RETRY_BACKOFF', 0.01)):
       patcher = mock.patch.object(manager_module, name, value)
       patcher.start()
       self.addCleanup(patcher.stop)
@@ -770,6 +770,147 @@ class TestProcessArtifact(ManagerDownloadTestBase):
     self.manager._download_ref = b"ref"
     self.manager._release_download_ref()
     self.manager.params.remove.assert_called_once_with("ModelManager_DownloadRef")
+
+class TestTransferRetries(ManagerDownloadTestBase):
+  """A transfer whose pieces exhaust their retries is retried from its resume state after a
+  cancellable backoff; permanent errors are not retried at all."""
+
+  def process(self):
+    artifact = self.make_artifact()
+    asyncio.run(self.manager._process_artifact(artifact, self.dest))
+    return artifact
+
+  def test_transient_failure_resumes_from_finished_pieces(self):
+    """The first transfer gives up on piece 1; the retry fetches only what the sidecar does not record."""
+    def body():
+      DownloadHandler.fail_times = {piece_range(1): manager_module.PIECE_RETRIES}
+      original = self.manager._download_file
+      done_before_retry: list[set[int]] = []
+
+      async def spy(url, path, artifact):
+        with contextlib.suppress(FileNotFoundError):
+          done_before_retry.append(set(self.resume_state()["done"]))
+        return await original(url, path, artifact)
+
+      # a slower piece backoff gives the other pieces time to land before the first transfer gives up
+      with mock.patch.object(manager_module, 'PIECE_BACKOFF', 0.05), mock.patch.object(self.manager, '_download_file', spy):
+        artifact = self.process()
+      assert len(done_before_retry) == 1 and done_before_retry[0], "expected exactly one retry, resuming recorded pieces"
+      requested = self.piece_requests()
+      assert requested.count(piece_range(1)) == manager_module.PIECE_RETRIES + 1
+      for i in done_before_retry[0]:
+        assert requested.count(piece_range(i)) == 1, f"piece {i} was recorded as done yet fetched again"
+      assert self.read_path() == WHOLE_BODY
+      assert artifact.downloadProgress.status == custom.ModelManagerSP.DownloadStatus.downloaded
+      assert not os.path.exists(self.sidecar)
+    self.run_with_server(body)
+
+  def test_transient_error_gives_up_after_every_attempt(self):
+    def body():
+      DownloadHandler.fail_ranges = {piece_range(1): 503}
+      artifact = self.make_artifact()
+      with self.assertRaises(requests.exceptions.HTTPError):
+        asyncio.run(self.manager._process_artifact(artifact, self.dest))
+      expected = manager_module.PIECE_RETRIES * manager_module.DOWNLOAD_ATTEMPTS
+      assert self.piece_requests().count(piece_range(1)) == expected
+      assert artifact.downloadProgress.status == custom.ModelManagerSP.DownloadStatus.failed
+      assert os.path.isfile(self.sidecar), "the resume state survives for the next request"
+    self.run_with_server(body)
+
+  def test_permanent_http_error_is_not_retried(self):
+    def body():
+      DownloadHandler.fail_ranges = {piece_range(1): 404}
+      artifact = self.make_artifact()
+      with self.assertRaises(requests.exceptions.HTTPError):
+        asyncio.run(self.manager._process_artifact(artifact, self.dest))
+      assert self.piece_requests().count(piece_range(1)) == 1, "a 404 must not be retried"
+      assert artifact.downloadProgress.status == custom.ModelManagerSP.DownloadStatus.failed
+    self.run_with_server(body)
+
+  def test_cancel_during_backoff_stops_the_retry(self):
+    def body():
+      DownloadHandler.fail_ranges = {piece_range(1): 503}
+      original = self.manager._download_file
+      gave_up = threading.Event()
+
+      async def wrapped(url, path, artifact):
+        try:
+          return await original(url, path, artifact)
+        except Exception:
+          gave_up.set()  # the ref disappears while the backoff is running
+          raise
+
+      self.manager.params.get.side_effect = lambda key: (None if gave_up.is_set() else b"ref") if key == "ModelManager_DownloadRef" else b"0"
+      self.manager._download_ref = b"ref"
+      artifact = self.make_artifact()
+      started = time.monotonic()
+      with mock.patch.object(manager_module, 'RETRY_BACKOFF', 30.0), mock.patch.object(self.manager, '_download_file', wrapped):
+        with self.assertRaises(DownloadCancelled):
+          asyncio.run(self.manager._process_artifact(artifact, self.dest))
+      assert time.monotonic() - started < 5, "the backoff must end at the cancel, not after 30 s"
+      assert self.piece_requests().count(piece_range(1)) == manager_module.PIECE_RETRIES, "no second transfer after a cancel"
+      assert artifact.downloadProgress.status == custom.ModelManagerSP.DownloadStatus.failed
+    self.run_with_server(body)
+
+
+class TestDownloadRequests(ManagerDownloadTestBase):
+  """What the download row shows once _process_download_requests has handled a request: a failure
+  stays visible until the next request, a finished or cancelled download clears it."""
+
+  def _request(self, ref: str) -> dict:
+    self.make_artifact()
+    self._bundle.ref = ref
+    self._bundle.minimumSelectorVersion = helpers.REQUIRED_JSON_VERSION
+    self.manager.source_models = {"qcom": [self._bundle], "chestnut": []}
+    params, store = self._make_params_with_store()
+    store["ModelManager_DownloadRef"] = ref
+    params.remove.side_effect = lambda key: store.__setitem__(key, None)
+    self.manager.params = params
+    return store
+
+  def _process_requests(self):
+    with mock.patch.object(manager_module.Paths, 'model_root', return_value=self.dest):
+      self.manager._process_download_requests()
+
+  def test_failed_download_stays_on_the_row(self):
+    def body():
+      DownloadHandler.fail_ranges = {piece_range(1): 404}
+      store = self._request("test-ref")
+      self._process_requests()
+      self._process_requests()  # an idle tick must not clear the failure
+      assert self.manager.selected_bundle is not None
+      assert self.manager.selected_bundle.status == custom.ModelManagerSP.DownloadStatus.failed
+      assert store["ModelManager_DownloadRef"] is None, "the failed request is released"
+      assert "ModelManager_ActiveBundle" not in store
+    self.run_with_server(body)
+
+  def test_finished_download_clears_the_row(self):
+    def body():
+      store = self._request("test-ref")
+      self._process_requests()
+      assert self.manager.selected_bundle is None
+      assert "ModelManager_ActiveBundle" in store
+      assert self.read_path() == WHOLE_BODY
+    self.run_with_server(body)
+
+  def test_cancelled_download_clears_the_row(self):
+    def body():
+      DownloadHandler.stall_ranges = {piece_range(3)}
+      DownloadHandler.stall_event = threading.Event()
+      store = self._request("test-ref")
+
+      def cancel_soon():
+        time.sleep(0.2)
+        store["ModelManager_DownloadRef"] = None
+        DownloadHandler.stall_event.set()
+
+      threading.Thread(target=cancel_soon).start()
+      self._process_requests()
+      assert self.manager.selected_bundle is None
+      assert "ModelManager_ActiveBundle" not in store
+      assert os.path.isfile(self.sidecar), "a cancel keeps the resume state"
+    self.run_with_server(body)
+
 
 class TestManagerImports(OpenpilotTestCase):
   """Catches undeclared dependencies. aiohttp lived only in the AGNOS venv; 19.6 dropped

--- a/openpilot/sunnypilot/models/tests/test_manager_download.py
+++ b/openpilot/sunnypilot/models/tests/test_manager_download.py
@@ -288,6 +288,14 @@ class TestManagerDownload(ManagerDownloadTestBase):
       assert self.read_path() == WHOLE_BODY
     self.run_with_server(body)
 
+  def test_speed_and_eta_reported(self):
+    def body():
+      artifact = self.download_file()
+      assert artifact.downloadProgress.status == custom.ModelManagerSP.DownloadStatus.downloading
+      assert artifact.downloadProgress.speed > 0
+      assert artifact.downloadProgress.eta >= 1
+    self.run_with_server(body)
+
   def test_progress_is_monotonic_and_bounded(self):
     def body():
       self.download_file()
@@ -557,6 +565,7 @@ class TestProcessArtifact(ManagerDownloadTestBase):
       assert self.read_path() == WHOLE_BODY
       assert artifact.downloadProgress.status == custom.ModelManagerSP.DownloadStatus.downloaded
       assert artifact.downloadProgress.progress == 100
+      assert artifact.downloadProgress.speed == 0
       assert artifact.downloadProgress.eta == 0
     self.run_with_server(body)
 

--- a/openpilot/sunnypilot/models/tests/test_manager_download.py
+++ b/openpilot/sunnypilot/models/tests/test_manager_download.py
@@ -7,6 +7,7 @@ See the LICENSE.md file in the root directory for more details.
 
 import asyncio
 import contextlib
+import glob
 import hashlib
 import http.server
 import json
@@ -21,11 +22,10 @@ from typing import Any
 from unittest import mock
 
 import requests
-from urllib3.connectionpool import HTTPConnectionPool
 
 from openpilot.cereal import custom
+from openpilot.common.hardware import hw
 from openpilot.common.test import OpenpilotTestCase
-from openpilot.common.file_chunker import get_chunk_name, get_manifest_path
 from openpilot.sunnypilot.models import manager as manager_module
 from openpilot.sunnypilot.models.fetcher import ModelFetcher, get_cached_bundles
 from openpilot.sunnypilot.models import helpers
@@ -38,8 +38,6 @@ FILE_NAME = 'driving_test_tinygrad.pkl'
 WHOLE_BODY = bytes(range(256)) * 40
 PIECE = 1000  # test piece size -> 11 pieces, the last one short
 NUM_PIECES = math.ceil(len(WHOLE_BODY) / PIECE)
-# a legacy chunked entry, served by path; goes with the chunked download path
-CHUNK_BODIES = [b'A' * 5000, b'B' * 5000, b'C' * 3000]
 
 
 def sha256(data: bytes) -> str:
@@ -63,26 +61,12 @@ class DownloadHandler(http.server.BaseHTTPRequestHandler):
   stall_released_by_event: bool | None = None
   support_ranges = True
   corrupt = False
-  request_paths: list[str] = []  # every path requested, chunk or whole
-  fail_paths: dict[str, int] = {}  # chunk path -> HTTP status
 
   def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
     pass
 
   def do_GET(self):
     cls = type(self)
-    cls.request_paths.append(self.path)
-    if self.path in cls.fail_paths:
-      self.send_response(cls.fail_paths[self.path])
-      self.end_headers()
-      return
-    for i, chunk in enumerate(CHUNK_BODIES):
-      if self.path.endswith(get_chunk_name('', i, len(CHUNK_BODIES))):
-        self.send_response(200)
-        self.send_header('Content-Length', str(len(chunk)))
-        self.end_headers()
-        self.wfile.write(chunk)
-        return
     if not self.path.endswith('/' + FILE_NAME):
       self.send_response(404)
       self.end_headers()
@@ -161,8 +145,6 @@ class ManagerDownloadTestBase(OpenpilotTestCase):
     DownloadHandler.stall_released_by_event = None
     DownloadHandler.support_ranges = True
     DownloadHandler.corrupt = False
-    DownloadHandler.request_paths = []
-    DownloadHandler.fail_paths = {}
 
     self._tmp = tempfile.TemporaryDirectory()
     self.addCleanup(self._tmp.cleanup)
@@ -197,19 +179,13 @@ class ManagerDownloadTestBase(OpenpilotTestCase):
       status = artifact.downloadProgress.status
       self.reported_statuses.append(getattr(status, 'raw', status))  # .raw: _DynamicEnum is not int()-able
 
-  def make_artifact(self, chunked: bool = False):
+  def make_artifact(self):
     bundle = custom.ModelManagerSP.ModelBundle.new_message()
     bundle.init('models', 1)
     artifact = bundle.models[0].artifact
     artifact.fileName = FILE_NAME
     artifact.downloadUri.uri = self.base_url + '/' + FILE_NAME
-    if chunked:  # a legacy manifest entry: the whole file's hash plus one per chunk
-      artifact.downloadUri.sha256 = sha256(b''.join(CHUNK_BODIES))
-      artifact.init('chunks', len(CHUNK_BODIES))
-      for i, body in enumerate(CHUNK_BODIES):
-        artifact.chunks[i].sha256 = sha256(body)
-    else:
-      artifact.downloadUri.sha256 = sha256(WHOLE_BODY)
+    artifact.downloadUri.sha256 = sha256(WHOLE_BODY)
     self._bundle = bundle
     self.artifact = artifact
     return artifact
@@ -476,178 +452,6 @@ class TestManagerDownload(ManagerDownloadTestBase):
     self.run_with_server(body)
 
 
-class TestChunkedDownload(ManagerDownloadTestBase):
-  """The chunked download path, still used by the manifests before selector version 20."""
-
-  def test_download_chunked_writes_all_chunks_and_manifest(self):
-    def body():
-      artifact = self.make_artifact(chunked=True)
-      base_path = os.path.join(self.dest, artifact.fileName)
-      asyncio.run(self.manager._download_chunked(artifact.downloadUri.uri, base_path, artifact))
-
-      for i, expected in enumerate(CHUNK_BODIES):
-        with open(get_chunk_name(base_path, i, len(CHUNK_BODIES)), 'rb') as f:
-          assert f.read() == expected, f"chunk {i} body mismatch"
-
-      with open(get_manifest_path(base_path)) as f:
-        assert f.read() == str(len(CHUNK_BODIES))
-
-      assert not os.path.isfile(base_path), "base file should be removed after chunking"
-      assert artifact.fileName not in self.manager._download_start_times
-    self.run_with_server(body)
-
-  def test_progress_is_monotonic_and_bounded(self):
-    def body():
-      artifact = self.make_artifact(chunked=True)
-      base_path = os.path.join(self.dest, artifact.fileName)
-      asyncio.run(self.manager._download_chunked(artifact.downloadUri.uri, base_path, artifact))
-
-      assert self.reported, "expected progress reports"
-      for a, b in zip(self.reported, self.reported[1:], strict=False):
-        assert b >= a, f"progress went backwards: {a} -> {b}"
-      assert max(self.reported) <= 99.0, f"chunked progress must stay <=99 until verify, got {max(self.reported)}"
-    self.run_with_server(body)
-
-  def test_session_is_reused_across_chunks(self):
-    """One connection pool shared across every chunk."""
-    def body():
-      artifact = self.make_artifact(chunked=True)
-      base_path = os.path.join(self.dest, artifact.fileName)
-
-      pools = []
-      original = HTTPConnectionPool.urlopen
-
-      def tracked(pool_self, *args, **kwargs):
-        pools.append(id(pool_self))
-        return original(pool_self, *args, **kwargs)
-
-      with mock.patch.object(HTTPConnectionPool, 'urlopen', tracked):
-        asyncio.run(self.manager._download_chunked(artifact.downloadUri.uri, base_path, artifact))
-
-      assert len(pools) == len(CHUNK_BODIES), f"expected one request per chunk, got {len(pools)}"
-      assert len(set(pools)) == 1, f"connection pool not reused across chunks: {len(set(pools))} pools"
-    self.run_with_server(body)
-
-  def test_http_error_propagates(self):
-    def body():
-      artifact = self.make_artifact(chunked=True)
-      base_path = os.path.join(self.dest, artifact.fileName)
-      failing = '/' + os.path.basename(get_chunk_name(artifact.downloadUri.uri, 1, len(CHUNK_BODIES)))
-      DownloadHandler.fail_paths = {failing: 404}
-
-      with self.assertRaises(requests.exceptions.HTTPError):
-        asyncio.run(self.manager._download_chunked(artifact.downloadUri.uri, base_path, artifact))
-
-      # chunk 1 failed, so its file and the manifest must not exist
-      assert not os.path.isfile(get_chunk_name(base_path, 1, len(CHUNK_BODIES)))
-      assert not os.path.isfile(get_manifest_path(base_path))
-    self.run_with_server(body)
-
-  def test_cancellation_mid_transfer(self):
-    """Cancellation is checked inside the byte loop; it must still fire after the port."""
-    def body():
-      artifact = self.make_artifact(chunked=True)
-      base_path = os.path.join(self.dest, artifact.fileName)
-      self.manager.params.get.return_value = None  # cancelled
-
-      with self.assertRaises(Exception) as ctx:
-        asyncio.run(self.manager._download_chunked(artifact.downloadUri.uri, base_path, artifact))
-      assert 'cancelled' in str(ctx.exception).lower()
-      assert not os.path.isfile(get_manifest_path(base_path))
-    self.run_with_server(body)
-
-  def test_repeat_downloads_are_stable(self):
-    """Back-to-back runs must produce identical bytes and leak no start-time state."""
-    def body():
-      for _ in range(2):
-        artifact = self.make_artifact(chunked=True)
-        base_path = os.path.join(self.dest, artifact.fileName)
-        asyncio.run(self.manager._download_chunked(artifact.downloadUri.uri, base_path, artifact))
-        for i, expected in enumerate(CHUNK_BODIES):
-          with open(get_chunk_name(base_path, i, len(CHUNK_BODIES)), 'rb') as f:
-            assert f.read() == expected
-        assert self.manager._download_start_times == {}
-    self.run_with_server(body)
-
-  def test_download_ref_present_keeps_download_alive(self):
-    """A pending download request (DownloadRef set) must not be cancelled mid-transfer."""
-    def body():
-      artifact = self.make_artifact(chunked=True)
-      base_path = os.path.join(self.dest, artifact.fileName)
-      self.manager.params.get.side_effect = lambda key: b"ref" if key == "ModelManager_DownloadRef" else None
-      self.manager._download_ref = b"ref"
-      asyncio.run(self.manager._download_chunked(artifact.downloadUri.uri, base_path, artifact))
-      assert os.path.isfile(get_manifest_path(base_path))
-    self.run_with_server(body)
-
-  def test_cancellation_via_download_ref(self):
-    """Removing DownloadRef mid-transfer cancels the download."""
-    def body():
-      artifact = self.make_artifact(chunked=True)
-      base_path = os.path.join(self.dest, artifact.fileName)
-      checks = {"n": 0}
-
-      def get(key):
-        if key == "ModelManager_DownloadRef":
-          checks["n"] += 1
-          return b"ref" if checks["n"] <= 2 else None
-        return b"0"
-
-      self.manager.params.get.side_effect = get
-      self.manager._download_ref = b"ref"
-      with self.assertRaises(Exception) as ctx:
-        asyncio.run(self.manager._download_chunked(artifact.downloadUri.uri, base_path, artifact))
-      assert 'cancelled' in str(ctx.exception).lower()
-      assert not os.path.isfile(get_manifest_path(base_path))
-    self.run_with_server(body)
-
-  def test_replaced_download_ref_queues_instead_of_cancelling(self):
-    """Selecting another model mid-transfer lets the running download finish."""
-    def body():
-      artifact = self.make_artifact(chunked=True)
-      base_path = os.path.join(self.dest, artifact.fileName)
-      self.manager.params.get.side_effect = lambda key: b"other-ref" if key == "ModelManager_DownloadRef" else None
-      self.manager._download_ref = b"ref"
-      asyncio.run(self.manager._download_chunked(artifact.downloadUri.uri, base_path, artifact))
-      assert os.path.isfile(get_manifest_path(base_path))
-    self.run_with_server(body)
-
-  def test_resume_skips_valid_chunks(self):
-    """A chunk already on disk is kept and not re-downloaded; progress starts above its share."""
-    def body():
-      artifact = self.make_artifact(chunked=True)
-      base_path = os.path.join(self.dest, artifact.fileName)
-      with open(get_chunk_name(base_path, 0, len(CHUNK_BODIES)), 'wb') as f:
-        f.write(CHUNK_BODIES[0])
-
-      asyncio.run(self.manager._process_artifact(artifact, self.dest))
-
-      chunk0_suffix = get_chunk_name('', 0, len(CHUNK_BODIES))
-      assert not any(p.endswith(chunk0_suffix) for p in DownloadHandler.request_paths), "valid chunk was re-downloaded"
-      for i, expected in enumerate(CHUNK_BODIES):
-        with open(get_chunk_name(base_path, i, len(CHUNK_BODIES)), 'rb') as f:
-          assert f.read() == expected
-      assert os.path.isfile(get_manifest_path(base_path))
-      assert min(self.reported) >= (1 / len(CHUNK_BODIES)) * 100 - 1, "progress must not restart below the resumed share"
-    self.run_with_server(body)
-
-  def test_verify_reports_valid_fraction_then_cached(self):
-    """A fully cached bundle publishes climbing verify progress and ends cached."""
-    def body():
-      artifact = self.make_artifact(chunked=True)
-      base_path = os.path.join(self.dest, artifact.fileName)
-      for i, data in enumerate(CHUNK_BODIES):
-        with open(get_chunk_name(base_path, i, len(CHUNK_BODIES)), 'wb') as f:
-          f.write(data)
-
-      asyncio.run(self.manager._process_artifact(artifact, self.dest))
-
-      assert DownloadHandler.request_paths == [], "cached bundle must not hit the network"
-      assert [round(p) for p in self.reported[:3]] == [33, 67, 100]
-      assert artifact.downloadProgress.status == custom.ModelManagerSP.DownloadStatus.cached
-    self.run_with_server(body)
-
-
 class TestProcessArtifact(ManagerDownloadTestBase):
   """Verification, cleanup and resume policy around the download."""
 
@@ -706,6 +510,18 @@ class TestProcessArtifact(ManagerDownloadTestBase):
       ds = custom.ModelManagerSP.DownloadStatus
       assert self.reported_statuses == [ds.verifying, ds.cached]
       assert artifact.downloadProgress.progress == 100
+    self.run_with_server(body)
+
+  def test_legacy_chunk_files_are_purged(self):
+    """Chunk files from a pre-v20 download would shadow the whole file in open_file_chunked."""
+    def body():
+      for suffix in ('.chunkmanifest', '.chunk01of02', '.chunk02of02'):
+        with open(self.path + suffix, 'wb') as f:
+          f.write(b'2' if suffix == '.chunkmanifest' else b'legacy')
+      artifact = self.make_artifact()
+      asyncio.run(self.manager._process_artifact(artifact, self.dest))
+      assert glob.glob(self.path + '.chunk*') == []
+      assert self.read_path() == WHOLE_BODY
     self.run_with_server(body)
 
   def test_cached_bundle_cancel_skips_slot_write(self):
@@ -770,6 +586,23 @@ class TestProcessArtifact(ManagerDownloadTestBase):
     self.manager._download_ref = b"ref"
     self.manager._release_download_ref()
     self.manager.params.remove.assert_called_once_with("ModelManager_DownloadRef")
+
+  def test_clear_cache_keeps_only_active_files(self):
+    """Interrupted downloads, legacy chunk files and other models all go; the selected slots' files stay."""
+    active = custom.ModelManagerSP.ModelBundle.new_message()
+    active.minimumSelectorVersion = helpers.REQUIRED_JSON_VERSION
+    active.init('models', 1)
+    active.models[0].artifact.fileName = 'active.pkl'
+    raw = active.to_dict()
+    self.manager.params.get.side_effect = lambda key, *a, **k: raw if key == "ModelManager_ActiveBundle" else None
+
+    for name in ('active.pkl', 'active.pkl.chunkmanifest', 'active.pkl.chunk01of02', 'other.pkl', 'other.pkl.download'):
+      with open(os.path.join(self.dest, name), 'wb') as f:
+        f.write(b'x')
+    with mock.patch.object(hw.Paths, 'model_root', staticmethod(lambda: self.dest)):
+      self.manager.clear_model_cache()
+    assert os.listdir(self.dest) == ['active.pkl']
+
 
 class TestTransferRetries(ManagerDownloadTestBase):
   """A transfer whose pieces exhaust their retries is retried from its resume state after a
@@ -957,7 +790,7 @@ class TestResolveBundleByRef(OpenpilotTestCase):
 
 
 def manifest_bundle(short_name: str, ref: str, index: int = 0, is_big: bool = False) -> dict:
-  """Minimal manifest bundle dict, version-compatible (no chunks to avoid disk side effects).
+  """Minimal whole-file manifest bundle dict, version-compatible.
   Big (chestnut) bundles carry `is_big: true` in the manifest JSON."""
   return {
     "index": index,
@@ -970,7 +803,7 @@ def manifest_bundle(short_name: str, ref: str, index: int = 0, is_big: bool = Fa
     "minimum_selector_version": str(helpers.REQUIRED_JSON_VERSION),
     "ref": ref,
     "models": [{
-      "type": "supercombo",
+      "type": "driving",
       "artifact": {
         "file_name": f"{short_name}.pkl",
         "download_uri": {"url": f"https://example.com/{short_name}.pkl", "sha256": "s"},
@@ -1044,6 +877,24 @@ class TestModelFetcherSources(OpenpilotTestCase):
       "chestnut": ModelFetcher.MODEL_URL_CHESTNUT,
     }
 
+  def test_chunked_manifest_entries_are_ignored(self):
+    """A stray `chunks` array is not parsed and leaves no chunk manifest on disk."""
+    chunked = manifest_bundle("small", "aaa")
+    chunked["models"][0]["artifact"]["chunks"] = [{"file_name": "small.pkl.chunk01of01", "sha256": "c"}]
+    with tempfile.TemporaryDirectory() as model_dir, mock.patch.object(hw.Paths, 'model_root', staticmethod(lambda: model_dir)):
+      bundles = ModelFetcher(mock.MagicMock()).model_parser.parse_models({"bundles": [chunked]})
+      assert len(bundles[0].models[0].artifact.chunks) == 0
+      assert os.listdir(model_dir) == []
+
+  def test_model_type_driving_and_legacy_chunked_both_parse(self):
+    """New manifests type the whole pkl `driving`; `chunked` must keep parsing because an upgrading
+    device reads its cached v22 catalog before the first refetch, and an unknown type raises."""
+    driving = manifest_bundle("small", "aaa")
+    legacy = manifest_bundle("old", "bbb", index=1)
+    legacy["models"][0]["type"] = "chunked"
+    bundles = ModelFetcher(mock.MagicMock()).model_parser.parse_models({"bundles": [driving, legacy]})
+    assert bundles[0].models[0].type == helpers.ModelManager.Model.Type.driving
+    assert bundles[1].models[0].type == helpers.ModelManager.Model.Type.chunked
 
 
 class TestSourceCacheIntegrity(OpenpilotTestCase):
@@ -1185,6 +1036,15 @@ class TestActiveBundleValidation(OpenpilotTestCase):
     runner_puts = [call for call in params.put.call_args_list if call.args[0] == "ModelRunnerTypeCache"]
     assert [call.args[1] for call in runner_puts] == [tinygrad]
 
+  def test_previous_version_slot_is_reset(self):
+    """A slot saved by a chunked-manifest client (selector 19) is dropped, never downloaded as-is."""
+    stale = self._raw_bundle("small")
+    stale["minimumSelectorVersion"] = helpers.REQUIRED_JSON_VERSION - 1
+    params = self._params(qcom=stale)
+    with mock.patch("openpilot.sunnypilot.models.helpers.chestnut_present", return_value=False):
+      validate_active_bundles(params, {"qcom": [], "chestnut": []})
+    params.remove.assert_called_once_with("ModelManager_ActiveBundle")
+
 
 class TestActiveBundleSelection(OpenpilotTestCase):
   """The effective active bundle is the active source's slot: chestnut when a GPU is
@@ -1280,31 +1140,33 @@ class TestEffectiveSource(OpenpilotTestCase):
 
 @unittest.skipUnless(os.environ.get('RUN_INTEGRATION_TESTS'), 'requires external network')
 class TestLiveModelManifest(OpenpilotTestCase):
-  """Every artifact and chunk URL in the published manifest must resolve."""
+  """Every artifact in the published manifests must be a reachable whole file that honors byte
+  ranges, which the parallel downloader depends on."""
 
   def test_all_manifest_urls_available(self):
-    from openpilot.sunnypilot.models.fetcher import ModelFetcher
-
-    manifest = requests.get(ModelFetcher.MODEL_URL, timeout=30).json()
     session = requests.Session()
     dead = []
 
-    for bundle in manifest.get('bundles', []):
-      for model in bundle.get('models', []):
-        artifact = model['artifact']
-        url = artifact['download_uri']['url']
-        chunks = artifact.get('chunks', [])
-        urls = ([url] if not chunks
-                else [get_chunk_name(url, i, len(chunks)) for i in range(len(chunks))])
-        for u in urls:
+    for manifest_url in (ModelFetcher.MODEL_URL, ModelFetcher.MODEL_URL_CHESTNUT):
+      manifest = requests.get(manifest_url, timeout=30).json()
+      for bundle in manifest.get('bundles', []):
+        # a build-all manifest starts as a copy of the previous one: entries still at the old
+        # selector version are never loaded by this client, so they are not checked either
+        if str(bundle.get('minimum_selector_version', '')).strip() != str(helpers.REQUIRED_JSON_VERSION):
+          continue
+        for model in bundle.get('models', []):
+          artifact = model['artifact']
+          if artifact.get('chunks'):
+            dead.append(f"{bundle.get('short_name')}: still chunked {artifact['file_name']}")
+          url = artifact['download_uri']['url']
           try:
-            r = session.head(u, timeout=15, allow_redirects=True)
-            if r.status_code != 200:
-              dead.append(f"{bundle.get('short_name')}: HTTP {r.status_code} {u}")
+            with session.get(url, headers={'Range': 'bytes=0-0'}, stream=True, timeout=15, allow_redirects=True) as r:
+              if r.status_code != 206:
+                dead.append(f"{bundle.get('short_name')}: HTTP {r.status_code} (expected 206) {url}")
           except requests.RequestException as e:
-            dead.append(f"{bundle.get('short_name')}: {type(e).__name__} {u}")
+            dead.append(f"{bundle.get('short_name')}: {type(e).__name__} {url}")
 
-    assert not dead, "unreachable model URLs:\n" + "\n".join(dead)
+    assert not dead, "unusable model URLs:\n" + "\n".join(dead)
 
 
 if __name__ == '__main__':

--- a/openpilot/system/ui/sunnypilot/widgets/download_status.py
+++ b/openpilot/system/ui/sunnypilot/widgets/download_status.py
@@ -57,7 +57,7 @@ class DownloadStatusAction(ItemAction):
     self.icon: str | None = None
     self.icon_color: rl.Color | None = None
     self._font = gui_app.font(FontWeight.NORMAL)
-    # raw progress arrives in steps, one per 128KB chunk the manager publishes
+    # raw progress arrives in steps, one per progress report from the manager
     self._progress = FirstOrderFilter(0.0, 0.5, 1 / gui_app.target_fps)
     # integrated per frame; (t * speed) % span jumps whenever the fill width changes
     self._sweep = 0.0

--- a/release/ci/model_generator.py
+++ b/release/ci/model_generator.py
@@ -130,7 +130,8 @@ def generate_chunked_model(driving_pkl: Path) -> dict:
     artifact_data["chunks"] = chunks_config
 
   return {
-    "type": "chunked",
+    # "driving" is the whole combined pkl; "chunked" only while a chunk manifest is present (defaults pipeline)
+    "type": "driving" if not chunks_config else "chunked",
     "artifact": artifact_data,
   }
 


### PR DESCRIPTION
Part 8 of 8 of the whole-file model download work, split out of #1998. Builds on part 7 (#2014). Merge only after the migration from part 3 (#2010) has been run for qcom and chestnut.

GitHub shows the whole stack's diff until the parts below merge; see the Commits tab for this part's own change.

The client reads `driving_models_v23.json` / `driving_models_chestnut_v26.json` and requires selector version 20; clients on 19 keep reading v22 / chestnut_v25 untouched, and rollback is a revert. With every artifact a whole file the chunked path goes: the parser no longer reads `chunks` or writes a `.chunkmanifest` per bundle on every catalog parse (every device today carries one per model name), the manager no longer verifies or fetches chunks, and legacy `.chunk*` files for a name are purged before it is downloaded, since `open_file_chunked` prefers a manifest over a whole file. `Model.Type` gains `driving`; `chunked` stays so an upgrading device can parse its cached v22 catalog. `compile_modeld.py` no longer splits the pkl and `sunnypilot-build-model` copies only the compiled pkl into the artifact. Default models stay chunked inside the release. Two thirds of the diff is deletion.

Publishing new models afterwards is `build-single-tinygrad-model` with `json_version=23` (26 for chestnut) and `version=20`; build-all still works for the next bump. Upgrading users get their slot reset, as with every bump.

On a comma 3X reading fork copies of the migrated manifests, the manager downloaded BMv6 (787 MB in 33 s) and CD210 (84 MB in 5 s), verified against the manifest with no sidecar or chunk files left; the hashes equal the entries in today's chunked manifests. The merged eight parts are byte-identical to #1998's tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGMnVnSk5inGTrd7kuDVG9

