### PR TITLE
modeld: chestnut power limit, adjustable via sunnylink

### DIFF
--- a/openpilot/common/params_keys.h
+++ b/openpilot/common/params_keys.h
@@ -245,6 +245,7 @@ inline static std::unordered_map<std::string, ParamKeyAttributes> keys = {
 
     // sunnypilot model params
     {"CameraOffset", {PERSISTENT | BACKUP, FLOAT, "0.0"}},
+    {"ChestnutPowerLimit", {PERSISTENT | BACKUP, INT, "0"}},  // watts, 0 = stock GPU limit
     {"LagdToggle", {PERSISTENT | BACKUP, BOOL, "1"}},
     {"LagdToggleDelay", {PERSISTENT | BACKUP, FLOAT, "0.2"}},
     {"LagdValueCache", {PERSISTENT, FLOAT, "0.2"}},

--- a/openpilot/sunnypilot/modeld_v2/chestnut_power_limit.py
+++ b/openpilot/sunnypilot/modeld_v2/chestnut_power_limit.py
@@ -13,10 +13,11 @@ from openpilot.common.swaglog import cloudlog
 # 1-2 A dashcams: a ~0.4 ohm path sags ~5 V at the GPU's stock boost transients,
 # which resets the USB link mid-transfer or hangs the device seconds into
 # inference. Bounding the SMU package power (PPT) removes those transients; the
-# driving model itself draws a fraction of the cap (24-55 W measured on a
-# Radeon 9060 16 GB). 0 leaves the GPU's own limit untouched.
+# driving models run within 60 W (24-55 W measured on a Radeon 9060 16 GB, whose
+# stock limit reads back as 160 W). chestnut is designed for 100 W of inference,
+# so nothing above that is offered. 0 leaves the GPU's own limit untouched.
 POWER_LIMIT_MIN_W = 40
-POWER_LIMIT_MAX_W = 220
+POWER_LIMIT_MAX_W = 100
 
 
 def get_power_limit(params: Params | None = None) -> int:

--- a/openpilot/sunnypilot/modeld_v2/chestnut_power_limit.py
+++ b/openpilot/sunnypilot/modeld_v2/chestnut_power_limit.py
@@ -1,0 +1,42 @@
+"""
+Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+"""
+from tinygrad.device import Device
+
+from openpilot.common.params import Params
+from openpilot.common.swaglog import cloudlog
+
+# A chestnut powered from a 12V accessory outlet sits behind wiring built for
+# 1-2 A dashcams: a ~0.4 ohm path sags ~5 V at the GPU's stock boost transients,
+# which resets the USB link mid-transfer or hangs the device seconds into
+# inference. Bounding the SMU package power (PPT) removes those transients; the
+# driving model itself draws a fraction of the cap (24-55 W measured on a
+# Radeon 9060 16 GB). 0 leaves the GPU's own limit untouched.
+POWER_LIMIT_MIN_W = 40
+POWER_LIMIT_MAX_W = 220
+
+
+def get_power_limit(params: Params | None = None) -> int:
+  """Requested package power limit in watts from ChestnutPowerLimit, clamped to a sane range. 0 means stock."""
+  params = params or Params()
+  try:
+    limit_w = int(params.get("ChestnutPowerLimit", return_default=True) or 0)
+  except (TypeError, ValueError):
+    return 0
+  if limit_w <= 0:
+    return 0
+  return max(POWER_LIMIT_MIN_W, min(POWER_LIMIT_MAX_W, limit_w))
+
+
+def apply_power_limit(limit_w: int) -> int | None:
+  """Set the SMU package power limit on the opened AMD device and return the value it reports back. No-op for 0."""
+  if limit_w <= 0:
+    return None
+  smu = Device["AMD"].iface.dev_impl.smu
+  smu._send_msg(smu.smu_mod.PPSMC_MSG_SetPptLimit, limit_w, timeout=100)
+  applied = int(smu._send_msg(smu.smu_mod.PPSMC_MSG_GetPptLimit, 0, read_back_arg=True, timeout=100))
+  cloudlog.event("chestnut power limit", requested=limit_w, applied=applied, error=applied != limit_w)
+  return applied

--- a/openpilot/sunnypilot/modeld_v2/modeld.py
+++ b/openpilot/sunnypilot/modeld_v2/modeld.py
@@ -47,6 +47,7 @@ from openpilot.sunnypilot.modeld_v2.parse_model_outputs import Parser
 from openpilot.sunnypilot.modeld_v2.constants import ModelConstants, Plan
 from openpilot.sunnypilot.modeld_v2.meta_helper import load_meta_constants
 from openpilot.sunnypilot.modeld_v2.camera_offset_helper import CameraOffsetHelper
+from openpilot.sunnypilot.modeld_v2.chestnut_power_limit import apply_power_limit, get_power_limit
 from openpilot.sunnypilot.modeld_v2.compile_modeld import (derive_frame_skip, make_split_input_queues,
                                                            make_supercombo_input_queues, nv12_copy_size,
                                                            WARP_INPUTS, POLICY_INPUTS)
@@ -364,6 +365,9 @@ def main(demo=False):
     def load_big():
       nonlocal big_model
       try:
+        # cap package power before the model transfer: on accessory-outlet installs the
+        # stock boost transients brown out the supply during the load as well as inference
+        apply_power_limit(get_power_limit(params))
         m = ModelState(cam_w=vipc_client_main.width, cam_h=vipc_client_main.height, chestnut=True)
         m.warmup()
         big_model = m

--- a/openpilot/sunnypilot/modeld_v2/tests/test_chestnut_power_limit.py
+++ b/openpilot/sunnypilot/modeld_v2/tests/test_chestnut_power_limit.py
@@ -46,7 +46,7 @@ class TestChestnutPowerLimit(OpenpilotTestCase):
 
   def test_clamped_to_range(self):
     for raw, expected in ((80, 80), (10, chestnut_power_limit.POWER_LIMIT_MIN_W), (500, chestnut_power_limit.POWER_LIMIT_MAX_W), (-5, 0)):
-      self.params.put("ChestnutPowerLimit", raw)
+      self.params.put("ChestnutPowerLimit", raw, block=True)
       assert chestnut_power_limit.get_power_limit(self.params) == expected
 
   def test_garbage_is_stock(self, monkeypatch):

--- a/openpilot/sunnypilot/modeld_v2/tests/test_chestnut_power_limit.py
+++ b/openpilot/sunnypilot/modeld_v2/tests/test_chestnut_power_limit.py
@@ -4,17 +4,9 @@ Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
 This file is part of sunnypilot and is licensed under the MIT License.
 See the LICENSE.md file in the root directory for more details.
 """
+from openpilot.common.params import Params
 from openpilot.common.test import OpenpilotTestCase
 import openpilot.sunnypilot.modeld_v2.chestnut_power_limit as chestnut_power_limit
-
-
-class FakeParams:
-  def __init__(self, value):
-    self.value = value
-
-  def get(self, key, return_default=False):
-    assert key == "ChestnutPowerLimit"
-    return self.value
 
 
 class FakeSmuMod:
@@ -23,7 +15,7 @@ class FakeSmuMod:
 
 
 class FakeSmu:
-  def __init__(self, limit=150):
+  def __init__(self, limit=160):
     self.smu_mod = FakeSmuMod
     self.limit = limit
     self.calls = []
@@ -46,16 +38,20 @@ class FakeDevice:
 
 
 class TestChestnutPowerLimit(OpenpilotTestCase):
+  def setup_method(self):
+    self.params = Params()
+
   def test_default_is_stock(self):
-    assert chestnut_power_limit.get_power_limit(FakeParams(0)) == 0
-    assert chestnut_power_limit.get_power_limit(FakeParams(None)) == 0
+    assert chestnut_power_limit.get_power_limit(self.params) == 0
 
   def test_clamped_to_range(self):
     for raw, expected in ((80, 80), (10, chestnut_power_limit.POWER_LIMIT_MIN_W), (500, chestnut_power_limit.POWER_LIMIT_MAX_W), (-5, 0)):
-      assert chestnut_power_limit.get_power_limit(FakeParams(raw)) == expected
+      self.params.put("ChestnutPowerLimit", raw)
+      assert chestnut_power_limit.get_power_limit(self.params) == expected
 
-  def test_garbage_is_stock(self):
-    assert chestnut_power_limit.get_power_limit(FakeParams("abc")) == 0
+  def test_garbage_is_stock(self, monkeypatch):
+    monkeypatch.setattr(self.params, "get", lambda key, return_default=False: "abc")
+    assert chestnut_power_limit.get_power_limit(self.params) == 0
 
   def test_apply_sets_and_reads_back(self, monkeypatch):
     smu = FakeSmu()

--- a/openpilot/sunnypilot/modeld_v2/tests/test_chestnut_power_limit.py
+++ b/openpilot/sunnypilot/modeld_v2/tests/test_chestnut_power_limit.py
@@ -1,0 +1,70 @@
+"""
+Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+"""
+from openpilot.common.test import OpenpilotTestCase
+import openpilot.sunnypilot.modeld_v2.chestnut_power_limit as chestnut_power_limit
+
+
+class FakeParams:
+  def __init__(self, value):
+    self.value = value
+
+  def get(self, key, return_default=False):
+    assert key == "ChestnutPowerLimit"
+    return self.value
+
+
+class FakeSmuMod:
+  PPSMC_MSG_SetPptLimit = 0x11
+  PPSMC_MSG_GetPptLimit = 0x12
+
+
+class FakeSmu:
+  def __init__(self, limit=150):
+    self.smu_mod = FakeSmuMod
+    self.limit = limit
+    self.calls = []
+
+  def _send_msg(self, msg, arg, read_back_arg=False, timeout=None):
+    self.calls.append((msg, arg))
+    if msg == FakeSmuMod.PPSMC_MSG_SetPptLimit:
+      self.limit = arg
+    return self.limit if read_back_arg else 0
+
+
+class FakeIface:
+  def __init__(self, smu):
+    self.dev_impl = type("DevImpl", (), {"smu": smu})
+
+
+class FakeDevice:
+  def __init__(self, smu):
+    self.iface = FakeIface(smu)
+
+
+class TestChestnutPowerLimit(OpenpilotTestCase):
+  def test_default_is_stock(self):
+    assert chestnut_power_limit.get_power_limit(FakeParams(0)) == 0
+    assert chestnut_power_limit.get_power_limit(FakeParams(None)) == 0
+
+  def test_clamped_to_range(self):
+    for raw, expected in ((80, 80), (10, chestnut_power_limit.POWER_LIMIT_MIN_W), (500, chestnut_power_limit.POWER_LIMIT_MAX_W), (-5, 0)):
+      assert chestnut_power_limit.get_power_limit(FakeParams(raw)) == expected
+
+  def test_garbage_is_stock(self):
+    assert chestnut_power_limit.get_power_limit(FakeParams("abc")) == 0
+
+  def test_apply_sets_and_reads_back(self, monkeypatch):
+    smu = FakeSmu()
+    monkeypatch.setattr(chestnut_power_limit, "Device", {"AMD": FakeDevice(smu)})
+    assert chestnut_power_limit.apply_power_limit(60) == 60
+    assert smu.calls == [(FakeSmuMod.PPSMC_MSG_SetPptLimit, 60), (FakeSmuMod.PPSMC_MSG_GetPptLimit, 0)]
+
+  def test_apply_zero_touches_nothing(self, monkeypatch):
+    smu = FakeSmu()
+    monkeypatch.setattr(chestnut_power_limit, "Device", {"AMD": FakeDevice(smu)})
+    assert chestnut_power_limit.apply_power_limit(0) is None
+    assert smu.calls == []

--- a/openpilot/sunnypilot/sunnylink/settings_ui.json
+++ b/openpilot/sunnypilot/sunnylink/settings_ui.json
@@ -1742,7 +1742,7 @@
               "key": "ChestnutPowerLimit",
               "widget": "option",
               "title": "GPU Power Limit",
-              "description": "Caps the chestnut GPU's package power (PPT) before the driving model loads. Use it when the enclosure runs from a 12V accessory outlet, whose wiring sags under the GPU's stock boost transients and can reset the USB link or hang the model mid-drive. The driving model needs well under 60W. Stock leaves the GPU's own limit untouched. Takes effect at the next model load (ignition on).",
+              "description": "Caps the chestnut GPU's package power (PPT) before the driving model loads. Use it when the enclosure runs from a 12V accessory outlet, whose wiring sags under the GPU's stock boost transients and can reset the USB link or hang the model mid-drive. Current driving models run within 60W. Stock leaves the GPU's own limit untouched. Takes effect at the next model load (ignition on).",
               "options": [
                 {
                   "value": 0,
@@ -1771,14 +1771,6 @@
                 {
                   "value": 100,
                   "label": "100W"
-                },
-                {
-                  "value": 120,
-                  "label": "120W"
-                },
-                {
-                  "value": 150,
-                  "label": "150W"
                 }
               ],
               "visibility": [

--- a/openpilot/sunnypilot/sunnylink/settings_ui.json
+++ b/openpilot/sunnypilot/sunnylink/settings_ui.json
@@ -1734,6 +1734,71 @@
           ]
         },
         {
+          "id": "chestnut",
+          "title": "chestnut",
+          "description": "External GPU power",
+          "items": [
+            {
+              "key": "ChestnutPowerLimit",
+              "widget": "option",
+              "title": "GPU Power Limit",
+              "description": "Caps the chestnut GPU's package power (PPT) before the driving model loads. Use it when the enclosure runs from a 12V accessory outlet, whose wiring sags under the GPU's stock boost transients and can reset the USB link or hang the model mid-drive. The driving model needs well under 60W. Stock leaves the GPU's own limit untouched. Takes effect at the next model load (ignition on).",
+              "options": [
+                {
+                  "value": 0,
+                  "label": "Stock"
+                },
+                {
+                  "value": 40,
+                  "label": "40W"
+                },
+                {
+                  "value": 50,
+                  "label": "50W"
+                },
+                {
+                  "value": 60,
+                  "label": "60W"
+                },
+                {
+                  "value": 70,
+                  "label": "70W"
+                },
+                {
+                  "value": 80,
+                  "label": "80W"
+                },
+                {
+                  "value": 100,
+                  "label": "100W"
+                },
+                {
+                  "value": 120,
+                  "label": "120W"
+                },
+                {
+                  "value": 150,
+                  "label": "150W"
+                }
+              ],
+              "visibility": [
+                {
+                  "type": "capability",
+                  "field": "device_type",
+                  "equals": "mici"
+                }
+              ],
+              "enablement": [
+                {
+                  "type": "param",
+                  "key": "ShowAdvancedControls",
+                  "equals": true
+                }
+              ]
+            }
+          ]
+        },
+        {
           "id": "language",
           "title": "Language",
           "items": [

--- a/openpilot/sunnypilot/sunnylink/settings_ui_src/pages/device.yaml
+++ b/openpilot/sunnypilot/sunnylink/settings_ui_src/pages/device.yaml
@@ -68,7 +68,7 @@ sections:
     title: GPU Power Limit
     description: Caps the chestnut GPU's package power (PPT) before the driving model loads. Use it when the enclosure runs
       from a 12V accessory outlet, whose wiring sags under the GPU's stock boost transients and can reset the USB link or hang
-      the model mid-drive. The driving model needs well under 60W. Stock leaves the GPU's own limit untouched. Takes effect at
+      the model mid-drive. Current driving models run within 60W. Stock leaves the GPU's own limit untouched. Takes effect at
       the next model load (ignition on).
     options:
     - value: 0
@@ -85,10 +85,6 @@ sections:
       label: 80W
     - value: 100
       label: 100W
-    - value: 120
-      label: 120W
-    - value: 150
-      label: 150W
     visibility:
     - type: capability
       field: device_type

--- a/openpilot/sunnypilot/sunnylink/settings_ui_src/pages/device.yaml
+++ b/openpilot/sunnypilot/sunnylink/settings_ui_src/pages/device.yaml
@@ -59,6 +59,42 @@ sections:
       label: 24h
     - value: 1800
       label: 30h (Default)
+- id: chestnut
+  title: chestnut
+  description: External GPU power
+  items:
+  - key: ChestnutPowerLimit
+    widget: option
+    title: GPU Power Limit
+    description: Caps the chestnut GPU's package power (PPT) before the driving model loads. Use it when the enclosure runs
+      from a 12V accessory outlet, whose wiring sags under the GPU's stock boost transients and can reset the USB link or hang
+      the model mid-drive. The driving model needs well under 60W. Stock leaves the GPU's own limit untouched. Takes effect at
+      the next model load (ignition on).
+    options:
+    - value: 0
+      label: Stock
+    - value: 40
+      label: 40W
+    - value: 50
+      label: 50W
+    - value: 60
+      label: 60W
+    - value: 70
+      label: 70W
+    - value: 80
+      label: 80W
+    - value: 100
+      label: 100W
+    - value: 120
+      label: 120W
+    - value: 150
+      label: 150W
+    visibility:
+    - type: capability
+      field: device_type
+      equals: mici
+    enablement:
+    - $ref: '#/macros/advanced_only'
 - id: language
   title: Language
   items:


### PR DESCRIPTION
**Description**

A chestnut powered from a 12V accessory outlet sits behind wiring built for 1–2 A dashcams. On my comma four (Prius Prime) the outlet path measures ~0.45 Ω (13.6 V no-load → 11.8 V at 3–4 A); at the GPU's stock boost transients (11 A+) the input collapses, which resets the USB link mid-transfer or hangs the device seconds into inference. The driving model itself draws 24–55 W.

This adds `ChestnutPowerLimit` (int, watts, default 0 = stock). When set, modeld sends `PPSMC_MSG_SetPptLimit` to the SMU right before the big-model transfer, reads the limit back and logs it. The applied value is already published as `chestnutState.powerLimitW`, so it shows up in telemetry. If the SMU call fails, the big-model load fails and modeld falls back to the small model like any other chestnut load error: an uncapped load on a supply the user has said cannot take it is the worse outcome.

Adjustable from sunnylink only (Device page, advanced controls, comma four), no on-device UI, following the CameraOffset precedent (#1614). Options Stock and 40–100 W (chestnut's 100 W inference design point); values are clamped to 40–100 W in code.

Files: param declaration, `modeld_v2/chestnut_power_limit.py` (mirrors the SMU access `ChestnutState.power_limit` already uses), a one-line hook in `load_big()`, the sunnylink device page (YAML + compiled JSON), unit tests.

**Verification**

comma four + chestnut (Radeon 9060 16 GB), Toyota Prius Prime, enclosure on the accessory outlet with a 12 AWG feed, running this cap as a fork patch on every drive since 2026-08-26:

- uncapped: `Device hang detected` ~46 s into engaged inference on every attempt, with USB resets during the 1.7 GB transfer
- 80 W: 27.5 min of continuous eGPU inference, zero model gaps, supply floor 11.7 V, draw peaks ~34 W
- 60 W: 88 min commute on the worst-case charging profile with zero hangs; 4/4 drives clean (~105 min); wall draw p50 40 W / max 59 W
- Cinque Terre V2 at 60 W: 36 ms median inference, 42 ms max, zero frame drops across 95 min of driving on 2026-09-11, so the cap costs no throughput
- `python sunnypilot/sunnylink/tools/compile_settings_ui.py --check` passes, ruff clean, new unit tests cover the clamp and the SMU message sequence against a stub device

Dongle ID and routes available on request; I keep them out of public threads. Same setup as #2019.

Assisted by Claude (disclosed in the commit per AI_POLICY.md). The cap has been in daily use on my device for three weeks.

